### PR TITLE
Factor out logic of cycling 1/2 - 2/3 - 1/3

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		12D896200936C0DE9FF41FB4 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		6327EAA4FEECF2AE087FCD30 /* Pods_RectangleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81D6E6EACB077B1A204F3A62 /* Pods_RectangleTests.framework */; };
+		866661F2257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */; };
 		981F27D12340E3E1006CD263 /* InternetAccessPolicy.plist in Resources */ = {isa = PBXBuildFile; fileRef = 981F27D02340E3E1006CD263 /* InternetAccessPolicy.plist */; };
 		9821402122B3884600ABFB3F /* BottomHalfCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9821402022B3884600ABFB3F /* BottomHalfCalculation.swift */; };
 		9821402322B3886100ABFB3F /* CenterCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9821402222B3886100ABFB3F /* CenterCalculation.swift */; };
@@ -120,6 +121,7 @@
 		53A6B6ACF05CD88EB34E0D00 /* Pods-Rectangle.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rectangle.debug.xcconfig"; path = "Target Support Files/Pods-Rectangle/Pods-Rectangle.debug.xcconfig"; sourceTree = "<group>"; };
 		80B094EEF6AE857D468B639A /* Pods-RectangleLauncher.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RectangleLauncher.debug.xcconfig"; path = "Target Support Files/Pods-RectangleLauncher/Pods-RectangleLauncher.debug.xcconfig"; sourceTree = "<group>"; };
 		81D6E6EACB077B1A204F3A62 /* Pods_RectangleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RectangleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatedExecutionsInThirdsCalculation.swift; sourceTree = "<group>"; };
 		9808018523D05C0B0077774A /* RectangleRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RectangleRelease.entitlements; sourceTree = "<group>"; };
 		9808018623D05C1F0077774A /* RectangleLauncherRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RectangleLauncherRelease.entitlements; sourceTree = "<group>"; };
 		981F27D02340E3E1006CD263 /* InternetAccessPolicy.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = InternetAccessPolicy.plist; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 				98C6DEEF23CE191700CC0C1E /* GapCalculation.swift */,
 				9851A5C2251BEBA300ECF78C /* OrientationAware.swift */,
 				98A6EDDC251F3F4A00F74B10 /* SixthsRepeated.swift */,
+				866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */,
 			);
 			path = WindowCalculation;
 			sourceTree = "<group>";
@@ -792,6 +795,7 @@
 				9824703F22B13FBC0037B409 /* ScreenDetection.swift in Sources */,
 				9821402B22B388A000ABFB3F /* LowerRightCalculation.swift in Sources */,
 				9821402522B3887200ABFB3F /* MaximizeCalculation.swift in Sources */,
+				866661F2257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift in Sources */,
 				9824704D22B189250037B409 /* WindowCalculation.swift in Sources */,
 				98C1008E230B9EF6006E5344 /* NextPrevDisplayCalculation.swift in Sources */,
 				9824703122AFA8470037B409 /* RectangleStatusItem.swift in Sources */,

--- a/Rectangle/WindowCalculation/BottomHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomHalfCalculation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class BottomHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation {
+class BottomHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation {
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -19,29 +19,12 @@ class BottomHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         return calculateRepeatedRect(params)
     }
     
-    
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
-        var oneHalfRect = visibleFrameOfScreen
-        oneHalfRect.size.height = floor(oneHalfRect.height / 2.0)
-        
-        return RectResult(oneHalfRect)
+        var rect = visibleFrameOfScreen
+        rect.size.height = floor(visibleFrameOfScreen.height * CGFloat(fraction))
+        return RectResult(rect)
     }
     
-    func calculateSecondRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var twoThirdsRect = visibleFrameOfScreen
-        twoThirdsRect.size.height = floor(visibleFrameOfScreen.height * 2 / 3.0)
-        return RectResult(twoThirdsRect)
-    }
-    
-    func calculateThirdRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var oneThirdRect = visibleFrameOfScreen
-        oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 3.0)
-        return RectResult(oneThirdRect)
-    }
 }

--- a/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation {
+class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation {
     
     override func calculate(_ params: WindowCalculationParameters) -> WindowCalculationResult? {
         
@@ -34,38 +34,18 @@ class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation
         }
         
     }
-
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+    
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
-        var oneHalfRect = visibleFrameOfScreen
-        oneHalfRect.size.width = floor(oneHalfRect.width / 2.0)
+        var rect = visibleFrameOfScreen
+        
+        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
         if params.action == .rightHalf {
-            oneHalfRect.origin.x += oneHalfRect.size.width
+            rect.origin.x = visibleFrameOfScreen.maxX - rect.width
         }
-        return RectResult(oneHalfRect)
-    }
-
-    func calculateSecondRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var twoThirdsRect = visibleFrameOfScreen
-        twoThirdsRect.size.width = floor(visibleFrameOfScreen.width * 2 / 3.0)
-        if params.action == .rightHalf {
-            twoThirdsRect.origin.x = visibleFrameOfScreen.minX + visibleFrameOfScreen.width - twoThirdsRect.width
-        }
-        return RectResult(twoThirdsRect)
-    }
-
-    func calculateThirdRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var oneThirdRect = visibleFrameOfScreen
-        oneThirdRect.size.width = floor(visibleFrameOfScreen.width / 3.0)
-        if params.action == .rightHalf {
-            oneThirdRect.origin.x = visibleFrameOfScreen.origin.x + visibleFrameOfScreen.width - oneThirdRect.width
-        }
-        return RectResult(oneThirdRect)
+        
+        return RectResult(rect)
     }
 
     func calculateLeftAcrossDisplays(_ params: WindowCalculationParameters, screen: NSScreen) -> WindowCalculationResult? {

--- a/Rectangle/WindowCalculation/LowerLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerLeftCalculation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsCalculation {
+class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation {
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -19,30 +19,15 @@ class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         return calculateRepeatedRect(params)
     }
     
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
-        var oneQuarterRect = visibleFrameOfScreen
-        oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(oneQuarterRect)
-    }
-    
-    func calculateSecondRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var twoThirdsRect = visibleFrameOfScreen
-        twoThirdsRect.size.width = floor(visibleFrameOfScreen.width * 2 / 3.0)
-        twoThirdsRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(twoThirdsRect)
-    }
-    
-    func calculateThirdRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var oneThirdRect = visibleFrameOfScreen
-        oneThirdRect.size.width = floor(visibleFrameOfScreen.width / 3.0)
-        oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(oneThirdRect)
+        var rect = visibleFrameOfScreen
+        
+        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
+        
+        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        
+        return RectResult(rect)
     }
 }

--- a/Rectangle/WindowCalculation/LowerRightCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerRightCalculation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class LowerRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
+class LowerRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation {
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -19,33 +19,15 @@ class LowerRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         return calculateRepeatedRect(params)
     }
     
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
-        var oneQuarterRect = visibleFrameOfScreen
-        oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        oneQuarterRect.origin.x += oneQuarterRect.width
-        return RectResult(oneQuarterRect)
-    }
-    
-    func calculateSecondRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var twoThirdsRect = visibleFrameOfScreen
-        twoThirdsRect.size.width = floor(visibleFrameOfScreen.width * 2 / 3.0)
-        twoThirdsRect.origin.x = visibleFrameOfScreen.minX + visibleFrameOfScreen.width - twoThirdsRect.width
-        twoThirdsRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(twoThirdsRect)
-    }
-    
-    func calculateThirdRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var oneThirdRect = visibleFrameOfScreen
-        oneThirdRect.size.width = floor(visibleFrameOfScreen.width / 3.0)
-        oneThirdRect.origin.x = visibleFrameOfScreen.minX + visibleFrameOfScreen.width - oneThirdRect.width
-        oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(oneThirdRect)
+        var rect = visibleFrameOfScreen
+        
+        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
+        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
+        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        
+        return RectResult(rect)
     }
 }

--- a/Rectangle/WindowCalculation/MoveLeftRightCalculation.swift
+++ b/Rectangle/WindowCalculation/MoveLeftRightCalculation.swift
@@ -13,7 +13,7 @@ import Cocoa
 // Defaults.centeredDirectionalMove.enabled
 // Defaults.resizeOnDirectionalMove.enabled (resizes in thirds, or just to half-width if traversesDisplays is enabled
 
-class MoveLeftRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
+class MoveLeftRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation {
     
     override func calculate(_ params: WindowCalculationParameters) -> WindowCalculationResult? {
         
@@ -75,16 +75,8 @@ class MoveLeftRightCalculation: WindowCalculation, RepeatedExecutionsCalculation
 
     }
     
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return calculateGenericRect(params, fraction: 1 / 2.0)
-    }
-    
-    func calculateSecondRect(_ params: RectCalculationParameters) -> RectResult {
-        return calculateGenericRect(params, fraction: 2 / 3.0)
-    }
-    
-    func calculateThirdRect(_ params: RectCalculationParameters) -> RectResult {
-        return calculateGenericRect(params, fraction: 1 / 3.0)
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
+        return calculateGenericRect(params, fraction: fraction)
     }
     
     func calculateGenericRect(_ params: RectCalculationParameters, fraction: Float? = nil) -> RectResult {

--- a/Rectangle/WindowCalculation/MoveUpDownCalculation.swift
+++ b/Rectangle/WindowCalculation/MoveUpDownCalculation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class MoveUpDownCalculation: WindowCalculation, RepeatedExecutionsCalculation {
+class MoveUpDownCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation {
     
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
         
@@ -35,16 +35,8 @@ class MoveUpDownCalculation: WindowCalculation, RepeatedExecutionsCalculation {
 
     }
     
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return calculateGenericRect(params, fraction: 1 / 2.0)
-    }
-    
-    func calculateSecondRect(_ params: RectCalculationParameters) -> RectResult {
-        return calculateGenericRect(params, fraction: 2 / 3.0)
-    }
-    
-    func calculateThirdRect(_ params: RectCalculationParameters) -> RectResult {
-        return calculateGenericRect(params, fraction: 1 / 3.0)
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
+        return calculateGenericRect(params, fraction: fraction)
     }
     
     func calculateGenericRect(_ params: RectCalculationParameters, fraction: Float? = nil) -> RectResult {
@@ -65,4 +57,3 @@ class MoveUpDownCalculation: WindowCalculation, RepeatedExecutionsCalculation {
     }
     
 }
-

--- a/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
@@ -1,5 +1,5 @@
 //
-//  SubsequentThirdsCalculation.swift
+//  RepeatedExecutionsCalculation.swift
 //  Rectangle
 //
 //  Created by Ryan Hanson on 10/18/19.

--- a/Rectangle/WindowCalculation/RepeatedExecutionsInThirdsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsInThirdsCalculation.swift
@@ -1,0 +1,31 @@
+//
+//  RepeatedExecutionsInThirdsCalculation.swift
+//  Rectangle
+//
+//  Created by Charlie Harding on 12/06/20.
+//  Copyright © 2020 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+protocol RepeatedExecutionsInThirdsCalculation: RepeatedExecutionsCalculation {
+    
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult
+
+}
+
+extension RepeatedExecutionsInThirdsCalculation {
+    
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        return calculateFractionalRect(params, fraction: 1 / 2.0)
+    }
+    
+    func calculateSecondRect(_ params: RectCalculationParameters) -> RectResult {
+        return calculateFractionalRect(params, fraction: 2 / 3.0)
+    }
+    
+    func calculateThirdRect(_ params: RectCalculationParameters) -> RectResult {
+        return calculateFractionalRect(params, fraction: 1 / 3.0)
+    }
+    
+}

--- a/Rectangle/WindowCalculation/TopHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/TopHalfCalculation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class TopHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation {
+class TopHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation {
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -19,31 +19,13 @@ class TopHalfCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         return calculateRepeatedRect(params)
     }
     
-    
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
-        var oneHalfRect = visibleFrameOfScreen
-        oneHalfRect.size.height = floor(oneHalfRect.height / 2.0)
-        oneHalfRect.origin.y += oneHalfRect.height + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-        return RectResult(oneHalfRect)
+        var rect = visibleFrameOfScreen
+        rect.size.height = floor(visibleFrameOfScreen.height * CGFloat(fraction))
+        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
+        return RectResult(rect)
     }
     
-    func calculateSecondRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var twoThirdsRect = visibleFrameOfScreen
-        twoThirdsRect.size.height = floor(visibleFrameOfScreen.height * 2 / 3.0)
-        twoThirdsRect.origin.y = visibleFrameOfScreen.origin.y + visibleFrameOfScreen.height - twoThirdsRect.height
-        return RectResult(twoThirdsRect)
-    }
-    
-    func calculateThirdRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var oneThirdRect = visibleFrameOfScreen
-        oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 3.0)
-        oneThirdRect.origin.y = visibleFrameOfScreen.origin.y + visibleFrameOfScreen.height - oneThirdRect.height
-        return RectResult(oneThirdRect)
-    }
 }

--- a/Rectangle/WindowCalculation/UpperLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperLeftCalculation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsCalculation {
+class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation {
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -19,35 +19,15 @@ class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         return calculateRepeatedRect(params)
     }
     
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+
+        var rect = visibleFrameOfScreen
         
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-        var oneQuarterRect = visibleFrameOfScreen
-        oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        oneQuarterRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-        return RectResult(oneQuarterRect)
-    }
-    
-    func calculateSecondRect(_ params: RectCalculationParameters) -> RectResult {
-
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-        var twoThirdsRect = visibleFrameOfScreen
-        twoThirdsRect.size.width = floor(visibleFrameOfScreen.width * 2 / 3.0)
-        twoThirdsRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        twoThirdsRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-
-        return RectResult(twoThirdsRect)
-    }
-    
-    func calculateThirdRect(_ params: RectCalculationParameters) -> RectResult {
+        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
         
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-        var oneThirdRect = visibleFrameOfScreen
-        oneThirdRect.size.width = floor(visibleFrameOfScreen.width / 3.0)
-        oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        oneThirdRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-
-        return RectResult(oneThirdRect)
+        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
+        return RectResult(rect)
     }
 }

--- a/Rectangle/WindowCalculation/UpperRightCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperRightCalculation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class UpperRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
+class UpperRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation {
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -19,36 +19,15 @@ class UpperRightCalculation: WindowCalculation, RepeatedExecutionsCalculation {
         return calculateRepeatedRect(params)
     }
     
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
-        var oneQuarterRect = visibleFrameOfScreen
-        oneQuarterRect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        oneQuarterRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        oneQuarterRect.origin.x += oneQuarterRect.width
-        oneQuarterRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-        return RectResult(oneQuarterRect)
-    }
-    
-    func calculateSecondRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var twoThirdsRect = visibleFrameOfScreen
-        twoThirdsRect.size.width = floor(visibleFrameOfScreen.width * 2 / 3.0)
-        twoThirdsRect.origin.x = visibleFrameOfScreen.minX + visibleFrameOfScreen.width - twoThirdsRect.width
-        twoThirdsRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        twoThirdsRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-        return RectResult(twoThirdsRect)
-    }
-    
-    func calculateThirdRect(_ params: RectCalculationParameters) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var oneThirdRect = visibleFrameOfScreen
-        oneThirdRect.size.width = floor(visibleFrameOfScreen.width / 3.0)
-        oneThirdRect.origin.x = visibleFrameOfScreen.minX + visibleFrameOfScreen.width - oneThirdRect.width
-        oneThirdRect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        oneThirdRect.origin.y = visibleFrameOfScreen.minY + floor(visibleFrameOfScreen.height / 2.0) + (visibleFrameOfScreen.height.truncatingRemainder(dividingBy: 2.0))
-        return RectResult(oneThirdRect)
+        var rect = visibleFrameOfScreen
+        
+        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
+        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
+        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
+        return RectResult(rect)
     }
 }


### PR DESCRIPTION
I refactored this as part of #283, but figured it was probably too off-topic for the same PR, so I held off submitting it until that was merged. This extracts the logic for handling the 1/2 - 2/3 - 1/3 to a sub-protocol of `RepeatedExecutionsCalculation`, called `RepeatedExecutionsInThirdsCalculation`.

I’ve now realised that `RepeatedExecutionsCalculation` doesn’t have any members that aren’t `RepeatedExecutionsInThirdsCalculation`, but I imagine that may change in future so I’ve left it in. It may be worth replacing `RepeatedExecutionCalculation`’s named methods with an array of function at some point, if the number of steps in the cycle needs to vary.