### PR TITLE
Add `specified`  WindowAction

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		12D896200936C0DE9FF41FB4 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		30166BD024F27D6A00A38608 /* SpecifiedCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30166BCF24F27D6A00A38608 /* SpecifiedCalculation.swift */; };
 		6327EAA4FEECF2AE087FCD30 /* Pods_RectangleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81D6E6EACB077B1A204F3A62 /* Pods_RectangleTests.framework */; };
 		981F27D12340E3E1006CD263 /* InternetAccessPolicy.plist in Resources */ = {isa = PBXBuildFile; fileRef = 981F27D02340E3E1006CD263 /* InternetAccessPolicy.plist */; };
 		9821402122B3884600ABFB3F /* BottomHalfCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9821402022B3884600ABFB3F /* BottomHalfCalculation.swift */; };
@@ -101,6 +102,7 @@
 /* Begin PBXFileReference section */
 		0796D218CC3C7CD563827A8D /* Pods-RectangleLauncher.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RectangleLauncher.release.xcconfig"; path = "Target Support Files/Pods-RectangleLauncher/Pods-RectangleLauncher.release.xcconfig"; sourceTree = "<group>"; };
 		20A533B9F2D3215AC7B85D1F /* Pods_Rectangle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rectangle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		30166BCF24F27D6A00A38608 /* SpecifiedCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifiedCalculation.swift; sourceTree = "<group>"; };
 		3EE34B57BB10FDB0B4E8359F /* Pods-RectangleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RectangleTests.release.xcconfig"; path = "Target Support Files/Pods-RectangleTests/Pods-RectangleTests.release.xcconfig"; sourceTree = "<group>"; };
 		534283F3C564C4526C67E459 /* Pods-RectangleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RectangleTests.debug.xcconfig"; path = "Target Support Files/Pods-RectangleTests/Pods-RectangleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		53A6B6ACF05CD88EB34E0D00 /* Pods-Rectangle.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rectangle.debug.xcconfig"; path = "Target Support Files/Pods-Rectangle/Pods-Rectangle.debug.xcconfig"; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 				98C1008D230B9EF6006E5344 /* NextPrevDisplayCalculation.swift */,
 				98FA9496235A2D7600F95C4F /* RepeatedExecutionsCalculation.swift */,
 				98C6DEEF23CE191700CC0C1E /* GapCalculation.swift */,
+				30166BCF24F27D6A00A38608 /* SpecifiedCalculation.swift */,
 			);
 			path = WindowCalculation;
 			sourceTree = "<group>";
@@ -763,6 +766,7 @@
 				98910B3E231130AF0066EC23 /* SettingsViewController.swift in Sources */,
 				9824700D22AF9B7D0037B409 /* AppDelegate.swift in Sources */,
 				9824704F22B189250037B409 /* BestEffortWindowMover.swift in Sources */,
+				30166BD024F27D6A00A38608 /* SpecifiedCalculation.swift in Sources */,
 				9824703922B0F37C0037B409 /* ShortcutManager.swift in Sources */,
 				9821403322B38A1B00ABFB3F /* UpperLeftCalculation.swift in Sources */,
 				98987AA52391890400BE72C4 /* LogViewer.swift in Sources */,

--- a/Rectangle/Base.lproj/Main.storyboard
+++ b/Rectangle/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -789,20 +789,20 @@
             <objects>
                 <viewController storyboardIdentifier="PrefsViewController" showSeguePresentationStyle="single" id="zlF-FD-XEr" customClass="PrefsViewController" customModule="Rectangle" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="8J7-VI-pmF">
-                        <rect key="frame" x="0.0" y="0.0" width="720" height="395"/>
+                        <rect key="frame" x="0.0" y="0.0" width="720" height="432"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="HUP-ob-5lz">
-                                <rect key="frame" x="0.0" y="0.0" width="720" height="395"/>
+                                <rect key="frame" x="0.0" y="0.0" width="720" height="432"/>
                                 <subviews>
-                                    <stackView distribution="fill" orientation="vertical" alignment="trailing" spacing="7" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gt6-OD-H04">
-                                        <rect key="frame" x="20" y="20" width="327" height="355"/>
+                                    <stackView distribution="fillEqually" orientation="vertical" alignment="trailing" spacing="7" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gt6-OD-H04">
+                                        <rect key="frame" x="20" y="20" width="327" height="392"/>
                                         <subviews>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6dl-2T-B9P">
-                                                <rect key="frame" x="68" y="336" width="259" height="19"/>
+                                                <rect key="frame" x="68" y="370" width="259" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ce1-6G-Nkf">
-                                                        <rect key="frame" x="0.0" y="2" width="81" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="81" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oac-MY-1n1">
                                                                 <rect key="frame" x="-2" y="0.0" width="56" height="16"/>
@@ -831,7 +831,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="bGP-y9-ToI" customClass="MASShortcutView">
-                                                        <rect key="frame" x="99" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="99" y="2" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="HHy-nL-j7h"/>
                                                             <constraint firstAttribute="width" constant="160" id="g6q-pY-eGi"/>
@@ -848,10 +848,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hzQ-m9-MoW">
-                                                <rect key="frame" x="60" y="310" width="267" height="19"/>
+                                                <rect key="frame" x="60" y="341" width="267" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MN2-Yv-nag">
-                                                        <rect key="frame" x="0.0" y="2" width="89" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="89" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="daG-bl-Dca">
                                                                 <rect key="frame" x="-2" y="0.0" width="64" height="16"/>
@@ -880,7 +880,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="DJc-yE-qoJ" customClass="MASShortcutView">
-                                                        <rect key="frame" x="107" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="107" y="2" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="160" id="gbX-O0-CQo"/>
                                                             <constraint firstAttribute="height" constant="19" id="k1S-LY-sDu"/>
@@ -897,10 +897,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UZI-sV-QY7">
-                                                <rect key="frame" x="69" y="284" width="258" height="19"/>
+                                                <rect key="frame" x="69" y="312" width="258" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Us6-9p-1W0">
-                                                        <rect key="frame" x="0.0" y="2" width="80" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="80" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="j1Z-dN-QdR">
                                                                 <rect key="frame" x="-2" y="0.0" width="55" height="16"/>
@@ -929,7 +929,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="ppH-ve-v6N" customClass="MASShortcutView">
-                                                        <rect key="frame" x="98" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="98" y="2" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="160" id="CYP-H5-scH"/>
                                                             <constraint firstAttribute="height" constant="19" id="m73-1c-QCb"/>
@@ -946,10 +946,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mG2-Ie-LGc">
-                                                <rect key="frame" x="47" y="258" width="280" height="19"/>
+                                                <rect key="frame" x="47" y="284" width="280" height="21"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bJh-ua-m5c">
-                                                        <rect key="frame" x="0.0" y="2" width="102" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="102" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xwW-KA-j8t">
                                                                 <rect key="frame" x="-2" y="0.0" width="77" height="16"/>
@@ -978,7 +978,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="EhR-CV-u8d" customClass="MASShortcutView">
-                                                        <rect key="frame" x="120" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="120" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="QPA-YK-9mN"/>
                                                             <constraint firstAttribute="width" constant="160" id="eTK-wh-TKh"/>
@@ -995,17 +995,17 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="12W-gY-FHp">
-                                                <rect key="frame" x="145" y="246" width="182" height="5"/>
+                                                <rect key="frame" x="145" y="272" width="182" height="5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="5" id="lTi-x2-WTD"/>
                                                     <constraint firstAttribute="width" constant="182" id="xZH-Ps-oFE"/>
                                                 </constraints>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xSC-UJ-fXz">
-                                                <rect key="frame" x="70" y="220" width="257" height="19"/>
+                                                <rect key="frame" x="70" y="243" width="257" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2uc-Nz-b1g">
-                                                        <rect key="frame" x="0.0" y="2" width="79" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="79" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HKQ-k8-IOz">
                                                                 <rect key="frame" x="-2" y="0.0" width="54" height="16"/>
@@ -1034,7 +1034,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="XIn-7Q-Fuy" customClass="MASShortcutView">
-                                                        <rect key="frame" x="97" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="97" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="160" id="L6q-We-uRa"/>
                                                             <constraint firstAttribute="height" constant="19" id="XcC-xK-4Ve"/>
@@ -1051,10 +1051,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hng-5H-ol0">
-                                                <rect key="frame" x="62" y="194" width="265" height="19"/>
+                                                <rect key="frame" x="62" y="214" width="265" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hDT-ZP-q5C">
-                                                        <rect key="frame" x="0.0" y="2" width="87" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="87" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ZHg-2r-X9K">
                                                                 <rect key="frame" x="-2" y="0.0" width="62" height="16"/>
@@ -1083,7 +1083,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="OgW-L0-nuS" customClass="MASShortcutView">
-                                                        <rect key="frame" x="105" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="105" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="FKY-cN-MnA"/>
                                                             <constraint firstAttribute="width" constant="160" id="OIf-0U-mLf"/>
@@ -1100,10 +1100,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vdR-hP-Tpn">
-                                                <rect key="frame" x="48" y="168" width="279" height="19"/>
+                                                <rect key="frame" x="48" y="185" width="279" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xfy-3f-KPI">
-                                                        <rect key="frame" x="0.0" y="2" width="101" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="101" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QBW-Z2-1Xz">
                                                                 <rect key="frame" x="-2" y="0.0" width="76" height="16"/>
@@ -1132,7 +1132,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="whf-FK-Ywl" customClass="MASShortcutView">
-                                                        <rect key="frame" x="119" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="119" y="2" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="V1a-Mu-hJH"/>
                                                             <constraint firstAttribute="width" constant="160" id="f0u-D0-4GA"/>
@@ -1149,10 +1149,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0dG-4f-nfF">
-                                                <rect key="frame" x="40" y="142" width="287" height="19"/>
+                                                <rect key="frame" x="40" y="156" width="287" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="quG-Lk-ueq">
-                                                        <rect key="frame" x="0.0" y="2" width="109" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="109" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-Oa-YEU">
                                                                 <rect key="frame" x="-2" y="0.0" width="84" height="16"/>
@@ -1181,7 +1181,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="wi5-BQ-zY2" customClass="MASShortcutView">
-                                                        <rect key="frame" x="127" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="127" y="2" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="PXT-Bz-cXI"/>
                                                             <constraint firstAttribute="width" constant="160" id="w18-Io-DBZ"/>
@@ -1198,17 +1198,17 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3kB-KX-eMQ">
-                                                <rect key="frame" x="145" y="130" width="182" height="5"/>
+                                                <rect key="frame" x="145" y="144" width="182" height="5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="5" id="lFF-ig-WLr"/>
                                                     <constraint firstAttribute="width" constant="182" id="wpN-17-BpH"/>
                                                 </constraints>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GgD-be-blq">
-                                                <rect key="frame" x="56" y="104" width="271" height="19"/>
+                                                <rect key="frame" x="56" y="115" width="271" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zjW-UX-cpn">
-                                                        <rect key="frame" x="0.0" y="2" width="91" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="91" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ujE-rY-lCg">
                                                                 <rect key="frame" x="-2" y="0.0" width="66" height="16"/>
@@ -1237,7 +1237,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="I3d-KP-y1J" customClass="MASShortcutView">
-                                                        <rect key="frame" x="111" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="111" y="2" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="160" id="6Q8-54-QyQ"/>
                                                             <constraint firstAttribute="height" constant="19" id="fHF-nY-MLc"/>
@@ -1254,7 +1254,7 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kgg-z8-TD6">
-                                                <rect key="frame" x="21" y="78" width="306" height="19"/>
+                                                <rect key="frame" x="21" y="87" width="306" height="21"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xcG-kM-Fl9">
                                                         <rect key="frame" x="0.0" y="2" width="126" height="16"/>
@@ -1286,7 +1286,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="cLa-f6-RSt" customClass="MASShortcutView">
-                                                        <rect key="frame" x="146" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="146" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="160" id="F1y-fr-HRS"/>
                                                             <constraint firstAttribute="height" constant="19" id="kBw-oI-aC7"/>
@@ -1303,10 +1303,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yo8-YB-lLj">
-                                                <rect key="frame" x="42" y="52" width="285" height="19"/>
+                                                <rect key="frame" x="42" y="58" width="285" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yxe-q4-7yW">
-                                                        <rect key="frame" x="0.0" y="2" width="105" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="105" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DDI-Yz-vr6">
                                                                 <rect key="frame" x="-2" y="0.0" width="80" height="16"/>
@@ -1335,7 +1335,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="G13-Q4-CV6" customClass="MASShortcutView">
-                                                        <rect key="frame" x="125" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="125" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="4xq-rG-nKr"/>
                                                             <constraint firstAttribute="width" constant="160" id="N44-iI-kwW"/>
@@ -1352,10 +1352,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZEb-ZE-AIt">
-                                                <rect key="frame" x="22" y="26" width="305" height="19"/>
+                                                <rect key="frame" x="22" y="29" width="305" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Osf-zT-z4q">
-                                                        <rect key="frame" x="0.0" y="2" width="125" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="125" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EGh-4z-I6I">
                                                                 <rect key="frame" x="-2" y="0.0" width="100" height="16"/>
@@ -1384,7 +1384,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="7Km-ay-hPl" customClass="MASShortcutView">
-                                                        <rect key="frame" x="145" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="145" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="dfA-2A-xPS"/>
                                                             <constraint firstAttribute="width" constant="160" id="jeR-9I-8MC"/>
@@ -1401,10 +1401,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="y0y-Y6-G9U">
-                                                <rect key="frame" x="57" y="0.0" width="270" height="19"/>
+                                                <rect key="frame" x="57" y="0.0" width="270" height="22"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="02U-1U-ZNS">
-                                                        <rect key="frame" x="0.0" y="2" width="90" height="16"/>
+                                                        <rect key="frame" x="0.0" y="3" width="90" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bod-Jy-fPb">
                                                                 <rect key="frame" x="-2" y="0.0" width="65" height="16"/>
@@ -1433,7 +1433,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="MYy-5x-boe" customClass="MASShortcutView">
-                                                        <rect key="frame" x="110" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="110" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="3I7-hv-MZL"/>
                                                             <constraint firstAttribute="width" constant="160" id="pgs-rz-DzD"/>
@@ -1488,11 +1488,11 @@
                                             <real value="3.4028234663852886e+38"/>
                                         </customSpacing>
                                     </stackView>
-                                    <stackView distribution="fill" orientation="vertical" alignment="trailing" spacing="7" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wDN-pM-8lR">
-                                        <rect key="frame" x="390" y="20" width="310" height="355"/>
+                                    <stackView distribution="fillEqually" orientation="vertical" alignment="trailing" spacing="7" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wDN-pM-8lR">
+                                        <rect key="frame" x="390" y="20" width="310" height="392"/>
                                         <subviews>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Hd-CT-TxW">
-                                                <rect key="frame" x="46" y="336" width="264" height="19"/>
+                                                <rect key="frame" x="46" y="372" width="264" height="20"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TGC-hg-6yl">
                                                         <rect key="frame" x="0.0" y="2" width="86" height="16"/>
@@ -1524,7 +1524,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="SqN-WJ-u3L" customClass="MASShortcutView">
-                                                        <rect key="frame" x="104" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="104" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="160" id="YVB-GF-OOD"/>
                                                             <constraint firstAttribute="height" constant="19" id="dJV-Q8-tpg"/>
@@ -1541,7 +1541,7 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rVb-UL-NJE">
-                                                <rect key="frame" x="0.0" y="310" width="310" height="19"/>
+                                                <rect key="frame" x="0.0" y="345" width="310" height="20"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PRu-9D-G3q">
                                                         <rect key="frame" x="0.0" y="2" width="132" height="16"/>
@@ -1573,7 +1573,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="WOL-Ei-P6G" customClass="MASShortcutView">
-                                                        <rect key="frame" x="150" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="150" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="69s-IR-1dm"/>
                                                             <constraint firstAttribute="width" constant="160" id="DuK-8e-vpE"/>
@@ -1590,7 +1590,7 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aRK-l3-f6q">
-                                                <rect key="frame" x="2" y="284" width="308" height="19"/>
+                                                <rect key="frame" x="2" y="319" width="308" height="19"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BVf-QY-tqC">
                                                         <rect key="frame" x="0.0" y="2" width="130" height="16"/>
@@ -1639,7 +1639,7 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nLL-Xs-VHA">
-                                                <rect key="frame" x="21" y="258" width="289" height="19"/>
+                                                <rect key="frame" x="21" y="292" width="289" height="20"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E6f-24-Eit">
                                                         <rect key="frame" x="0.0" y="2" width="111" height="16"/>
@@ -1688,7 +1688,7 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="POP-uw-KpE">
-                                                <rect key="frame" x="27" y="232" width="283" height="19"/>
+                                                <rect key="frame" x="27" y="265" width="283" height="20"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="br5-Mn-jM0">
                                                         <rect key="frame" x="0.0" y="2" width="105" height="16"/>
@@ -1737,7 +1737,7 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qPO-Zc-MBX">
-                                                <rect key="frame" x="62" y="206" width="248" height="19"/>
+                                                <rect key="frame" x="62" y="238" width="248" height="20"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Mo5-WX-MxB">
                                                         <rect key="frame" x="0.0" y="2" width="70" height="16"/>
@@ -1769,7 +1769,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="WrB-f6-rnc" customClass="MASShortcutView">
-                                                        <rect key="frame" x="88" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="88" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="160" id="7rp-wt-YNO"/>
                                                             <constraint firstAttribute="height" constant="19" id="zCg-t7-Cdi"/>
@@ -1786,10 +1786,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G0A-5v-FZT">
-                                                <rect key="frame" x="56" y="180" width="254" height="19"/>
+                                                <rect key="frame" x="56" y="212" width="254" height="19"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KIs-zp-YfP">
-                                                        <rect key="frame" x="0.0" y="2" width="76" height="16"/>
+                                                        <rect key="frame" x="0.0" y="1" width="76" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DVN-Fh-ZlH">
                                                                 <rect key="frame" x="-2" y="0.0" width="51" height="16"/>
@@ -1834,15 +1834,64 @@
                                                     <real value="3.4028234663852886e+38"/>
                                                 </customSpacing>
                                             </stackView>
+                                            <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="23p-bf-lkZ">
+                                                <rect key="frame" x="46" y="185" width="264" height="20"/>
+                                                <subviews>
+                                                    <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GhI-cP-Gfz">
+                                                        <rect key="frame" x="0.0" y="2" width="86" height="16"/>
+                                                        <subviews>
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hLL-JB-yds">
+                                                                <rect key="frame" x="-2" y="0.0" width="61" height="16"/>
+                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Specified" id="eLm-jv-DaZ">
+                                                                    <font key="font" usesAppearanceFont="YES"/>
+                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                            </textField>
+                                                            <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="9Ds-5r-z4A">
+                                                                <rect key="frame" x="65" y="1" width="21" height="14"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="21" id="S0Y-s5-XQD"/>
+                                                                    <constraint firstAttribute="height" constant="14" id="x1U-24-3I1"/>
+                                                                </constraints>
+                                                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="restoreTemplate" id="cf4-H0-eAh"/>
+                                                            </imageView>
+                                                        </subviews>
+                                                        <visibilityPriorities>
+                                                            <integer value="1000"/>
+                                                            <integer value="1000"/>
+                                                        </visibilityPriorities>
+                                                        <customSpacing>
+                                                            <real value="3.4028234663852886e+38"/>
+                                                            <real value="3.4028234663852886e+38"/>
+                                                        </customSpacing>
+                                                    </stackView>
+                                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="Pzn-9m-syr" customClass="MASShortcutView">
+                                                        <rect key="frame" x="104" y="0.0" width="160" height="19"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="19" id="Mq8-lo-8Oe"/>
+                                                            <constraint firstAttribute="width" constant="160" id="ZDZ-Cv-hUL"/>
+                                                        </constraints>
+                                                    </customView>
+                                                </subviews>
+                                                <visibilityPriorities>
+                                                    <integer value="1000"/>
+                                                    <integer value="1000"/>
+                                                </visibilityPriorities>
+                                                <customSpacing>
+                                                    <real value="3.4028234663852886e+38"/>
+                                                    <real value="3.4028234663852886e+38"/>
+                                                </customSpacing>
+                                            </stackView>
                                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Dqh-Mk-l24">
-                                                <rect key="frame" x="128" y="168" width="182" height="5"/>
+                                                <rect key="frame" x="128" y="173" width="182" height="5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="182" id="Mab-5D-Ck3"/>
                                                     <constraint firstAttribute="height" constant="5" id="Y0S-8q-of8"/>
                                                 </constraints>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NYl-g1-gHO">
-                                                <rect key="frame" x="27" y="142" width="283" height="19"/>
+                                                <rect key="frame" x="27" y="146" width="283" height="20"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W7V-QT-NjF">
                                                         <rect key="frame" x="0.0" y="2" width="105" height="16"/>
@@ -1891,7 +1940,7 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NWy-gq-tX3">
-                                                <rect key="frame" x="3" y="116" width="307" height="19"/>
+                                                <rect key="frame" x="3" y="119" width="307" height="20"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C8I-tj-Qx4">
                                                         <rect key="frame" x="0.0" y="2" width="129" height="16"/>
@@ -1923,7 +1972,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="daM-hW-c6u" customClass="MASShortcutView">
-                                                        <rect key="frame" x="147" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="147" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="LcG-CM-Hse"/>
                                                             <constraint firstAttribute="width" constant="160" id="vtL-IH-WLh"/>
@@ -1940,14 +1989,14 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zde-zC-Hp9">
-                                                <rect key="frame" x="128" y="104" width="182" height="5"/>
+                                                <rect key="frame" x="128" y="107" width="182" height="5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="5" id="0ea-L9-Dxz"/>
                                                     <constraint firstAttribute="width" constant="182" id="HQk-e5-sgB"/>
                                                 </constraints>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3Ku-sN-43t">
-                                                <rect key="frame" x="41" y="78" width="269" height="19"/>
+                                                <rect key="frame" x="41" y="80" width="269" height="20"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nzY-kb-hBq">
                                                         <rect key="frame" x="0.0" y="2" width="89" height="16"/>
@@ -1979,7 +2028,7 @@
                                                         </customSpacing>
                                                     </stackView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="wqe-dP-72p" customClass="MASShortcutView">
-                                                        <rect key="frame" x="109" y="0.0" width="160" height="19"/>
+                                                        <rect key="frame" x="109" y="1" width="160" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="160" id="17L-ij-gdb"/>
                                                             <constraint firstAttribute="height" constant="19" id="FLi-46-L0Y"/>
@@ -1996,10 +2045,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="J6f-Ug-bUW">
-                                                <rect key="frame" x="33" y="52" width="277" height="19"/>
+                                                <rect key="frame" x="33" y="54" width="277" height="19"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YuG-PK-sHB">
-                                                        <rect key="frame" x="0.0" y="2" width="97" height="16"/>
+                                                        <rect key="frame" x="0.0" y="1" width="97" height="16"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y9e-dj-00t">
                                                                 <rect key="frame" x="-2" y="0.0" width="72" height="16"/>
@@ -2045,7 +2094,7 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5Qa-C8-rbw">
-                                                <rect key="frame" x="47" y="26" width="263" height="19"/>
+                                                <rect key="frame" x="47" y="27" width="263" height="20"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GJ7-ha-Hpw">
                                                         <rect key="frame" x="0.0" y="2" width="83" height="16"/>
@@ -2094,7 +2143,7 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VLV-Cc-em4">
-                                                <rect key="frame" x="30" y="0.0" width="280" height="19"/>
+                                                <rect key="frame" x="30" y="0.0" width="280" height="20"/>
                                                 <subviews>
                                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A0d-Qz-1hL">
                                                         <rect key="frame" x="0.0" y="2" width="100" height="16"/>
@@ -2162,8 +2211,10 @@
                                             <integer value="1000"/>
                                             <integer value="1000"/>
                                             <integer value="1000"/>
+                                            <integer value="1000"/>
                                         </visibilityPriorities>
                                         <customSpacing>
+                                            <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
@@ -2190,7 +2241,7 @@
                                     <constraint firstItem="gt6-OD-H04" firstAttribute="top" secondItem="HUP-ob-5lz" secondAttribute="top" constant="20" symbolic="YES" id="LTd-n7-ML0"/>
                                     <constraint firstAttribute="trailing" secondItem="wDN-pM-8lR" secondAttribute="trailing" constant="20" symbolic="YES" id="Le7-Sp-jyh"/>
                                     <constraint firstItem="gt6-OD-H04" firstAttribute="leading" secondItem="HUP-ob-5lz" secondAttribute="leading" multiplier="2" constant="20" symbolic="YES" id="VUL-yV-6VZ"/>
-                                    <constraint firstAttribute="height" constant="395" id="efX-jm-yWE"/>
+                                    <constraint firstAttribute="height" constant="432" id="efX-jm-yWE"/>
                                     <constraint firstAttribute="bottom" secondItem="wDN-pM-8lR" secondAttribute="bottom" constant="20" symbolic="YES" id="kbx-oK-lTl"/>
                                 </constraints>
                             </customView>
@@ -2226,6 +2277,7 @@
                         <outlet property="previousDisplayShortcutView" destination="daM-hW-c6u" id="Gdd-dY-wHF"/>
                         <outlet property="restoreShortcutView" destination="lej-Pz-wb0" id="9p0-dP-tKu"/>
                         <outlet property="rightHalfShortcutView" destination="DJc-yE-qoJ" id="OJZ-8F-b8g"/>
+                        <outlet property="specifiedShortcutView" destination="Pzn-9m-syr" id="Sm6-Ht-CuN"/>
                         <outlet property="topHalfShortcutView" destination="ppH-ve-v6N" id="JE4-GU-6w0"/>
                         <outlet property="topLeftShortcutView" destination="XIn-7Q-Fuy" id="5oj-Fa-48o"/>
                         <outlet property="topRightShortcutView" destination="OgW-L0-nuS" id="akm-zB-cnx"/>
@@ -2233,7 +2285,7 @@
                 </viewController>
                 <customObject id="BOw-l7-fkl" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-283" y="1338"/>
+            <point key="canvasLocation" x="-283" y="1380"/>
         </scene>
         <!--Tab View Controller-->
         <scene sceneID="b39-fJ-MZO">

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -33,6 +33,8 @@ class Defaults {
     static let curtainChangeSize = OptionalBoolDefault(key: "curtainChangeSize")
     static let relaunchOpensMenu = BoolDefault(key: "relaunchOpensMenu")
     static let obtainWindowOnClick = OptionalBoolDefault(key: "obtainWindowOnClick")
+    static let specifiedHeight = FloatDefault(key: "specifiedHeight", defaultValue: 1050)
+    static let specifiedWidth = FloatDefault(key: "specifiedWidth", defaultValue: 1680)
 }
 
 class BoolDefault {

--- a/Rectangle/PrefsViewController.swift
+++ b/Rectangle/PrefsViewController.swift
@@ -48,6 +48,8 @@ class PrefsViewController: NSViewController {
     @IBOutlet weak var moveDownShortcutView: MASShortcutView!
     
     @IBOutlet weak var almostMaximizeShortcutView: MASShortcutView!
+
+    @IBOutlet weak var specifiedShortcutView: MASShortcutView!
     
     // Settings
     override func awakeFromNib() {
@@ -78,7 +80,8 @@ class PrefsViewController: NSViewController {
             .moveRight: moveRightShortcutView,
             .moveUp: moveUpShortcutView,
             .moveDown: moveDownShortcutView,
-            .almostMaximize: almostMaximizeShortcutView
+            .almostMaximize: almostMaximizeShortcutView,
+            .specified: specifiedShortcutView,
         ]
         
         for (action, view) in actionsToViews {

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -41,7 +41,8 @@ enum WindowAction: Int {
     moveRight = 26,
     moveUp = 27,
     moveDown = 28,
-    almostMaximize = 29
+    almostMaximize = 29,
+    specified = 30
     
     // Order matters here - it's used in the menu
     static let active = [leftHalf, rightHalf, topHalf, bottomHalf,
@@ -49,7 +50,8 @@ enum WindowAction: Int {
                          firstThird, firstTwoThirds, centerThird, lastTwoThirds, lastThird,
                          maximize, almostMaximize, maximizeHeight, smaller, larger, center, restore,
                          nextDisplay, previousDisplay,
-                         moveLeft, moveRight, moveUp, moveDown]
+                         moveLeft, moveRight, moveUp, moveDown,
+                         specified]
     
     func post() {
         NotificationCenter.default.post(name: notificationName, object: ExecutionParameters(self))
@@ -97,6 +99,7 @@ enum WindowAction: Int {
         case .moveUp: return "moveUp"
         case .moveDown: return "moveDown"
         case .almostMaximize: return "almostMaximize"
+        case .specified: return "specified"
         }
     }
 
@@ -183,6 +186,9 @@ enum WindowAction: Int {
         case .almostMaximize:
             key = "e57-QJ-6bL.title"
             value = "Almost Maximize"
+        case .specified:
+            key = "hLL-JB-yds.title"
+            value = "Specified"
         }
         
         return NSLocalizedString(key, tableName: "Main", value: value, comment: "")
@@ -283,6 +289,7 @@ enum WindowAction: Int {
         case .moveUp: return NSImage(imageLiteralResourceName: "moveUpTemplate")
         case .moveDown: return NSImage(imageLiteralResourceName: "moveDownTemplate")
         case .almostMaximize: return NSImage(imageLiteralResourceName: "almostMaximizeTemplate")
+        case .specified: return NSImage(imageLiteralResourceName: "almostMaximizeTemplate")
         }
     }
     

--- a/Rectangle/WindowCalculation/SpecifiedCalculation.swift
+++ b/Rectangle/WindowCalculation/SpecifiedCalculation.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+final class SpecifiedCalculation: WindowCalculation {
+
+    let specifiedHeight: CGFloat
+    let specifiedWidth: CGFloat
+
+    override init() {
+        self.specifiedHeight = CGFloat(Defaults.specifiedHeight.value)
+        self.specifiedWidth = CGFloat(Defaults.specifiedWidth.value)
+    }
+
+    override func calculateRect(_ window: Window, lastAction: RectangleAction?, visibleFrameOfScreen: CGRect, action: WindowAction) -> RectResult {
+
+        var calculatedWindowRect = visibleFrameOfScreen
+
+        // Resize
+        calculatedWindowRect.size.height = round(specifiedHeight)
+        calculatedWindowRect.size.width = round(specifiedWidth)
+
+        // Center
+        calculatedWindowRect.origin.x = round((visibleFrameOfScreen.width - calculatedWindowRect.width) / 2.0) + visibleFrameOfScreen.minX
+        calculatedWindowRect.origin.y = round((visibleFrameOfScreen.height - calculatedWindowRect.height) / 2.0) + visibleFrameOfScreen.minY
+
+        return RectResult(calculatedWindowRect)
+    }
+}

--- a/Rectangle/WindowCalculation/WindowCalculation.swift
+++ b/Rectangle/WindowCalculation/WindowCalculation.swift
@@ -101,6 +101,7 @@ class WindowCalculationFactory {
     let moveUpCalculation = MoveUpCalculation()
     let moveDownCalculation = MoveDownCalculation()
     let almostMaximizeCalculation = AlmostMaximizeCalculation()
+    let specifiedCalculation = SpecifiedCalculation()
     
     func calculation(for action: WindowAction) -> WindowCalculation? {
         
@@ -130,8 +131,10 @@ class WindowCalculationFactory {
         case .moveUp: return moveUpCalculation
         case .moveDown: return moveDownCalculation
         case .almostMaximize: return almostMaximizeCalculation
-        default: return nil
+        case .specified: return specifiedCalculation
+        case .restore:
+            assertionFailure("Unsupported WindowAction: `\(action)`")
+            return nil
         }
     }
-    
 }


### PR DESCRIPTION
The main purpose of the functionality is to add a hotkey to change the window size to a specific one.

The case that occurred to me is:
I work on 3440x1440 ultra wide 21:9 I want to change the screen size of some windows to a specific one.

As a basis, I took the standard screen resolution of the MacBook Pro 15', 1680x1050

You can change this with the command in the terminal:
defaults write com.knollsoft.Rectangle specifiedHeight -float 1050
defaults write com.knollsoft.Rectangle specifiedWidth -float 1680