### PR TITLE
account for gapSize when changing window size

### DIFF
--- a/Rectangle/WindowCalculation/ChangeSizeCalculation.swift
+++ b/Rectangle/WindowCalculation/ChangeSizeCalculation.swift
@@ -12,6 +12,7 @@ class ChangeSizeCalculation: WindowCalculation {
 
     let minimumWindowWidth: CGFloat
     let minimumWindowHeight: CGFloat
+    let gapSize: CGFloat
 
     override init() {
         let defaultHeight = Defaults.minimumWindowHeight.value
@@ -23,6 +24,9 @@ class ChangeSizeCalculation: WindowCalculation {
         minimumWindowWidth = (defaultWidth <= 0 || defaultWidth > 1)
             ? 0.25
             : CGFloat(defaultWidth)
+
+        let defaultGapSize = Defaults.gapSize.value
+        gapSize = (defaultGapSize <= 0) ? 5.0 : CGFloat(defaultGapSize)
     }
     
     override func calculateRect(_ window: Window, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> RectResult {
@@ -44,7 +48,6 @@ class ChangeSizeCalculation: WindowCalculation {
                                                                                visibleFrameOfScreen: visibleFrameOfScreen)
         if resizedWindowRect.height >= visibleFrameOfScreen.height {
             resizedWindowRect.size.height = visibleFrameOfScreen.height
-            resizedWindowRect.origin.y = window.rect.origin.y
         }
         if againstAllEdgesOfScreen(windowRect: window.rect, visibleFrameOfScreen: visibleFrameOfScreen) && (sizeOffset < 0) {
             resizedWindowRect.size.width = window.rect.width + sizeOffset
@@ -59,11 +62,11 @@ class ChangeSizeCalculation: WindowCalculation {
     }
     
     private func againstEdgeOfScreen(_ gap: CGFloat) -> Bool {
-        return abs(gap) <= 5.0
+        return abs(gap) <= gapSize
     }
     
     private func againstTheLeftEdgeOfScreen(_ windowRect: CGRect, _ visibleFrameOfScreen: CGRect) -> Bool {
-        return againstEdgeOfScreen(windowRect.origin.x - visibleFrameOfScreen.origin.x)
+        return againstEdgeOfScreen(windowRect.minX - visibleFrameOfScreen.minX)
     }
     
     private func againstTheRightEdgeOfScreen(_ windowRect: CGRect, _ visibleFrameOfScreen: CGRect) -> Bool {


### PR DESCRIPTION
Fixes the following type of scenario when using gapSize:
- move window to a corner
- make window smaller
- the window is now shrunk away from the corner (unlike the non-gapSize
  behavior where the window stays "glued" to the edges)

(This also includes some minor consistency fixes.)

A detail I considered: changing sizes when a window is at an edge will
eliminate the gap between the window and the edge. I thought about
preserving the gap with the edge, but this behavior feels reasonable and
trying to preserve the gap would create a bunch of *ahem* edge cases to
deal with (eg if a window is full height, doing a increase-size command
shouldn't add gaps to avoid making the height smaller).