### PR TITLE
Re-add documentation on adding window gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,14 @@ defaults write com.knollsoft.Rectangle screenEdgeGapLeft -int 10
 defaults write com.knollsoft.Rectangle screenEdgeGapRight -int 10
 ```
 
+### Setting gaps between windows
+
+You can specify gaps between windows that will be left uncovered when resizing windows. If this config is used alongside the screen edge gap, they will be summed together when calculating the gap.
+
+```bash
+defaults write com.knollsoft.Rectangle gapSize -float <NUM_PIXELS>
+```
+
 ### Ignore specific drag to snap areas
 
 Each drag to snap area on the edge of a screen can be ignored with a single Terminal command, but it's a bit field setting so you'll have to determine the bit field for which ones you want to disable.


### PR DESCRIPTION
I was looking to add window gaps and noticed that the feature is available through this [issue](https://github.com/rxhanson/Rectangle/issues/225). Looks like the documentation on how to enable it was removed in this [commit](https://github.com/rxhanson/Rectangle/commit/3e9d5f12c1366257203e7eb832fcd1ab299573be#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5). 

I wasn't sure if that was removed inadvertently, so I figured I would open a PR to add it back. If you made the explicit choice to remove it from the README, please let me know and I will close the PR.

Thanks a lot for creating Rectangle!