### PR TITLE
Terminal/iTerm 2 - Fix a resize bug regarding not resizing to a 2/3 & 1/3 (top & bottom) 

### DIFF
--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -181,7 +181,7 @@ class SnappingManager {
     func getBoxRect(hotSpot: HotSpot, currentWindowRect: CGRect) -> CGRect? {
         if let calculation = windowCalculationFactory.calculation(for: hotSpot.action) {
             
-            return calculation.calculateRect(currentWindowRect, visibleFrameOfScreen: hotSpot.screen.visibleFrame, action: hotSpot.action)
+            return calculation.calculateRect(currentWindowRect, lastAction: nil, visibleFrameOfScreen: hotSpot.screen.visibleFrame, action: hotSpot.action)
         }
         return nil
     }

--- a/Rectangle/WindowCalculation/AlmostMaximizeCalculation.swift
+++ b/Rectangle/WindowCalculation/AlmostMaximizeCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class AlmostMaximizeCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
 
         var calculatedWindowRect = visibleFrameOfScreen
         

--- a/Rectangle/WindowCalculation/BottomHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomHalfCalculation.swift
@@ -10,28 +10,31 @@ import Foundation
 
 class BottomHalfCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
         var oneHalfRect = visibleFrameOfScreen
         oneHalfRect.size.height = floor(oneHalfRect.height / 2.0)
         
-        if Defaults.subsequentExecutionMode.value != .none {
-            if abs(windowRect.midX - oneHalfRect.midX) <= 1.0 {
-                var twoThirdsRect = oneHalfRect
-                twoThirdsRect.size.height = floor(visibleFrameOfScreen.height * 2 / 3.0)
-                
-                if rectCenteredWithinRect(oneHalfRect, windowRect) {
-                    return twoThirdsRect
-                }
-                
-                if rectCenteredWithinRect(twoThirdsRect, windowRect) {
-                    var oneThirdRect = oneHalfRect
-                    oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 3.0)
-                    return oneThirdRect
-                }
-            }
+        if Defaults.subsequentExecutionMode.value == .none {
+            return oneHalfRect
         }
         
-        return oneHalfRect
+        let count = (lastAction?.action == action) ? (lastAction?.count ?? 0) : 0
+        let position = count % 3
+        
+        switch (position) {
+            case 2:
+                var oneThirdRect = oneHalfRect
+                oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+                return oneThirdRect
+            
+            case 1:
+                var twoThirdsRect = oneHalfRect
+                twoThirdsRect.size.height = floor(visibleFrameOfScreen.height * 2 / 3.0)
+                return twoThirdsRect
+            
+            default:
+                return oneHalfRect
+        }
     }
 }

--- a/Rectangle/WindowCalculation/CenterCalculation.swift
+++ b/Rectangle/WindowCalculation/CenterCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class CenterCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
 
         if rectFitsWithinRect(rect1: windowRect, rect2: visibleFrameOfScreen) {
             var calculatedWindowRect = windowRect

--- a/Rectangle/WindowCalculation/CenterThirdCalculation.swift
+++ b/Rectangle/WindowCalculation/CenterThirdCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class CenterThirdCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
         return isLandscape(visibleFrameOfScreen)
             ? horizontallyCenteredThird(visibleFrameOfScreen)

--- a/Rectangle/WindowCalculation/ChangeSizeCalculation.swift
+++ b/Rectangle/WindowCalculation/ChangeSizeCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class ChangeSizeCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         let sizeOffset: CGFloat = action == .smaller ? -30.0 : 30.0
         
         var resizedWindowRect = windowRect

--- a/Rectangle/WindowCalculation/FirstThirdCalculation.swift
+++ b/Rectangle/WindowCalculation/FirstThirdCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class FirstThirdCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
         return isLandscape(visibleFrameOfScreen)
             ? leftThird(visibleFrameOfScreen)

--- a/Rectangle/WindowCalculation/FirstTwoThirdsCalculation.swift
+++ b/Rectangle/WindowCalculation/FirstTwoThirdsCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class FirstTwoThirdsCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
         return isLandscape(visibleFrameOfScreen)
             ? leftTwoThirds(visibleFrameOfScreen)

--- a/Rectangle/WindowCalculation/LastThirdCalculation.swift
+++ b/Rectangle/WindowCalculation/LastThirdCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class LastThirdCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
         return isLandscape(visibleFrameOfScreen)
             ? rightThird(visibleFrameOfScreen)

--- a/Rectangle/WindowCalculation/LastTwoThirdsCalculation.swift
+++ b/Rectangle/WindowCalculation/LastTwoThirdsCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class LastTwoThirdsCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
         return isLandscape(visibleFrameOfScreen)
             ? rightTwoThirds(visibleFrameOfScreen)

--- a/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
@@ -106,7 +106,7 @@ class LeftRightHalfCalculation: WindowCalculation {
     }
 
     // Used to draw box for snapping
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         switch action {
         case .leftHalf:
             var oneHalfRect = visibleFrameOfScreen

--- a/Rectangle/WindowCalculation/LowerLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerLeftCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class LowerLeftCalculation: WindowCalculation {
 
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         var oneQuarterRect = visibleFrameOfScreen
         oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)

--- a/Rectangle/WindowCalculation/LowerRightCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerRightCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class LowerRightCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         var oneQuarterRect = visibleFrameOfScreen
         oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)

--- a/Rectangle/WindowCalculation/MaximizeCalculation.swift
+++ b/Rectangle/WindowCalculation/MaximizeCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class MaximizeCalculation: WindowCalculation {
 
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         return visibleFrameOfScreen
     }
     

--- a/Rectangle/WindowCalculation/MaximizeHeightCalculation.swift
+++ b/Rectangle/WindowCalculation/MaximizeHeightCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class MaximizeHeightCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         var maxHeightRect = windowRect
         maxHeightRect.origin.y = visibleFrameOfScreen.minY
         maxHeightRect.size.height = visibleFrameOfScreen.height

--- a/Rectangle/WindowCalculation/MoveDownCalculation.swift
+++ b/Rectangle/WindowCalculation/MoveDownCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class MoveDownCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
         var calculatedWindowRect = windowRect
         calculatedWindowRect.origin.y = visibleFrameOfScreen.minY

--- a/Rectangle/WindowCalculation/MoveLeftRightCalculation.swift
+++ b/Rectangle/WindowCalculation/MoveLeftRightCalculation.swift
@@ -81,7 +81,7 @@ class MoveLeftRightCalculation: WindowCalculation {
     }
     
     // unused
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         return nil
     }
     

--- a/Rectangle/WindowCalculation/MoveUpCalculation.swift
+++ b/Rectangle/WindowCalculation/MoveUpCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class MoveUpCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
         var calculatedWindowRect = windowRect
         calculatedWindowRect.origin.y = visibleFrameOfScreen.maxY - windowRect.height

--- a/Rectangle/WindowCalculation/NextPrevDisplayCalculation.swift
+++ b/Rectangle/WindowCalculation/NextPrevDisplayCalculation.swift
@@ -23,7 +23,7 @@ class NextPrevDisplayCalculation: WindowCalculation {
         }
 
         if let screen = screen {
-            if let rect = calculateRect(windowRect, visibleFrameOfScreen: NSRectToCGRect(screen.visibleFrame), action: action) {
+            if let rect = calculateRect(windowRect, lastAction: lastAction, visibleFrameOfScreen: NSRectToCGRect(screen.visibleFrame), action: action) {
                 return WindowCalculationResult(rect: rect, screen: screen, resultingAction: action)
             }
         }
@@ -31,8 +31,8 @@ class NextPrevDisplayCalculation: WindowCalculation {
         return nil
     }
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
-        return centerCalculation.calculateRect(windowRect, visibleFrameOfScreen: visibleFrameOfScreen, action: action)
+        return centerCalculation.calculateRect(windowRect, lastAction: lastAction, visibleFrameOfScreen: visibleFrameOfScreen, action: action)
     }
 }

--- a/Rectangle/WindowCalculation/TopHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/TopHalfCalculation.swift
@@ -10,31 +10,35 @@ import Foundation
 
 class TopHalfCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
         var oneHalfRect = visibleFrameOfScreen
         oneHalfRect.size.height = floor(oneHalfRect.height / 2.0)
         oneHalfRect.origin.y += oneHalfRect.height + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
 
-        if Defaults.subsequentExecutionMode.value != .none {
-            if abs(windowRect.midX - oneHalfRect.midX) <= 1.0 {
+        if Defaults.subsequentExecutionMode.value == .none {
+            return oneHalfRect
+        }
+        
+        let count = (lastAction?.action == action) ? (lastAction?.count ?? 0) : 0
+        let position = count % 3
+        
+        switch (position) {
+            case 2:
+                var oneThirdRect = oneHalfRect
+                oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+                oneThirdRect.origin.y = visibleFrameOfScreen.origin.y + visibleFrameOfScreen.height - oneThirdRect.height
+                return oneThirdRect
+            
+            case 1:
                 var twoThirdsRect = oneHalfRect
                 twoThirdsRect.size.height = floor(visibleFrameOfScreen.height * 2 / 3.0)
                 twoThirdsRect.origin.y = visibleFrameOfScreen.origin.y + visibleFrameOfScreen.height - twoThirdsRect.height
-                if rectCenteredWithinRect(oneHalfRect, windowRect) {
-                    return twoThirdsRect
-                }
-                if rectCenteredWithinRect(twoThirdsRect, windowRect) {
-                    var oneThirdRect = oneHalfRect
-                    oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 3.0)
-                    oneThirdRect.origin.y = visibleFrameOfScreen.origin.y + visibleFrameOfScreen.height - oneThirdRect.height
-                    return oneThirdRect
-                }
-            }
+                return twoThirdsRect
+            
+            default:
+                return oneHalfRect
         }
-        
-        return oneHalfRect
-        
     }
     
 }

--- a/Rectangle/WindowCalculation/UpperLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperLeftCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class UpperLeftCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         var oneQuarterRect = visibleFrameOfScreen
         oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)

--- a/Rectangle/WindowCalculation/UpperRightCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperRightCalculation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class UpperRightCalculation: WindowCalculation {
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
         
         var oneQuarterRect = visibleFrameOfScreen
         oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)

--- a/Rectangle/WindowCalculation/WindowCalculation.swift
+++ b/Rectangle/WindowCalculation/WindowCalculation.swift
@@ -12,14 +12,14 @@ protocol WindowCalculation {
     
     func calculate(_ windowRect: CGRect, lastAction: RectangleAction?, usableScreens: UsableScreens, action: WindowAction) -> WindowCalculationResult?
     
-    func calculateRect(_ windowRect: CGRect, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect?
+    func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect?
 }
 
 extension WindowCalculation {
     
-    func calculate(_ windowRect: CGRect, lastAction: RectangleAction?, usableScreens: UsableScreens, action: WindowAction) -> WindowCalculationResult? {
+        func calculate(_ windowRect: CGRect, lastAction: RectangleAction?, usableScreens: UsableScreens, action: WindowAction) -> WindowCalculationResult? {
         
-        if let rect = calculateRect(windowRect, visibleFrameOfScreen: usableScreens.currentScreen.visibleFrame, action: action) {
+            if let rect = calculateRect(windowRect, lastAction: lastAction, visibleFrameOfScreen: usableScreens.currentScreen.visibleFrame, action: action) {
             
             return WindowCalculationResult(rect: rect, screen: usableScreens.currentScreen, resultingAction: action)
         }

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -78,7 +78,7 @@ class WindowManager {
         let currentNormalizedRect = AccessibilityElement.normalizeCoordinatesOf(currentWindowRect, frameOfScreen: usableScreens.frameOfCurrentScreen)
         
         let windowCalculation = windowCalculationFactory.calculation(for: action)
-
+        
         guard let calcResult = windowCalculation?.calculate(currentNormalizedRect, lastAction: lastRectangleAction, usableScreens: usableScreens, action: action) else {
             NSSound.beep()
             return
@@ -98,13 +98,19 @@ class WindowManager {
         }
 
         let resultingRect = frontmostWindowElement.rectOfElement()
-        windowHistory.lastRectangleActions[windowId] = RectangleAction(action: calcResult.resultingAction, rect: resultingRect)
+        let currentCount = (lastRectangleAction?.action == calcResult.resultingAction) ? lastRectangleAction?.count : nil
+        windowHistory.lastRectangleActions[windowId] = RectangleAction(
+            action: calcResult.resultingAction,
+            rect: resultingRect,
+            count: currentCount?.advanced(by: 1) ?? 1
+        )
     }
 }
 
 struct RectangleAction {
     let action: WindowAction
     let rect: CGRect
+    let count: Int
 }
 
 struct ExecutionParameters {


### PR DESCRIPTION
…cking if a rect is centered within another rect

Fixes the issue of iTerm/Terminal windows not being resized down to a 1/3 & 2/3 due their own resize logic which rounds up/down to the height of a line