### PR TITLE
FR translation fix for snap area option in settings

### DIFF
--- a/Rectangle/fr.lproj/Main.strings
+++ b/Rectangle/fr.lproj/Main.strings
@@ -24,7 +24,7 @@
 "1tx-W0-xDw.title" = "Abaisser";
 
 /* Class = "NSButtonCell"; title = "Snap windows by dragging"; ObjectID = "1ui-PL-TkR"; */
-"1ui-PL-TkR.title" = "Fermer les fenêtres en les faisant glisser";
+"1ui-PL-TkR.title" = "Redimensionner les fenêtres en les faisant glisser";
 
 /* Class = "NSMenuItem"; title = "Raise"; ObjectID = "2h7-ER-AoG"; */
 "2h7-ER-AoG.title" = "Lever";


### PR DESCRIPTION
"Fermer les fenêtres en les faisant glisser" means "Close windows by dragging" which is not what the feature does.
"Snap" is not easy to translate in French in this context, I translated it as "Redimensionner" which means "Resize", I hope that's ok.