### PR TITLE
Add useless gaps feature for space between windows/screen edges

### DIFF
--- a/Rectangle/Base.lproj/Main.storyboard
+++ b/Rectangle/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -2268,14 +2268,14 @@
             <objects>
                 <viewController storyboardIdentifier="SettingsViewController" id="yhc-gS-h02" customClass="SettingsViewController" customModule="Rectangle" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="mTk-eQ-4uf">
-                        <rect key="frame" x="0.0" y="0.0" width="490" height="277"/>
+                        <rect key="frame" x="0.0" y="0.0" width="490" height="309"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tUi-Ja-evb">
-                                <rect key="frame" x="20" y="61" width="450" height="196"/>
+                                <rect key="frame" x="20" y="61" width="450" height="228"/>
                                 <subviews>
                                     <button verticalHuggingPriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="eQJ-O3-a8H">
-                                        <rect key="frame" x="-2" y="180" width="454" height="18"/>
+                                        <rect key="frame" x="-2" y="212" width="454" height="18"/>
                                         <buttonCell key="cell" type="check" title="Launch on login" bezelStyle="regularSquare" imagePosition="left" inset="2" id="e9j-DR-MEH">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -2285,7 +2285,7 @@
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3wO-pf-nsb">
-                                        <rect key="frame" x="-2" y="156" width="454" height="18"/>
+                                        <rect key="frame" x="-2" y="188" width="454" height="18"/>
                                         <buttonCell key="cell" type="check" title="Snap windows by dragging" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1ui-PL-TkR">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -2295,7 +2295,7 @@
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wBT-R4-q9s">
-                                        <rect key="frame" x="-2" y="132" width="454" height="18"/>
+                                        <rect key="frame" x="-2" y="164" width="454" height="18"/>
                                         <buttonCell key="cell" type="check" title="Hide menu bar icon" bezelStyle="regularSquare" imagePosition="left" inset="2" id="qlg-kC-FMr">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -2305,15 +2305,15 @@
                                         </connections>
                                     </button>
                                     <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="gIp-Hu-6ns">
-                                        <rect key="frame" x="-2" y="110" width="454" height="14"/>
+                                        <rect key="frame" x="-2" y="142" width="454" height="14"/>
                                         <textFieldCell key="cell" title="When the menu bar icon is hidden, relaunch Rectangle from Finder to open the menu." id="ltc-mf-BHr">
-                                            <font key="font" metaFont="menu" size="11"/>
+                                            <font key="font" metaFont="toolTip"/>
                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
                                     <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="95T-Ls-2ah">
-                                        <rect key="frame" x="-2" y="84" width="454" height="18"/>
+                                        <rect key="frame" x="-2" y="116" width="454" height="18"/>
                                         <buttonCell key="cell" type="check" title="Cycle across displays on repeated left or right commands" bezelStyle="regularSquare" imagePosition="left" inset="2" id="SXx-HZ-GkB">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -2323,15 +2323,15 @@
                                         </connections>
                                     </button>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Pe4-di-byb">
-                                        <rect key="frame" x="-2" y="48" width="454" height="28"/>
+                                        <rect key="frame" x="-2" y="80" width="454" height="28"/>
                                         <textFieldCell key="cell" title="If you repeat move or half actions, the window will move to the next display instead of 1/2, 2/3, and 1/3 size." id="01Z-t3-cBm">
-                                            <font key="font" metaFont="menu" size="11"/>
+                                            <font key="font" metaFont="toolTip"/>
                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UY7-Nt-G3K">
-                                        <rect key="frame" x="-2" y="22" width="454" height="18"/>
+                                        <rect key="frame" x="-2" y="54" width="454" height="18"/>
                                         <buttonCell key="cell" type="check" title="Allow any keyboard shortcut" bezelStyle="regularSquare" imagePosition="left" inset="2" id="n4U-FC-L9s">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -2341,12 +2341,50 @@
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HcU-0y-wJU">
-                                        <rect key="frame" x="-2" y="-2" width="454" height="18"/>
+                                        <rect key="frame" x="-2" y="30" width="454" height="18"/>
                                         <buttonCell key="cell" type="check" title="Check for updates automatically" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rmV-YD-Hzj">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
+                                    <stackView autoresizesSubviews="NO" distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Y9O-Ed-XYo">
+                                        <rect key="frame" x="0.0" y="0.0" width="450" height="22"/>
+                                        <subviews>
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="N5U-vW-di5">
+                                                <rect key="frame" x="-2" y="3" width="87" height="16"/>
+                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Useless Gaps" id="RNJ-7p-rXL">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xmx-Om-ndD">
+                                                <rect key="frame" x="83" y="1" width="354" height="21"/>
+                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="KVv-YJ-nqZ">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3xo-js-24G">
+                                                <rect key="frame" x="434" y="-3" width="19" height="28"/>
+                                                <stepperCell key="cell" continuous="YES" alignment="left" increment="2" maxValue="100" id="n0B-XJ-MO1"/>
+                                                <connections>
+                                                    <action selector="uselessGapsChanged:" target="yhc-gS-h02" id="ysa-pY-CqF"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                        <visibilityPriorities>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                        </visibilityPriorities>
+                                        <customSpacing>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                        </customSpacing>
+                                    </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="width" priority="999" constant="450" id="Db3-zB-dtQ"/>
@@ -2361,8 +2399,10 @@
                                     <integer value="1000"/>
                                     <integer value="1000"/>
                                     <integer value="1000"/>
+                                    <integer value="1000"/>
                                 </visibilityPriorities>
                                 <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
@@ -2400,6 +2440,8 @@
                         <outlet property="hideMenuBarIconCheckbox" destination="wBT-R4-q9s" id="bkO-zn-yAZ"/>
                         <outlet property="launchOnLoginCheckbox" destination="eQJ-O3-a8H" id="iF3-bq-l1j"/>
                         <outlet property="subsequentExecutionCheckbox" destination="95T-Ls-2ah" id="mhe-zK-Tja"/>
+                        <outlet property="uselessGapsStepper" destination="3xo-js-24G" id="pBV-Mn-hcy"/>
+                        <outlet property="uselessGapsValueTextField" destination="KVv-YJ-nqZ" id="MLD-af-Sgh"/>
                         <outlet property="windowSnappingCheckbox" destination="3wO-pf-nsb" id="00K-AW-LYi"/>
                     </connections>
                 </viewController>
@@ -2466,7 +2508,7 @@
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XRC-ST-jLi">
                                         <rect key="frame" x="-2" y="137" width="254" height="28"/>
                                         <textFieldCell key="cell" alignment="center" title="Go to System Preferences → Security &amp; Privacy → Privacy → Accessibility" id="lgE-cR-cQ5">
-                                            <font key="font" metaFont="menu" size="11"/>
+                                            <font key="font" metaFont="toolTip"/>
                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -18,6 +18,7 @@ class Defaults {
     static let windowSnapping = OptionalBoolDefault(key: "windowSnapping")
     static let almostMaximizeHeight = FloatDefault(key: "almostMaximizeHeight")
     static let almostMaximizeWidth = FloatDefault(key: "almostMaximizeWidth")
+    static let uselessGaps = FloatDefault(key: "uselessGaps")
 }
 
 class BoolDefault {

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -21,7 +21,9 @@ class SettingsViewController: NSViewController {
     @IBOutlet weak var subsequentExecutionCheckbox: NSButton!
     @IBOutlet weak var allowAnyShortcutCheckbox: NSButton!
     @IBOutlet weak var checkForUpdatesAutomaticallyCheckbox: NSButton!
-    
+    @IBOutlet weak var uselessGapsStepper: NSStepper!
+    @IBOutlet weak var uselessGapsValueTextField: NSTextFieldCell!
+
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
         let newSetting: Bool = sender.state == .on
         let smLoginSuccess = SMLoginItemSetEnabled(AppDelegate.launcherAppId as CFString, newSetting)
@@ -56,6 +58,11 @@ class SettingsViewController: NSViewController {
         NotificationCenter.default.post(name: SettingsViewController.allowAnyShortcutNotificationName, object: newSetting)
     }
     
+    @IBAction func uselessGapsChanged(_ sender: NSStepper) {
+        Defaults.uselessGaps.value = sender.floatValue
+        uselessGapsValueTextField.floatValue = Defaults.uselessGaps.value
+    }
+
     @IBAction func restoreDefaults(_ sender: Any) {
         WindowAction.active.forEach { UserDefaults.standard.removeObject(forKey: $0.name) }
     }
@@ -81,6 +88,9 @@ class SettingsViewController: NSViewController {
             windowSnappingCheckbox.state = .off
         }
         
+        uselessGapsStepper.floatValue = Defaults.uselessGaps.value
+        uselessGapsValueTextField.floatValue = Defaults.uselessGaps.value
+
         if let updater = SUUpdater.shared() {
             checkForUpdatesAutomaticallyCheckbox.bind(.value, to: updater, withKeyPath: "automaticallyChecksForUpdates", options: nil)
         }

--- a/Rectangle/WindowCalculation/BottomHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomHalfCalculation.swift
@@ -25,20 +25,20 @@ class BottomHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         
         var oneHalfRect = visibleFrameOfScreen
         oneHalfRect.size.height = floor(oneHalfRect.height / 2.0)
-        return oneHalfRect
+        return applyUselessGaps(oneHalfRect, sharedEdges: .bottom)
     }
     
     func calculateSecondRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
         
         var twoThirdsRect = visibleFrameOfScreen
         twoThirdsRect.size.height = floor(visibleFrameOfScreen.height * 2 / 3.0)
-        return twoThirdsRect
+        return applyUselessGaps(twoThirdsRect, sharedEdges: .bottom)
     }
     
     func calculateThirdRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
         
         var oneThirdRect = visibleFrameOfScreen
         oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 3.0)
-        return oneThirdRect
+        return applyUselessGaps(oneThirdRect, sharedEdges: .bottom)
     }
 }

--- a/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
@@ -40,7 +40,7 @@ class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation
         if action == .rightHalf {
             oneHalfRect.origin.x += oneHalfRect.size.width
         }
-        return oneHalfRect
+        return applyUselessGaps(oneHalfRect, sharedEdges: action == .rightHalf ? .left : .right)
     }
 
     func calculateSecondRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -50,7 +50,7 @@ class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation
         if action == .rightHalf {
             twoThirdsRect.origin.x = visibleFrameOfScreen.minX + visibleFrameOfScreen.width - twoThirdsRect.width
         }
-        return twoThirdsRect
+        return applyUselessGaps(twoThirdsRect, sharedEdges: action == .rightHalf ? .left : .right)
     }
 
     func calculateThirdRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -60,7 +60,7 @@ class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation
         if action == .rightHalf {
             oneThirdRect.origin.x = visibleFrameOfScreen.origin.x + visibleFrameOfScreen.width - oneThirdRect.width
         }
-        return oneThirdRect
+        return applyUselessGaps(oneThirdRect, sharedEdges: action == .rightHalf ? .left : .right)
     }
 
     func calculateLeftAcrossDisplays(_ windowRect: CGRect, lastAction: RectangleAction?, screen: NSScreen, usableScreens: UsableScreens) -> WindowCalculationResult? {

--- a/Rectangle/WindowCalculation/LowerLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerLeftCalculation.swift
@@ -25,7 +25,7 @@ class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         var oneQuarterRect = visibleFrameOfScreen
         oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return oneQuarterRect
+        return applyUselessGaps(oneQuarterRect)
     }
     
     func calculateSecondRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -33,7 +33,7 @@ class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         var twoThirdsRect = visibleFrameOfScreen
         twoThirdsRect.size.width = floor(visibleFrameOfScreen.width * 2 / 3.0)
         twoThirdsRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return twoThirdsRect
+        return applyUselessGaps(twoThirdsRect)
     }
     
     func calculateThirdRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -41,6 +41,6 @@ class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         var oneThirdRect = visibleFrameOfScreen
         oneThirdRect.size.width = floor(visibleFrameOfScreen.width / 3.0)
         oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return oneThirdRect
+        return applyUselessGaps(oneThirdRect)
     }
 }

--- a/Rectangle/WindowCalculation/LowerRightCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerRightCalculation.swift
@@ -26,7 +26,7 @@ class LowerRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
         oneQuarterRect.origin.x += oneQuarterRect.width
-        return oneQuarterRect
+        return applyUselessGaps(oneQuarterRect)
     }
     
     func calculateSecondRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -35,7 +35,7 @@ class LowerRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         twoThirdsRect.size.width = floor(visibleFrameOfScreen.width * 2 / 3.0)
         twoThirdsRect.origin.x = visibleFrameOfScreen.minX + visibleFrameOfScreen.width - twoThirdsRect.width
         twoThirdsRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return twoThirdsRect
+        return applyUselessGaps(twoThirdsRect)
     }
     
     func calculateThirdRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -44,6 +44,6 @@ class LowerRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         oneThirdRect.size.width = floor(visibleFrameOfScreen.width / 3.0)
         oneThirdRect.origin.x = visibleFrameOfScreen.minX + visibleFrameOfScreen.width - oneThirdRect.width
         oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return oneThirdRect
+        return applyUselessGaps(oneThirdRect)
     }
 }

--- a/Rectangle/WindowCalculation/MaximizeCalculation.swift
+++ b/Rectangle/WindowCalculation/MaximizeCalculation.swift
@@ -11,7 +11,7 @@ import Foundation
 class MaximizeCalculation: WindowCalculation {
 
     func calculateRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect? {
-        return visibleFrameOfScreen
+        return applyUselessGaps(visibleFrameOfScreen)
     }
     
 }

--- a/Rectangle/WindowCalculation/TopHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/TopHalfCalculation.swift
@@ -26,7 +26,7 @@ class TopHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         var oneHalfRect = visibleFrameOfScreen
         oneHalfRect.size.height = floor(oneHalfRect.height / 2.0)
         oneHalfRect.origin.y += oneHalfRect.height + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-        return oneHalfRect
+        return applyUselessGaps(oneHalfRect, sharedEdges: .top)
     }
     
     func calculateSecondRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -34,7 +34,7 @@ class TopHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         var twoThirdsRect = visibleFrameOfScreen
         twoThirdsRect.size.height = floor(visibleFrameOfScreen.height * 2 / 3.0)
         twoThirdsRect.origin.y = visibleFrameOfScreen.origin.y + visibleFrameOfScreen.height - twoThirdsRect.height
-        return twoThirdsRect
+        return applyUselessGaps(twoThirdsRect, sharedEdges: .top)
     }
     
     func calculateThirdRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -42,6 +42,6 @@ class TopHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         var oneThirdRect = visibleFrameOfScreen
         oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 3.0)
         oneThirdRect.origin.y = visibleFrameOfScreen.origin.y + visibleFrameOfScreen.height - oneThirdRect.height
-        return oneThirdRect
+        return applyUselessGaps(oneThirdRect, sharedEdges: .top)
     }
 }

--- a/Rectangle/WindowCalculation/UpperLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperLeftCalculation.swift
@@ -26,7 +26,7 @@ class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
         oneQuarterRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-        return oneQuarterRect
+        return applyUselessGaps(oneQuarterRect)
     }
     
     func calculateSecondRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -36,7 +36,7 @@ class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         twoThirdsRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
         twoThirdsRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
 
-        return twoThirdsRect
+        return applyUselessGaps(twoThirdsRect)
     }
     
     func calculateThirdRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -46,6 +46,6 @@ class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
         oneThirdRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
 
-        return oneThirdRect
+        return applyUselessGaps(oneThirdRect)
     }
 }

--- a/Rectangle/WindowCalculation/UpperRightCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperRightCalculation.swift
@@ -27,7 +27,7 @@ class UpperRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
         oneQuarterRect.origin.x += oneQuarterRect.width
         oneQuarterRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-        return oneQuarterRect
+        return applyUselessGaps(oneQuarterRect)
     }
     
     func calculateSecondRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -37,7 +37,7 @@ class UpperRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         twoThirdsRect.origin.x = visibleFrameOfScreen.minX + visibleFrameOfScreen.width - twoThirdsRect.width
         twoThirdsRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
         twoThirdsRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-        return twoThirdsRect
+        return applyUselessGaps(twoThirdsRect)
     }
     
     func calculateThirdRect(_ windowRect: CGRect, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> CGRect {
@@ -47,6 +47,6 @@ class UpperRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         oneThirdRect.origin.x = visibleFrameOfScreen.minX + visibleFrameOfScreen.width - oneThirdRect.width
         oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
         oneThirdRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-        return oneThirdRect
+        return applyUselessGaps(oneThirdRect)
     }
 }

--- a/Rectangle/WindowCalculation/WindowCalculation.swift
+++ b/Rectangle/WindowCalculation/WindowCalculation.swift
@@ -41,6 +41,61 @@ extension WindowCalculation {
         return rect.width > rect.height
     }
     
+    func applyUselessGaps(_ rect: CGRect, sharedEdges: Edge = .none) -> CGRect {
+        let uselessGapSize = CGFloat(Defaults.uselessGaps.value)
+        var withGaps = rect.insetBy(dx: uselessGapSize, dy: uselessGapSize)
+
+        if (sharedEdges.contains(.left)) {
+            withGaps = CGRect(
+                x: withGaps.origin.x - (uselessGapSize / 2),
+                y: withGaps.origin.y,
+                width: withGaps.width + (uselessGapSize / 2),
+                height: withGaps.height
+            )
+        }
+
+        if (sharedEdges.contains(.right)) {
+            withGaps = CGRect(
+                x: withGaps.origin.x,
+                y: withGaps.origin.y,
+                width: withGaps.width + (uselessGapSize / 2),
+                height: withGaps.height
+            )
+        }
+
+        if (sharedEdges.contains(.top)) {
+            withGaps = CGRect(
+                x: withGaps.origin.x,
+                y: withGaps.origin.y - (uselessGapSize / 2),
+                width: withGaps.width,
+                height: withGaps.height + (uselessGapSize / 2)
+            )
+        }
+
+        if (sharedEdges.contains(.bottom)) {
+            withGaps = CGRect(
+                x: withGaps.origin.x,
+                y: withGaps.origin.y,
+                width: withGaps.width,
+                height: withGaps.height + (uselessGapSize / 2)
+            )
+        }
+
+        return withGaps
+    }
+
+}
+
+struct Edge: OptionSet {
+    let rawValue: Int
+
+    static let left = Edge(rawValue: 1 << 0)
+    static let right = Edge(rawValue: 1 << 1)
+    static let top = Edge(rawValue: 1 << 2)
+    static let bottom = Edge(rawValue: 1 << 3)
+
+    static let all: Edge = [.left, .right, .top, .bottom]
+    static let none: Edge = []
 }
 
 struct WindowCalculationResult {


### PR DESCRIPTION
Adds adjustable 'useless gaps' (space between windows/edge of screen) for a number of the arrangements. 

I wanted this feature for my personal use so I just did it anyway and can use my own fork if you aren't interested in incorporating it. There was some demand for the feature back in Spectacle (https://github.com/eczarny/spectacle/issues/290).

Disclaimer: I'm new to MacOS development. I've done a little bit of Swift for iOS. I had to much with the settings (removed a build phase 'Run Script' which was giving me an error) to get stuff building on my end and I excluded those changes from the PR. Hopefully this branch will build fine for you if you're interested in incorporating the feature. 