### PR TITLE
Corrected a typo

### DIFF
--- a/Rectangle/zh-Hant.lproj/Main.strings
+++ b/Rectangle/zh-Hant.lproj/Main.strings
@@ -132,7 +132,7 @@
 "Eah-KL-kbn.title" = "變大";
 
 /* Class = "NSTextFieldCell"; title = "First Third"; ObjectID = "F12-EV-Lfz"; */
-"F12-EV-Lfz.title" = "左三之一";
+"F12-EV-Lfz.title" = "左三分之一";
 
 /* Class = "NSMenu"; title = "Help"; ObjectID = "F2S-fz-NVQ"; */
 "F2S-fz-NVQ.title" = "說明";


### PR DESCRIPTION
Corrected "First Third" from '左三之一' to '左三分之一'
Sorry for the typo and thanks to @networm for reminder!