### PR TITLE
Fix incorrect window resizing by disabling AXEnhancedUserInterface

### DIFF
--- a/Rectangle/AccessibilityElement.swift
+++ b/Rectangle/AccessibilityElement.swift
@@ -10,6 +10,13 @@ import Foundation
 import Carbon
 import Cocoa
 
+// The AXEnhancedUserInterface attribute is undocumented. However, it does appear in the
+// Accessibility Inspector [1] under the name "Enhanced User Interface" and in the list of
+// attribute names returned by AXUIElementCopyAttributeNames for an AXUIElement with a
+// role of kAXApplicationRole.
+// [1]: https://developer.apple.com/library/archive/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTestingApps.html
+let kAXEnhancedUserInterface: String = "AXEnhancedUserInterface"
+
 class AccessibilityElement {
     static let systemWideElement = AccessibilityElement(AXUIElementCreateSystemWide())
 
@@ -71,9 +78,34 @@ class AccessibilityElement {
     }
     
     func setRectOf(_ rect: CGRect) {
-            set(size: rect.size)
-            set(position: rect.origin)
-            set(size: rect.size)
+        // "Enhanced User Interface" is an undocumented attribute that has been
+        // reported by others to cause issue with window resizing (e.g.
+        // https://github.com/electron/electron/issues/7206). If this setting is
+        // enabled for the application of the window being resized, disable this
+        // attribute before performing the resizes. See:
+        // * https://github.com/rxhanson/Rectangle/issues/15
+        // * https://github.com/rxhanson/Rectangle/issues/29
+        // * https://github.com/rxhanson/Rectangle/issues/94
+        // * https://github.com/rxhanson/Rectangle/issues/165
+        let app = application()
+        var enhancedUserInterfaceEnabled: Bool? = nil
+
+        if let app = app {
+            enhancedUserInterfaceEnabled = app.isEnhancedUserInterfaceEnabled()
+            if enhancedUserInterfaceEnabled == true {
+                Logger.log("AXEnhancedUserInterface was enabled, will disable before resizing")
+                AXUIElementSetAttributeValue(app.underlyingElement, kAXEnhancedUserInterface as CFString, kCFBooleanFalse)
+            }
+        }
+
+        set(size: rect.size)
+        set(position: rect.origin)
+        set(size: rect.size)
+
+        // If "enhanced user interface" was originally enabled for the app, turn it back on
+        if let app = app, enhancedUserInterfaceEnabled == true {
+            AXUIElementSetAttributeValue(app.underlyingElement, kAXEnhancedUserInterface as CFString, kCFBooleanTrue)
+        }
     }
     
     func isResizable() -> Bool {
@@ -101,6 +133,17 @@ class AccessibilityElement {
         return value(for: .subrole) == kAXSystemDialogSubrole
     }
     
+    func isEnhancedUserInterfaceEnabled() -> Bool? {
+        var rawValue: AnyObject?
+        let error = AXUIElementCopyAttributeValue(self.underlyingElement, kAXEnhancedUserInterface as CFString, &rawValue)
+
+        if error == .success && CFGetTypeID(rawValue) == CFBooleanGetTypeID() {
+            return CFBooleanGetValue((rawValue as! CFBoolean))
+        }
+
+        return nil
+    }
+
     func getIdentifier() -> Int? {
         if let windowInfo = CGWindowListCopyWindowInfo(.optionOnScreenOnly, 0) as? Array<Dictionary<String,Any>> {
             let pid = getPid()
@@ -198,6 +241,19 @@ class AccessibilityElement {
         return element
     }
     
+    private func application() -> Self? {
+        var element = self
+        while element.role() != kAXApplicationRole {
+            if let nextElement = element.parent() {
+                element = nextElement
+            } else {
+                return nil
+            }
+        }
+
+        return element
+    }
+
     private func parent() -> Self? {
         return self.value(for: .parent)
     }


### PR DESCRIPTION
This PR should fix the issue noted in the README regarding [windows not resizing to the proper dimensions](https://github.com/rxhanson/Rectangle/blob/cd87fbfb98c06f7a75661a04f1223bac95972cd4/README.md#window-movingresizing-appears-animatedsmooth-instead-of-quick-and-windows-dont-end-up-where-you-expect).

### To reproduce the original issue:

1. Open ["Accessibility Inspector"](https://developer.apple.com/library/archive/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTestingApps.html)
1. Inspect the window of an app know to have this issue (e.g. Google Chrome, Sublime Text, Outlook)
1. Select the application via the "Hierarchy" section
1. Note the value of "Enhanced User Interface", changing it to true if needed
    ![enhanced-ui-attr](https://user-images.githubusercontent.com/8900251/101290062-1466bc80-37ce-11eb-820a-3d57914d8d49.png)
1. Trigger a resize of the window using Rectangle

Using the above process, Rectangle v0.39 will not resize the window properly when "Enhanced User Interface" is enabled. With changes in this PR, Rectangle will resize the window correctly, regardless of the original value of "Enhanced User Interface".

### Tested on:

* macOS 10.15.7

Refs: #15, #29, #94, #165