### PR TITLE
Update installation to reflect `brew cask` deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can download the latest dmg from https://rectangleapp.com or the [Releases p
 Or install with brew cask:
 
 ```bash
-brew cask install rectangle
+brew install --cask rectangle
 ```
 ## How to use it
 The keyboard shortcuts are self explanatory, but the snap areas can use some explanation if you've never used them on Windows or other window management apps.


### PR DESCRIPTION
Installing via `brew cask ...` produces the following warning:

```
Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.
```

More info [here](https://brew.sh/2020/09/08/homebrew-2.5.0/). Not familiar enough with the `brew` ecosystem to know if versioning is a concern here, but this replacement works on `brew --version == 2.6.1`.