### PR TITLE
Correct wrong zh-Hans translations manually

### DIFF
--- a/Rectangle/zh-Hans.lproj/Main.strings
+++ b/Rectangle/zh-Hans.lproj/Main.strings
@@ -1,6 +1,6 @@
 
 /* Class = "NSTextFieldCell"; title = "If you repeat move or half actions, the window will move to the next display instead of 1/2, 2/3, and 1/3 size."; ObjectID = "01Z-t3-cBm"; */
-"01Z-t3-cBm.title" = "如果重复执行动作或半动作，则窗口将移至下一个显示，而不是1 / 2、2 / 3和1/3大小。";
+"01Z-t3-cBm.title" = "如果重复按移动窗口或设置窗口大小按键，则窗口将移至下一个显示器显示，而不是 1/2、2/3 和 1/3 大小。";
 
 /* Class = "NSTextFieldCell"; title = "Last Two Thirds"; ObjectID = "08q-Ce-1QL"; */
 "08q-Ce-1QL.title" = "最后三分之二";
@@ -15,10 +15,10 @@
 "1UK-8n-QPP.title" = "自定义工具栏…";
 
 /* Class = "NSMenuItem"; title = "Rectangle"; ObjectID = "1Xt-HY-uBw"; */
-"1Xt-HY-uBw.title" = "矩形";
+"1Xt-HY-uBw.title" = "Rectangle";
 
 /* Class = "NSMenu"; title = "Find"; ObjectID = "1b7-l0-nxx"; */
-"1b7-l0-nxx.title" = "找";
+"1b7-l0-nxx.title" = "查找";
 
 /* Class = "NSMenuItem"; title = "Lower"; ObjectID = "1tx-W0-xDw"; */
 "1tx-W0-xDw.title" = "降低";
@@ -36,7 +36,7 @@
 "3IN-sU-3Bg.title" = "拼写";
 
 /* Class = "NSMenuItem"; title = "Use Default"; ObjectID = "3Om-Ey-2VK"; */
-"3Om-Ey-2VK.title" = "默认情况下使用";
+"3Om-Ey-2VK.title" = "使用默认值";
 
 /* Class = "NSMenu"; title = "Speech"; ObjectID = "3rS-ZA-NoH"; */
 "3rS-ZA-NoH.title" = "言语";
@@ -48,22 +48,22 @@
 "46P-cB-AYj.title" = "紧缩";
 
 /* Class = "NSMenuItem"; title = "Find"; ObjectID = "4EN-yA-p0u"; */
-"4EN-yA-p0u.title" = "找";
+"4EN-yA-p0u.title" = "查找";
 
 /* Class = "NSMenuItem"; title = "Enter Full Screen"; ObjectID = "4J7-dP-txa"; */
 "4J7-dP-txa.title" = "进入全屏";
 
 /* Class = "NSMenuItem"; title = "Quit Rectangle"; ObjectID = "4sb-4s-VLi"; */
-"4sb-4s-VLi.title" = "退出Rectangle";
+"4sb-4s-VLi.title" = "退出 Rectangle";
 
 /* Class = "NSMenuItem"; title = "Edit"; ObjectID = "5QF-Oa-p0T"; */
 "5QF-Oa-p0T.title" = "编辑";
 
 /* Class = "NSMenuItem"; title = "Copy Style"; ObjectID = "5Vv-lz-BsD"; */
-"5Vv-lz-BsD.title" = "复制样式";
+"5Vv-lz-BsD.title" = "拷贝样式";
 
 /* Class = "NSMenuItem"; title = "About Rectangle"; ObjectID = "5kV-Vb-QxS"; */
-"5kV-Vb-QxS.title" = "关于Rectangle";
+"5kV-Vb-QxS.title" = "关于 Rectangle";
 
 /* Class = "NSTextFieldCell"; title = "Maximize Height"; ObjectID = "6DV-cd-fda"; */
 "6DV-cd-fda.title" = "最大化高度";
@@ -72,16 +72,16 @@
 "6dh-zS-Vam.title" = "重做";
 
 /* Class = "NSTextFieldCell"; title = "Bottom Left"; ObjectID = "6ma-hP-5xX"; */
-"6ma-hP-5xX.title" = "左下方";
+"6ma-hP-5xX.title" = "左下";
 
 /* Class = "NSMenuItem"; title = "Correct Spelling Automatically"; ObjectID = "78Y-hA-62v"; */
 "78Y-hA-62v.title" = "自动纠正拼写";
 
 /* Class = "NSTextFieldCell"; title = "Center Third"; ObjectID = "7YK-9Z-lzw"; */
-"7YK-9Z-lzw.title" = "中心第三";
+"7YK-9Z-lzw.title" = "三分之一居中";
 
 /* Class = "NSTextFieldCell"; title = "Center"; ObjectID = "8Bg-SZ-hDO"; */
-"8Bg-SZ-hDO.title" = "中央";
+"8Bg-SZ-hDO.title" = "居中";
 
 /* Class = "NSMenu"; title = "Writing Direction"; ObjectID = "8mr-sm-Yjd"; */
 "8mr-sm-Yjd.title" = "写作方向";
@@ -90,25 +90,25 @@
 "8oe-J2-oUU.title" = "最大化";
 
 /* Class = "NSWindow"; title = "Authorize Rectangle"; ObjectID = "9JD-tZ-7jf"; */
-"9JD-tZ-7jf.title" = "授权Rectangle";
+"9JD-tZ-7jf.title" = "授权 Rectangle";
 
 /* Class = "NSTextFieldCell"; title = "If the checkbox is disabled, click the padlock and enter your password"; ObjectID = "9XM-Zb-HEb"; */
 "9XM-Zb-HEb.title" = "如果复选框已禁用，请单击挂锁并输入密码";
 
 /* Class = "NSMenuItem"; title = "Substitutions"; ObjectID = "9ic-FL-obx"; */
-"9ic-FL-obx.title" = "换人";
+"9ic-FL-obx.title" = "替换";
 
 /* Class = "NSMenuItem"; title = "Smart Copy/Paste"; ObjectID = "9yt-4B-nSM"; */
-"9yt-4B-nSM.title" = "智能复制/粘贴";
+"9yt-4B-nSM.title" = "智能拷贝/粘贴";
 
 /* Class = "NSMenuItem"; title = "Quit Rectangle"; ObjectID = "A66-A4-cGD"; */
-"A66-A4-cGD.title" = "退出Rectangle";
+"A66-A4-cGD.title" = "退出 Rectangle";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "主菜单";
 
 /* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
-"BOF-NM-1cW.title" = "优先…";
+"BOF-NM-1cW.title" = "偏好设置…";
 
 /* Class = "NSMenuItem"; title = "\tLeft to Right"; ObjectID = "BgM-ve-c93"; */
 "BgM-ve-c93.title" = "\t左到右";
@@ -120,7 +120,7 @@
 "C9v-g0-DH8.title" = "恢复";
 
 /* Class = "NSMenuItem"; title = "Ignore frontmost.app"; ObjectID = "D99-0O-MB6"; */
-"D99-0O-MB6.title" = "忽略frontmost.app";
+"D99-0O-MB6.title" = "忽略 frontmost.app";
 
 /* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */
 "DVo-aG-piG.title" = "关";
@@ -132,34 +132,34 @@
 "Eah-KL-kbn.title" = "变大";
 
 /* Class = "NSTextFieldCell"; title = "First Third"; ObjectID = "F12-EV-Lfz"; */
-"F12-EV-Lfz.title" = "第一三";
+"F12-EV-Lfz.title" = "前三分之一";
 
 /* Class = "NSMenu"; title = "Help"; ObjectID = "F2S-fz-NVQ"; */
-"F2S-fz-NVQ.title" = "救命";
+"F2S-fz-NVQ.title" = "帮助";
 
 /* Class = "NSTextFieldCell"; title = "Right Half"; ObjectID = "F8S-GI-LiB"; */
 "F8S-GI-LiB.title" = "右半";
 
 /* Class = "NSMenuItem"; title = "Rectangle Help"; ObjectID = "FKE-Sm-Kum"; */
-"FKE-Sm-Kum.title" = "Rectangle帮助";
+"FKE-Sm-Kum.title" = "Rectangle 帮助";
 
 /* Class = "NSMenuItem"; title = "Text"; ObjectID = "Fal-I4-PZk"; */
 "Fal-I4-PZk.title" = "文本";
 
 /* Class = "NSMenu"; title = "Substitutions"; ObjectID = "FeM-D8-WVr"; */
-"FeM-D8-WVr.title" = "换人";
+"FeM-D8-WVr.title" = "替换";
 
 /* Class = "NSMenuItem"; title = "Bold"; ObjectID = "GB9-OM-e27"; */
-"GB9-OM-e27.title" = "胆大";
+"GB9-OM-e27.title" = "粗体";
 
 /* Class = "NSMenu"; title = "Format"; ObjectID = "GEO-Iw-cKr"; */
 "GEO-Iw-cKr.title" = "格式";
 
 /* Class = "NSMenuItem"; title = "Use Default"; ObjectID = "GUa-eO-cwY"; */
-"GUa-eO-cwY.title" = "默认情况下使用";
+"GUa-eO-cwY.title" = "使用默认值";
 
 /* Class = "NSMenuItem"; title = "Font"; ObjectID = "Gi5-1S-RQB"; */
-"Gi5-1S-RQB.title" = "字形";
+"Gi5-1S-RQB.title" = "字体";
 
 /* Class = "NSMenuItem"; title = "Writing Direction"; ObjectID = "H1b-Si-o9J"; */
 "H1b-Si-o9J.title" = "写作方向";
@@ -168,7 +168,7 @@
 "H8h-7b-M4v.title" = "视图";
 
 /* Class = "NSMenuItem"; title = "Text Replacement"; ObjectID = "HFQ-gK-NFA"; */
-"HFQ-gK-NFA.title" = "文字替换";
+"HFQ-gK-NFA.title" = "文本替换";
 
 /* Class = "NSMenuItem"; title = "Show Spelling and Grammar"; ObjectID = "HFo-cy-zxI"; */
 "HFo-cy-zxI.title" = "显示拼写和语法";
@@ -177,7 +177,7 @@
 "HIK-3r-i7E.title" = "检查更新…";
 
 /* Class = "NSTextFieldCell"; title = "Move Up"; ObjectID = "HOm-BV-2jc"; */
-"HOm-BV-2jc.title" = "提升";
+"HOm-BV-2jc.title" = "上移";
 
 /* Class = "NSMenu"; title = "View"; ObjectID = "HyV-fh-RgO"; */
 "HyV-fh-RgO.title" = "视图";
@@ -198,16 +198,16 @@
 "J7y-lM-qPV.title" = "不使用";
 
 /* Class = "NSTextFieldCell"; title = "Next Display"; ObjectID = "Jnd-Lc-nlh"; */
-"Jnd-Lc-nlh.title" = "下一个显示";
+"Jnd-Lc-nlh.title" = "下一个显示器";
 
 /* Class = "NSMenuItem"; title = "Revert to Saved"; ObjectID = "KaW-ft-85H"; */
-"KaW-ft-85H.title" = "恢复为已保存";
+"KaW-ft-85H.title" = "撤消改动";
 
 /* Class = "NSMenuItem"; title = "Show All"; ObjectID = "Kd2-mp-pUS"; */
 "Kd2-mp-pUS.title" = "显示所有";
 
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "LE2-aR-0XJ"; */
-"LE2-aR-0XJ.title" = "全部摆在前面";
+"LE2-aR-0XJ.title" = "前置全部窗口";
 
 /* Class = "NSMenuItem"; title = "Paste Ruler"; ObjectID = "LVM-kO-fVI"; */
 "LVM-kO-fVI.title" = "粘贴标尺";
@@ -216,7 +216,7 @@
 "Lbh-J2-qVU.title" = "\t左到右";
 
 /* Class = "NSMenuItem"; title = "Copy Ruler"; ObjectID = "MkV-Pr-PK5"; */
-"MkV-Pr-PK5.title" = "复制标尺";
+"MkV-Pr-PK5.title" = "拷贝标尺";
 
 /* Class = "NSTextFieldCell"; title = "Make Smaller"; ObjectID = "MzN-CJ-ASD"; */
 "MzN-CJ-ASD.title" = "变小";
@@ -237,7 +237,7 @@
 "OaQ-X3-Vso.title" = "基准线";
 
 /* Class = "NSMenuItem"; title = "Hide Rectangle"; ObjectID = "Olw-nP-bQN"; */
-"Olw-nP-bQN.title" = "隐藏Rectangle";
+"Olw-nP-bQN.title" = "隐藏 Rectangle";
 
 /* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "OwM-mh-QMV"; */
 "OwM-mh-QMV.title" = "查找上一个";
@@ -246,13 +246,13 @@
 "Oyz-dy-DGm.title" = "停止说话";
 
 /* Class = "NSMenuItem"; title = "Bigger"; ObjectID = "Ptp-SP-VEL"; */
-"Ptp-SP-VEL.title" = "大";
+"Ptp-SP-VEL.title" = "更大";
 
 /* Class = "NSMenuItem"; title = "Show Fonts"; ObjectID = "Q5e-8K-NDq"; */
 "Q5e-8K-NDq.title" = "显示字体";
 
 /* Class = "NSTextFieldCell"; title = "Previous Display"; ObjectID = "QwF-QN-YH7"; */
-"QwF-QN-YH7.title" = "上一个显示";
+"QwF-QN-YH7.title" = "上一个显示器";
 
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "R4o-n2-Eq4"; */
 "R4o-n2-Eq4.title" = "放大";
@@ -270,10 +270,10 @@
 "S0p-oC-mLd.title" = "跳转到选择";
 
 /* Class = "NSWindow"; title = "Rectangle Preferences"; ObjectID = "STb-JK-oB1"; */
-"STb-JK-oB1.title" = "Rectangle首选项";
+"STb-JK-oB1.title" = "Rectangle 偏好设置";
 
 /* Class = "NSButtonCell"; title = "Cycle across displays on repeated left or right commands"; ObjectID = "SXx-HZ-GkB"; */
-"SXx-HZ-GkB.title" = "通过重复的左或右命令在显示之间循环";
+"SXx-HZ-GkB.title" = "通过重复左或右命令在显示器之间循环显示";
 
 /* Class = "NSMenu"; title = "Window"; ObjectID = "Td7-aD-5lo"; */
 "Td7-aD-5lo.title" = "窗口";
@@ -282,7 +282,7 @@
 "UEZ-Bs-lqG.title" = "大写";
 
 /* Class = "NSMenuItem"; title = "Center"; ObjectID = "VIY-Ag-zcb"; */
-"VIY-Ag-zcb.title" = "中央";
+"VIY-Ag-zcb.title" = "居中";
 
 /* Class = "NSMenuItem"; title = "Authorize…"; ObjectID = "VIf-4h-MJW"; */
 "VIf-4h-MJW.title" = "授权…";
@@ -297,19 +297,19 @@
 "W48-6f-4Dl.title" = "编辑";
 
 /* Class = "NSMenuItem"; title = "Underline"; ObjectID = "WRG-CD-K1S"; */
-"WRG-CD-K1S.title" = "强调";
+"WRG-CD-K1S.title" = "下划线";
 
 /* Class = "NSMenuItem"; title = "New"; ObjectID = "Was-JA-tGl"; */
 "Was-JA-tGl.title" = "新";
 
 /* Class = "NSMenuItem"; title = "Paste and Match Style"; ObjectID = "WeT-3V-zwk"; */
-"WeT-3V-zwk.title" = "粘贴和匹配样式";
+"WeT-3V-zwk.title" = "粘贴并匹配样式";
 
 /* Class = "NSTextFieldCell"; title = "Left Half"; ObjectID = "Xc8-Sm-pig"; */
 "Xc8-Sm-pig.title" = "左半";
 
 /* Class = "NSMenuItem"; title = "Find…"; ObjectID = "Xz5-n4-O0W"; */
-"Xz5-n4-O0W.title" = "找…";
+"Xz5-n4-O0W.title" = "查找…";
 
 /* Class = "NSMenuItem"; title = "Find and Replace…"; ObjectID = "YEy-JH-Tfz"; */
 "YEy-JH-Tfz.title" = "查找和替换…";
@@ -318,7 +318,7 @@
 "YGs-j5-SAR.title" = "\t默认";
 
 /* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "YRC-4a-xGg"; */
-"YRC-4a-xGg.title" = "优先…";
+"YRC-4a-xGg.title" = "偏好设置…";
 
 /* Class = "NSMenuItem"; title = "Start Speaking"; ObjectID = "Ynk-f8-cLZ"; */
 "Ynk-f8-cLZ.title" = "开始说话";
@@ -336,13 +336,13 @@
 "aUF-d1-5bR.title" = "窗口";
 
 /* Class = "NSMenu"; title = "Font"; ObjectID = "aXa-aM-Jaq"; */
-"aXa-aM-Jaq.title" = "字形";
+"aXa-aM-Jaq.title" = "字体";
 
 /* Class = "NSTextFieldCell"; title = "Top Left"; ObjectID = "adp-cN-qkh"; */
 "adp-cN-qkh.title" = "左上方";
 
 /* Class = "NSMenuItem"; title = "Use Default"; ObjectID = "agt-UL-0e3"; */
-"agt-UL-0e3.title" = "默认情况下使用";
+"agt-UL-0e3.title" = "使用默认值";
 
 /* Class = "NSMenuItem"; title = "Show Colors"; ObjectID = "bgn-CT-cEk"; */
 "bgn-CT-cEk.title" = "显示颜色";
@@ -351,7 +351,7 @@
 "bib-Uj-vzu.title" = "文件";
 
 /* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "buJ-ug-pKt"; */
-"buJ-ug-pKt.title" = "使用选择进行查找";
+"buJ-ug-pKt.title" = "查找选中文字";
 
 /* Class = "NSMenu"; title = "Transformations"; ObjectID = "c8a-y6-VQd"; */
 "c8a-y6-VQd.title" = "转变";
@@ -363,16 +363,16 @@
 "cDB-IK-hbR.title" = "不使用";
 
 /* Class = "NSTextFieldCell"; title = "Last Third"; ObjectID = "cRm-wn-Yv6"; */
-"cRm-wn-Yv6.title" = "最后三分之一";
+"cRm-wn-Yv6.title" = "后三分之一";
 
 /* Class = "NSMenuItem"; title = "Selection"; ObjectID = "cqv-fj-IhA"; */
-"cqv-fj-IhA.title" = "选拔";
+"cqv-fj-IhA.title" = "选择";
 
 /* Class = "NSMenuItem"; title = "Smart Links"; ObjectID = "cwL-P1-jid"; */
 "cwL-P1-jid.title" = "智能链接";
 
 /* Class = "NSTextFieldCell"; title = "Top Half"; ObjectID = "d7y-s8-7GE"; */
-"d7y-s8-7GE.title" = "上半场";
+"d7y-s8-7GE.title" = "上半";
 
 /* Class = "NSMenuItem"; title = "Make Lower Case"; ObjectID = "d9M-CD-aMd"; */
 "d9M-CD-aMd.title" = "小写";
@@ -393,22 +393,22 @@
 "e9j-DR-MEH.title" = "登录时启动";
 
 /* Class = "NSTextFieldCell"; title = "Bottom Half"; ObjectID = "ec4-FB-fMa"; */
-"ec4-FB-fMa.title" = "下半区";
+"ec4-FB-fMa.title" = "下半";
 
 /* Class = "NSMenuItem"; title = "About"; ObjectID = "gFy-Zj-RGl"; */
 "gFy-Zj-RGl.title" = "关于";
 
 /* Class = "NSMenuItem"; title = "Paste"; ObjectID = "gVA-U4-sdL"; */
-"gVA-U4-sdL.title" = "糊";
+"gVA-U4-sdL.title" = "粘贴";
 
 /* Class = "NSTabViewItem"; label = "Settings"; ObjectID = "gtf-PD-IHm"; */
 "gtf-PD-IHm.label" = "设定值";
 
 /* Class = "NSTextFieldCell"; title = "Rectangle needs your permission to control your window positions."; ObjectID = "gyg-xl-dPn"; */
-"gyg-xl-dPn.title" = "Rectangle需要您的许可才能控制窗口位置。";
+"gyg-xl-dPn.title" = "Rectangle 需要您的许可才能控制窗口位置。";
 
 /* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "hQb-2v-fYv"; */
-"hQb-2v-fYv.title" = "智能行情";
+"hQb-2v-fYv.title" = "智能引用";
 
 /* Class = "NSMenuItem"; title = "Check Document Now"; ObjectID = "hz2-CU-CR7"; */
 "hz2-CU-CR7.title" = "立即检查文件";
@@ -417,13 +417,13 @@
 "hz9-B4-Xy5.title" = "服务";
 
 /* Class = "NSMenuItem"; title = "Smaller"; ObjectID = "i1d-Er-qST"; */
-"i1d-Er-qST.title" = "较小的";
+"i1d-Er-qST.title" = "更小";
 
 /* Class = "NSButtonCell"; title = "Open System Preferences"; ObjectID = "iWV-c2-BJD"; */
 "iWV-c2-BJD.title" = "打开系统偏好设置";
 
 /* Class = "NSTextFieldCell"; title = "Authorize Rectangle"; ObjectID = "iXo-XL-T6q"; */
-"iXo-XL-T6q.title" = "授权Rectangle";
+"iXo-XL-T6q.title" = "授权 Rectangle";
 
 /* Class = "NSMenu"; title = "Baseline"; ObjectID = "ijk-EB-dga"; */
 "ijk-EB-dga.title" = "基准线";
@@ -444,10 +444,10 @@
 "kIP-vf-haE.title" = "显示侧边栏";
 
 /* Class = "NSTextFieldCell"; title = "Go to System Preferences → Security & Privacy → Privacy → Accessibility"; ObjectID = "lgE-cR-cQ5"; */
-"lgE-cR-cQ5.title" = "进入系统偏好设置→安全和隐私→隐私→可访问性";
+"lgE-cR-cQ5.title" = "进入系统偏好设置→安全性与隐私→隐私→辅助功能";
 
 /* Class = "NSTextFieldCell"; title = "When the menu bar icon is hidden, relaunch Rectangle from Finder to open the menu."; ObjectID = "ltc-mf-BHr"; */
-"ltc-mf-BHr.title" = "隐藏菜单栏图标后，从Finder重新启动Rectangle以打开菜单。";
+"ltc-mf-BHr.title" = "隐藏菜单栏图标后，从 Finder 重新启动 Rectangle 以再次显示菜单。";
 
 /* Class = "NSMenuItem"; title = "Check Grammar With Spelling"; ObjectID = "mK6-2p-4JG"; */
 "mK6-2p-4JG.title" = "检查拼写语法";
@@ -459,7 +459,7 @@
 "o6e-r0-MWq.title" = "连字";
 
 /* Class = "NSMenu"; title = "Open Recent"; ObjectID = "oas-Oc-fiZ"; */
-"oas-Oc-fiZ.title" = "最近开放";
+"oas-Oc-fiZ.title" = "打开最近的";
 
 /* Class = "NSMenuItem"; title = "Loosen"; ObjectID = "ogc-rX-tC1"; */
 "ogc-rX-tC1.title" = "松开";
@@ -471,7 +471,7 @@
 "pxx-59-PXV.title" = "保存…";
 
 /* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "q09-fT-Sye"; */
-"q09-fT-Sye.title" = "找下一个";
+"q09-fT-Sye.title" = "查找下一个";
 
 /* Class = "NSMenuItem"; title = "Page Setup…"; ObjectID = "qIS-W8-SiK"; */
 "qIS-W8-SiK.title" = "页面设置…";
@@ -483,25 +483,25 @@
 "rbD-Rh-wIN.title" = "键入时检查拼写";
 
 /* Class = "NSMenuItem"; title = "Smart Dashes"; ObjectID = "rgM-f4-ycn"; */
-"rgM-f4-ycn.title" = "聪明的破折号";
+"rgM-f4-ycn.title" = "智能破折号";
 
 /* Class = "NSButtonCell"; title = "Check for updates automatically"; ObjectID = "rmV-YD-Hzj"; */
 "rmV-YD-Hzj.title" = "自动检查更新";
 
 /* Class = "NSTextFieldCell"; title = "Move Right"; ObjectID = "rzr-Qq-702"; */
-"rzr-Qq-702.title" = "向右移";
+"rzr-Qq-702.title" = "右移";
 
 /* Class = "NSMenuItem"; title = "Show Toolbar"; ObjectID = "snW-S8-Cw5"; */
 "snW-S8-Cw5.title" = "显示工具栏";
 
 /* Class = "NSTextFieldCell"; title = "Check Rectangle.app"; ObjectID = "t7n-mU-75I"; */
-"t7n-mU-75I.title" = "检查Rectangle.app";
+"t7n-mU-75I.title" = "检查 Rectangle.app";
 
 /* Class = "NSMenuItem"; title = "Data Detectors"; ObjectID = "tRr-pd-1PS"; */
 "tRr-pd-1PS.title" = "数据检测器";
 
 /* Class = "NSMenuItem"; title = "Open Recent"; ObjectID = "tXI-mr-wws"; */
-"tXI-mr-wws.title" = "最近开放";
+"tXI-mr-wws.title" = "打开最近的";
 
 /* Class = "NSMenu"; title = "Kern"; ObjectID = "tlD-Oa-oAM"; */
 "tlD-Oa-oAM.title" = "克恩";
@@ -510,16 +510,16 @@
 "uLF-Uf-tBt.title" = "恢复默认快捷方式";
 
 /* Class = "NSMenu"; title = "Rectangle"; ObjectID = "uQy-DD-JDr"; */
-"uQy-DD-JDr.title" = "矩形";
+"uQy-DD-JDr.title" = "Rectangle";
 
 /* Class = "NSMenuItem"; title = "Cut"; ObjectID = "uRl-iY-unG"; */
-"uRl-iY-unG.title" = "切";
+"uRl-iY-unG.title" = "剪切";
 
 /* Class = "NSTabViewItem"; label = "Keyboard Shortcuts"; ObjectID = "uw2-9W-2jq"; */
 "uw2-9W-2jq.label" = "键盘快捷键";
 
 /* Class = "NSTextFieldCell"; title = "Move Left"; ObjectID = "v2f-bX-xiM"; */
-"v2f-bX-xiM.title" = "向左移动";
+"v2f-bX-xiM.title" = "左移";
 
 /* Class = "NSMenuItem"; title = "Paste Style"; ObjectID = "vKC-jM-MkH"; */
 "vKC-jM-MkH.title" = "粘贴样式";
@@ -540,10 +540,10 @@
 "wb2-vD-lq4.title" = "右对齐";
 
 /* Class = "NSMenuItem"; title = "Help"; ObjectID = "wpr-3q-Mcd"; */
-"wpr-3q-Mcd.title" = "救命";
+"wpr-3q-Mcd.title" = "帮助";
 
 /* Class = "NSMenuItem"; title = "Copy"; ObjectID = "x3v-GG-iWU"; */
-"x3v-GG-iWU.title" = "复制";
+"x3v-GG-iWU.title" = "拷贝";
 
 /* Class = "NSMenuItem"; title = "Use All"; ObjectID = "xQD-1f-W4t"; */
 "xQD-1f-W4t.title" = "全部使用";
@@ -552,7 +552,7 @@
 "xrE-MZ-jX0.title" = "言语";
 
 /* Class = "NSMenuItem"; title = "Quit Rectangle"; ObjectID = "yvN-PE-bxn"; */
-"yvN-PE-bxn.title" = "退出Rectangle";
+"yvN-PE-bxn.title" = "退出 Rectangle";
 
 /* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "z6F-FW-3nz"; */
 "z6F-FW-3nz.title" = "显示替代";


### PR DESCRIPTION
Fix wrong machine translations.
Leave application name as untranslated name.
Use correct term commonly used by macOS, such as `Find` `Copy` `Cut` `Paste` `Smart` `Help` `Preferences` translations.
Add missing space between English and Chinese to improve readability.
