### PR TITLE
Fix: restore defaults properly

### DIFF
--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -109,13 +109,14 @@ class SettingsViewController: NSViewController {
     }
     
     @IBAction func restoreDefaults(_ sender: Any) {
-        WindowAction.active.forEach { UserDefaults.standard.removeObject(forKey: $0.name) }
         let currentDefaults = Defaults.alternateDefaultShortcuts.enabled ? "Rectangle" : "Spectacle"
         let defaultShortcutsTitle = NSLocalizedString("Default Shortcuts", tableName: "Main", value: "", comment: "")
         let currentlyUsingText = NSLocalizedString("Currently using: ", tableName: "Main", value: "", comment: "")
         let cancelText = NSLocalizedString("Cancel", tableName: "Main", value: "", comment: "")
         let response = AlertUtil.threeButtonAlert(question: defaultShortcutsTitle, text: currentlyUsingText + currentDefaults, buttonOneText: "Rectangle", buttonTwoText: "Spectacle", buttonThreeText: cancelText)
         if response == .alertThirdButtonReturn { return }
+
+        WindowAction.active.forEach { UserDefaults.standard.removeObject(forKey: $0.name) }
         let rectangleDefaults = response == .alertFirstButtonReturn
         if rectangleDefaults != Defaults.alternateDefaultShortcuts.enabled {
             Defaults.alternateDefaultShortcuts.enabled = rectangleDefaults


### PR DESCRIPTION
"Restore default shortcuts" button always reset my shortcuts even if I clicked "cancel" button 😞 

```swift
WindowAction.active.forEach { UserDefaults.standard.removeObject(forKey: $0.name) }
```

I'm not familiar with swift but just checked the code and found that some remove is done regardless of alert response. I assume this is where the reset is done, and I moved it after checking alert response part.