### PR TITLE
When moving a window to next/prev display, try to keep it in the same position if possible

### DIFF
--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -65,6 +65,11 @@ enum WindowAction: Int {
                          firstFourth, secondFourth, thirdFourth, lastFourth,
                          topLeftSixth, topCenterSixth, topRightSixth, bottomLeftSixth, bottomCenterSixth, bottomRightSixth
     ]
+    
+    static let positionalActions = [leftHalf, rightHalf, centerHalf, topHalf, bottomHalf,
+                                    topLeft, topRight, bottomLeft, bottomRight,
+                                    maximize
+    ]
 
     func post() {
         NotificationCenter.default.post(name: notificationName, object: ExecutionParameters(self))

--- a/Rectangle/WindowCalculation/NextPrevDisplayCalculation.swift
+++ b/Rectangle/WindowCalculation/NextPrevDisplayCalculation.swift
@@ -24,7 +24,15 @@ class NextPrevDisplayCalculation: WindowCalculation {
         }
 
         if let screen = screen {
+            let oldRectParams = params.asRectParams(visibleFrame: usableScreens.currentScreen.adjustedVisibleFrame)
             let rectParams = params.asRectParams(visibleFrame: screen.adjustedVisibleFrame)
+            
+            let existingPositionCalculation = getExistingPositionCalculation(oldRectParams: oldRectParams, newRectParams: rectParams)
+            
+            if existingPositionCalculation != nil {
+                return WindowCalculationResult(rect: existingPositionCalculation!.rect, screen: screen, resultingAction: params.action)
+            }
+            
             let rectResult = calculateRect(rectParams)
             return WindowCalculationResult(rect: rectResult.rect, screen: screen, resultingAction: params.action)
         }
@@ -40,4 +48,40 @@ class NextPrevDisplayCalculation: WindowCalculation {
         
         return WindowCalculationFactory.centerCalculation.calculateRect(params)
     }
+
+
+    private func getExistingPositionCalculation(oldRectParams: RectCalculationParameters, newRectParams: RectCalculationParameters) -> RectResult? {
+        for action in WindowAction.positionalActions {
+            let oldCalculationParams = RectCalculationParameters(
+                    window: oldRectParams.window,
+                    visibleFrameOfScreen: oldRectParams.visibleFrameOfScreen,
+                    action: action,
+                    lastAction: oldRectParams.lastAction)
+            let oldCalculation = WindowCalculationFactory.calculationsByAction[action]!.calculateRect(oldCalculationParams)
+            if (closeEnough(thisRect: oldRectParams.window.rect, thatRect: oldCalculation.rect)) {
+                let newCalculationParams = RectCalculationParameters(
+                        window: newRectParams.window,
+                        visibleFrameOfScreen: newRectParams.visibleFrameOfScreen,
+                        action: action,
+                        lastAction: newRectParams.lastAction)
+                return WindowCalculationFactory.calculationsByAction[action]?.calculateRect(newCalculationParams)
+            }
+        }
+        return nil
+    }
+
+    private func closeEnough(thisRect: CGRect, thatRect: CGRect) -> Bool {
+        if thisRect.equalTo(thatRect) {
+            return true
+        }
+        return closeEnough(thisCGFloat: thisRect.origin.x, thatCGFloat: thatRect.origin.x) &&
+                closeEnough(thisCGFloat: thisRect.origin.y, thatCGFloat: thatRect.origin.y) &&
+                closeEnough(thisCGFloat: thisRect.width, thatCGFloat: thatRect.width) &&
+                closeEnough(thisCGFloat: thisRect.height, thatCGFloat: thatRect.height)
+    }
+
+    private func closeEnough(thisCGFloat: CGFloat, thatCGFloat: CGFloat) -> Bool {
+        abs(thisCGFloat - thatCGFloat) <= 1
+    }
+
 }


### PR DESCRIPTION
When moving a window to next/prev display, check if it is either maximized, or left/right half of current display, if so apply that same position on new display.

Started looking into this, and these 3 positions are the ones that I use the most. This was good enough for my usage so I figured I would open a PR.

If this is a feature you would accept a PR with more work for let me know, if not no worries.

Also feels like there's a better way to implement this, so if you have any thoughts let me know.