### PR TITLE
Display function keys correctly in status bar menu

### DIFF
--- a/Rectangle/ShortcutManager.swift
+++ b/Rectangle/ShortcutManager.swift
@@ -37,7 +37,7 @@ class ShortcutManager {
     
     public func getKeyEquivalent(action: WindowAction) -> (String?, NSEvent.ModifierFlags)? {
         guard let masShortcut = MASShortcutBinder.shared()?.value(forKey: action.name) as? MASShortcut else { return nil }
-        return (masShortcut.keyCodeString, masShortcut.modifierFlags)
+        return (masShortcut.keyCodeStringForKeyEquivalent, masShortcut.modifierFlags)
     }
     
     deinit {


### PR DESCRIPTION
Fixes rxhanson/Rectangle#69

`NSMenuItem.keyEquivalent` only displays the first character of the set string in the menu. To be able to display key equivalents like “F12”, we need to use font glyphs that render that entire character (which are defined by Apple in a private area of the unicode table: https://developer.apple.com/documentation/appkit/1535851-function-key_unicodes?language=objc)

MASShortcut already supports this with `MASSShortcut.keyCodeStringForKeyEquivalent`. We just need to return this property instead of the more human-readable `keyCodeString` when we want a string that can be used with `NSMenuItem.keyEquivalent`.