### PR TITLE
Fix gap on center half and positioning of vertical sixths

### DIFF
--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -372,8 +372,8 @@ enum WindowAction: Int {
     
     var gapsApplicable: Bool {
         switch self {
-        case .leftHalf, .rightHalf, .bottomHalf, .topHalf, .maximize, .bottomLeft, .bottomRight, .topLeft, .topRight, .firstThird, .firstTwoThirds, .centerThird, .lastTwoThirds, .lastThird, .firstFourth, .secondFourth, .thirdFourth, .lastFourth,
-             .topLeftSixth, .topCenterSixth, .topRightSixth, .bottomLeftSixth, .bottomCenterSixth, .bottomRightSixth:
+        case .leftHalf, .rightHalf, .bottomHalf, .topHalf, .centerHalf, .maximize, .bottomLeft, .bottomRight, .topLeft, .topRight, .firstThird, .firstTwoThirds, .centerThird, .lastTwoThirds, .lastThird,
+             .firstFourth, .secondFourth, .thirdFourth, .lastFourth, .topLeftSixth, .topCenterSixth, .topRightSixth, .bottomLeftSixth, .bottomCenterSixth, .bottomRightSixth:
             return true
         default:
             return false

--- a/Rectangle/WindowCalculation/BottomCenterSixthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomCenterSixthCalculation.swift
@@ -12,6 +12,7 @@ class BottomCenterSixthCalculation: WindowCalculation, OrientationAware {
     
     private let bottomRightTwoSixths = BottomRightTwoSixthsCalculation()
     private let bottomLeftTwoSixths = BottomLeftTwoSixthsCalculation()
+    private let topRightTwoSixths = TopRightTwoSixthsCalculation()
     
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
@@ -27,8 +28,10 @@ class BottomCenterSixthCalculation: WindowCalculation, OrientationAware {
         switch lastSubAction{
         case .bottomCenterSixthLandscape, .rightCenterSixthPortrait:
             calc = bottomRightTwoSixths.orientationBasedRect
-        case .bottomRightTwoSixthsLandscape, .bottomRightTwoSixthsPortrait:
+        case .bottomRightTwoSixthsLandscape:
             calc = bottomLeftTwoSixths.orientationBasedRect
+        case .bottomRightTwoSixthsPortrait:
+            calc = topRightTwoSixths.orientationBasedRect
         default: calc = orientationBasedRect
         }
         

--- a/Rectangle/WindowCalculation/BottomRightSixthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomRightSixthCalculation.swift
@@ -43,8 +43,8 @@ class BottomRightSixthCalculation: WindowCalculation, OrientationAware, SixthsRe
     
     func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
         rect.origin.x = visibleFrameOfScreen.origin.x + (rect.width * 2)
         return RectResult(rect, subAction: .bottomRightSixthPortrait)
     }

--- a/Rectangle/WindowCalculation/TopCenterSixthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopCenterSixthCalculation.swift
@@ -12,6 +12,7 @@ class TopCenterSixthCalculation: WindowCalculation, OrientationAware {
     
     private let topRightTwoSixths = TopRightTwoSixthsCalculation()
     private let topLeftTwoSixths = TopLeftTwoSixthsCalculation()
+    private let bottomLeftTwoSixths = BottomLeftTwoSixthsCalculation()
     
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
         
@@ -26,9 +27,11 @@ class TopCenterSixthCalculation: WindowCalculation, OrientationAware {
         
         let calc: SimpleCalc
         switch lastSubAction{
-        case .topCenterSixthLandscape, .leftCenterSixthPortrait:
+        case .topCenterSixthLandscape:
             calc = topRightTwoSixths.orientationBasedRect
-        case .topRightTwoSixthsLandscape, .topRightTwoSixthsPortrait:
+        case .leftCenterSixthPortrait:
+            calc = bottomLeftTwoSixths.orientationBasedRect
+        case .topRightTwoSixthsLandscape, .bottomLeftTwoSixthsPortrait:
             calc = topLeftTwoSixths.orientationBasedRect
         default: calc = orientationBasedRect
         }
@@ -69,6 +72,8 @@ class TopRightTwoSixthsCalculation: WindowCalculation, OrientationAware {
         var rect = visibleFrameOfScreen
         rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         rect.size.height = floor(visibleFrameOfScreen.height * 2.0 / 3.0)
+        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
+        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
         return RectResult(rect, subAction: .topRightTwoSixthsPortrait)
     }
 }
@@ -87,7 +92,7 @@ class TopLeftTwoSixthsCalculation: WindowCalculation, OrientationAware {
         var rect = visibleFrameOfScreen
         rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         rect.size.height = floor(visibleFrameOfScreen.height * 2.0 / 3.0)
-        rect.origin.y = visibleFrameOfScreen.minY + rect.height
+        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
         return RectResult(rect, subAction: .topLeftTwoSixthsPortrait)
     }
 }


### PR DESCRIPTION
A couple of bug fixes:

- Add a gap around centerHalf, for consistency with all other fractional positions.
- Correct orientation of Bottom Right Sixth on vertical displays.
- Update the repetition sequence on center sixths in portrait: previously the window would jump between the two sides of the screen, whereas now it will stay on the same side as it cycles through the center-sixth and the two two-sixths positions.

Before and after (center sixths commands):

![before](https://i.imgur.com/P4jQOJO.gif) ![after](https://i.imgur.com/Oo6qec3.gif)