### PR TITLE
Change label for hidden shortcuts

### DIFF
--- a/Rectangle/Base.lproj/Main.storyboard
+++ b/Rectangle/Base.lproj/Main.storyboard
@@ -1775,7 +1775,7 @@
                                         <subviews>
                                             <button focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WPl-J4-Y8A">
                                                 <rect key="frame" x="0.0" y="8" width="32" height="16"/>
-                                                <buttonCell key="cell" type="bevel" title="▶︎ ⋯" bezelStyle="rounded" imagePosition="right" alignment="center" focusRingType="none" imageScaling="proportionallyDown" inset="2" id="MKW-qf-Q2C">
+                                                <buttonCell key="cell" type="bevel" title="▶︎ More..." bezelStyle="rounded" imagePosition="right" alignment="center" focusRingType="none" imageScaling="proportionallyDown" inset="2" id="MKW-qf-Q2C">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>


### PR DESCRIPTION
The "..." label doesn't well describe what is hidden by the control. I changed it to `More...`. Note that this is untested because I can't get it to build, but it looks okay in the storyboard.

<img width="355" alt="image" src="https://user-images.githubusercontent.com/67526318/107682311-05c8d580-6c55-11eb-8980-8e6ea13b48b1.png">
