### PR TITLE
Repeated commands move window to same position on next screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,27 +54,64 @@ If you wish to change the default shortcuts after first launch, use the followin
 defaults write com.knollsoft.Rectangle alternateDefaultShortcuts -bool true
 ```
 
-### Halves to thirds (repeated execution of half and quarter actions)
-Halves to thirds is controlled by the `Move to adjacent display on repeated left or right commands` setting in the preferences. 
-If this setting is not checked, then each time you execute a half or quarter action, the width of the window will cycle through the following sizes: 1/2 -> 2/3 -> 1/3.
+### Repeated Command Behavior
 
-The cycling behavior can be disabled entirely with:
+Rectangle implements a number of behaviors for handling repeated commands, only some of which are exposed in the preferences.
+
+The cycling behavior can be set with
+
+```bash
+defaults write com.knollsoft.Rectangle subsequentExecutionMode -int <VALUE>
+```
+
+Where `<VALUE>` is one of the following:
+
+#### `0`: Halves to thirds (Spectacle behavior)
+
+Each time you execute a half or quarter action, the width of the window will cycle through the following sizes: 1/2 → 2/3 → 1/3.
+This settings is enabled implicitly when the "Move to adjacent display on repeated left or right commands" setting in the preferences is unchecked. This follows the default behavior in Spectacle.
+
+#### `1`: Cycle displays for left / right actions
+
+This settings is enabled when the "Move to adjacent display on repeated left or right commands" setting in the preferences is checked.
+
+#### `2`: Cycling disabled
+
+Disables cycling behavior entirely.
+
+Accessible only through the following terminal command:
 
 ```bash
 defaults write com.knollsoft.Rectangle subsequentExecutionMode -int 2
 ```
 
-`subsequentExecutionMode` accepts the following values:
-0: halves to thirds Spectacle behavior (box unchecked)
-1: cycle displays (box checked)
-2: disabled
-3: cycle displays for left/right actions, halves to thirds for the rest (old Rectangle behavior)
+#### `3`: Cycle displays for left / right actions, and halves to thirds for the rest
+
+Combines the behaviors of settings `0` and `1`, but moves across windows instead of cycling halves / thirds when windows are moved left or right.
+
+Accessible only through the following terminal command:
+
+```bash
+defaults write com.knollsoft.Rectangle subsequentExecutionMode -int 3
+```
+
+#### `4`: Cycle displays (repeated execution of normally idempotent actions)
+
+A hidden preference is available to cycle windows across displays in a spatially consistent way, similar to the "cycle between screens when using shortcuts" a behavior available in the Divvy window manager.
+
+For example, setting a window to "right half" will execute that action first on the window's parent screen. A second execution will move that window to the "right half" of the next display. If a window already satisfies the conditions called for by a shortcut, then it will cycle immediately to the next display.
+
+Accessible only through the following terminal command:
+
+```bash
+defaults write com.knollsoft.Rectangle subsequentExecutionMode -int 4
+```
 
 ### Resize on Directional Move
 By default, the commands to move to certain edges will not resize the window.
 If `resizeOnDirectionalMove` is enabled, the _halves to thirds_ mode is instead used.
 This means that when moving to the left/right, the width will be changed, and when moving to the top/bottom, the height will be changed.
-This size will cycle between 1/2 -> 2/3 -> 1/3 of the screen’s width/height.
+This size will cycle between 1/2 → 2/3 → 1/3 of the screen’s width/height.
 
 Note that if subsequent execution mode is set to cycle displays when this is enabled, Move Left and Move Right will always resize to 1/2, and pressing it again will move to the next display.
 

--- a/Rectangle/SubsequentExecutionMode.swift
+++ b/Rectangle/SubsequentExecutionMode.swift
@@ -13,6 +13,7 @@ enum SubsequentExecutionMode: Int {
     case acrossMonitor = 1
     case none = 2
     case acrossAndResize = 3 // across monitor for right/left, spectacle resize for all else
+    case cycleMonitor = 4 // moves window to same (normalized) position on next monitor
 }
 
 class SubsequentExecutionDefault: Default {

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -265,6 +265,39 @@ enum WindowAction: Int {
         default: return true
         }
     }
+    
+    var isDisplayCyclable: Bool {
+        switch self {
+        case .leftHalf,
+             .rightHalf,
+             .maximize,
+             .bottomHalf,
+             .topHalf,
+             .center,
+             .bottomLeft,
+             .bottomRight,
+             .topLeft,
+             .topRight,
+             .firstThird,
+             .firstTwoThirds,
+             .centerThird,
+             .lastTwoThirds,
+             .lastThird,
+             .almostMaximize,
+             .centerHalf,
+             .firstFourth,
+             .secondFourth,
+             .thirdFourth,
+             .lastFourth,
+             .topLeftSixth,
+             .topCenterSixth,
+             .topRightSixth,
+             .bottomLeftSixth,
+             .bottomCenterSixth,
+             .bottomRightSixth: return true
+        default: return false
+        }
+    }
 
     var spectacleDefault: Shortcut? {
         switch self {

--- a/Rectangle/WindowCalculation/BottomCenterSixthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomCenterSixthCalculation.swift
@@ -17,6 +17,7 @@ class BottomCenterSixthCalculation: WindowCalculation, OrientationAware {
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
               let last = params.lastAction,
               let lastSubAction = last.subAction,
               params.action == .bottomCenterSixth

--- a/Rectangle/WindowCalculation/BottomLeftSixthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomLeftSixthCalculation.swift
@@ -14,6 +14,7 @@ class BottomLeftSixthCalculation: WindowCalculation, OrientationAware, SixthsRep
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
               let last = params.lastAction,
               let lastSubAction = last.subAction
         else {

--- a/Rectangle/WindowCalculation/BottomRightSixthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomRightSixthCalculation.swift
@@ -14,6 +14,7 @@ class BottomRightSixthCalculation: WindowCalculation, OrientationAware, SixthsRe
         
         let visibleFrameOfScreen = params.visibleFrameOfScreen
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
               let last = params.lastAction,
               let lastSubAction = last.subAction
         else {

--- a/Rectangle/WindowCalculation/FirstFourthCalculation.swift
+++ b/Rectangle/WindowCalculation/FirstFourthCalculation.swift
@@ -14,6 +14,7 @@ class FirstFourthCalculation: WindowCalculation, OrientationAware {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
         
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
               params.action == .firstFourth,
               let last = params.lastAction,
               let lastSubAction = last.subAction

--- a/Rectangle/WindowCalculation/FirstThirdCalculation.swift
+++ b/Rectangle/WindowCalculation/FirstThirdCalculation.swift
@@ -13,6 +13,7 @@ class FirstThirdCalculation: WindowCalculation, OrientationAware {
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
             let last = params.lastAction, let lastSubAction = last.subAction else {
             return orientationBasedRect(visibleFrameOfScreen)
         }

--- a/Rectangle/WindowCalculation/FirstTwoThirdsCalculation.swift
+++ b/Rectangle/WindowCalculation/FirstTwoThirdsCalculation.swift
@@ -15,6 +15,7 @@ class FirstTwoThirdsCalculation: WindowCalculation, OrientationAware {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
             let last = params.lastAction, let lastSubAction = last.subAction else {
             return orientationBasedRect(visibleFrameOfScreen)
         }

--- a/Rectangle/WindowCalculation/LastFourthCalculation.swift
+++ b/Rectangle/WindowCalculation/LastFourthCalculation.swift
@@ -13,6 +13,7 @@ class LastFourthCalculation: WindowCalculation, OrientationAware {
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
             let last = params.lastAction, let lastSubAction = last.subAction else {
                 return orientationBasedRect(visibleFrameOfScreen)
         }

--- a/Rectangle/WindowCalculation/LastThirdCalculation.swift
+++ b/Rectangle/WindowCalculation/LastThirdCalculation.swift
@@ -14,6 +14,7 @@ class LastThirdCalculation: WindowCalculation, OrientationAware {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
             let last = params.lastAction, let lastSubAction = last.subAction else {
             return orientationBasedRect(visibleFrameOfScreen)
         }

--- a/Rectangle/WindowCalculation/LastTwoThirdsCalculation.swift
+++ b/Rectangle/WindowCalculation/LastTwoThirdsCalculation.swift
@@ -14,6 +14,7 @@ class LastTwoThirdsCalculation: WindowCalculation, OrientationAware {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
             let last = params.lastAction, let lastSubAction = last.subAction else {
             return orientationBasedRect(visibleFrameOfScreen)
         }

--- a/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
@@ -27,7 +27,7 @@ class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCal
             let screen = usableScreens.currentScreen
             let rectResult: RectResult = calculateRepeatedRect(params.asRectParams())
             return WindowCalculationResult(rect: rectResult.rect, screen: screen, resultingAction: params.action)
-        case .none:
+        case .none, .cycleMonitor:
             let screen = usableScreens.currentScreen
             let oneHalfRect = calculateFirstRect(params.asRectParams())
             return WindowCalculationResult(rect: oneHalfRect.rect, screen: screen, resultingAction: params.action)

--- a/Rectangle/WindowCalculation/SecondFourthCalculation.swift
+++ b/Rectangle/WindowCalculation/SecondFourthCalculation.swift
@@ -17,6 +17,7 @@ class SecondFourthCalculation: WindowCalculation, OrientationAware {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
         
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
             let last = params.lastAction,
             let lastSubAction = last.subAction,
             last.action == .secondFourth

--- a/Rectangle/WindowCalculation/ThirdFourthCalculation.swift
+++ b/Rectangle/WindowCalculation/ThirdFourthCalculation.swift
@@ -16,6 +16,7 @@ class ThirdFourthCalculation: WindowCalculation, OrientationAware {
 
         let visibleFrameOfScreen = params.visibleFrameOfScreen
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
             let last = params.lastAction,
             let lastSubAction = last.subAction,
             last.action == .thirdFourth

--- a/Rectangle/WindowCalculation/TopCenterSixthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopCenterSixthCalculation.swift
@@ -18,6 +18,7 @@ class TopCenterSixthCalculation: WindowCalculation, OrientationAware {
         
         let visibleFrameOfScreen = params.visibleFrameOfScreen
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
               let last = params.lastAction,
               let lastSubAction = last.subAction,
               params.action == .topCenterSixth

--- a/Rectangle/WindowCalculation/TopLeftSixthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopLeftSixthCalculation.swift
@@ -14,6 +14,7 @@ class TopLeftSixthCalculation: WindowCalculation, OrientationAware, SixthsRepeat
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
               let last = params.lastAction,
               let lastSubAction = last.subAction
         else {

--- a/Rectangle/WindowCalculation/TopRightSixthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopRightSixthCalculation.swift
@@ -13,6 +13,7 @@ class TopRightSixthCalculation: WindowCalculation, OrientationAware, SixthsRepea
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
         guard Defaults.subsequentExecutionMode.value != .none,
+              Defaults.subsequentExecutionMode.value != .cycleMonitor, // Just check for .resizes instead?
               let last = params.lastAction,
               let lastSubAction = last.subAction
         else {


### PR DESCRIPTION
Following up on discussion https://github.com/rxhanson/Rectangle/discussions/374

This is a little kludgy... there's a recursive call to `execute`, and a white lie gets passed to `recordAction`. Definitely open to improvements.