### PR TITLE
Fix Taiwan Traditional Chinese File

### DIFF
--- a/Rectangle/zh-Hant-TW.lproj/Main.strings
+++ b/Rectangle/zh-Hant-TW.lproj/Main.strings
@@ -120,7 +120,7 @@
 "C9v-g0-DH8.title" = "還原";
 
 /* Class = "NSMenuItem"; title = "Ignore frontmost.app"; ObjectID = "D99-0O-MB6"; */
-"D99-0O-MB6.title" = "忽略 frontmost.app";
+"D99-0O-MB6.title" = "忽略「frontmost.app」";
 
 /* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */
 "DVo-aG-piG.title" = "關閉";


### PR DESCRIPTION
### Fix Taiwan Traditional Chinese File
### 修正臺灣正體中文檔案

- Fix the item "Ignore frontmost.app" translation from “忽略 frontmost.app” to “忽略「frontmost.app」”.
修正項目"Ignore frontmost.app" 之翻譯，自「忽略 frontmost.app」修正為「忽略「frontmost.app」」。