### PR TITLE
Add ninths

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -97,6 +97,16 @@
 		98FD7C5F2687BC14009E9DAF /* FirstThreeFourthsCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FD7C5E2687BC14009E9DAF /* FirstThreeFourthsCalculation.swift */; };
 		98FD7C612687BCB6009E9DAF /* LastThreeFourthsCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FD7C602687BCB6009E9DAF /* LastThreeFourthsCalculation.swift */; };
 		CC0B7937429AC28C21ABF5B4 /* Pods_RectangleLauncher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2D8480CC730811C953FC1B6 /* Pods_RectangleLauncher.framework */; };
+		D04CE3002781794E00BD47B3 /* TopLeftNinthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04CE2FF2781794E00BD47B3 /* TopLeftNinthCalculation.swift */; };
+		D04CE30227817A6100BD47B3 /* TopCenterNinthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04CE30127817A6100BD47B3 /* TopCenterNinthCalculation.swift */; };
+		D04CE30427817A6F00BD47B3 /* TopRightNinthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04CE30327817A6F00BD47B3 /* TopRightNinthCalculation.swift */; };
+		D04CE30627817A8400BD47B3 /* MiddleLeftNinthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04CE30527817A8400BD47B3 /* MiddleLeftNinthCalculation.swift */; };
+		D04CE30827817A9200BD47B3 /* MiddleCenterNinthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04CE30727817A9200BD47B3 /* MiddleCenterNinthCalculation.swift */; };
+		D04CE30A27817A9F00BD47B3 /* MiddleRightNinthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04CE30927817A9F00BD47B3 /* MiddleRightNinthCalculation.swift */; };
+		D04CE30C27817AA900BD47B3 /* BottomLeftNinthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04CE30B27817AA900BD47B3 /* BottomLeftNinthCalculation.swift */; };
+		D04CE30E27817AB500BD47B3 /* BottomCenterNinthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04CE30D27817AB500BD47B3 /* BottomCenterNinthCalculation.swift */; };
+		D04CE31027817ABE00BD47B3 /* BottomRightNinthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04CE30F27817ABE00BD47B3 /* BottomRightNinthCalculation.swift */; };
+		D04CE31227817C9B00BD47B3 /* NinthsRepeated.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04CE31127817C9B00BD47B3 /* NinthsRepeated.swift */; };
 		F0A0DFB36FCC3FCE6E184500 /* Pods_Rectangle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20A533B9F2D3215AC7B85D1F /* Pods_Rectangle.framework */; };
 /* End PBXBuildFile section */
 
@@ -260,6 +270,16 @@
 		98FE8976246E79C400871535 /* zh-Hant-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-HK"; path = "zh-Hant-HK.lproj/Main.strings"; sourceTree = "<group>"; };
 		98FE8977246E79C400871535 /* zh-Hant-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-HK"; path = "zh-Hant-HK.lproj/Main.strings"; sourceTree = "<group>"; };
 		BFFF93EBEA6E2FF7245A7CF5 /* Pods-Rectangle.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rectangle.release.xcconfig"; path = "Target Support Files/Pods-Rectangle/Pods-Rectangle.release.xcconfig"; sourceTree = "<group>"; };
+		D04CE2FF2781794E00BD47B3 /* TopLeftNinthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopLeftNinthCalculation.swift; sourceTree = "<group>"; };
+		D04CE30127817A6100BD47B3 /* TopCenterNinthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCenterNinthCalculation.swift; sourceTree = "<group>"; };
+		D04CE30327817A6F00BD47B3 /* TopRightNinthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopRightNinthCalculation.swift; sourceTree = "<group>"; };
+		D04CE30527817A8400BD47B3 /* MiddleLeftNinthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleLeftNinthCalculation.swift; sourceTree = "<group>"; };
+		D04CE30727817A9200BD47B3 /* MiddleCenterNinthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleCenterNinthCalculation.swift; sourceTree = "<group>"; };
+		D04CE30927817A9F00BD47B3 /* MiddleRightNinthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleRightNinthCalculation.swift; sourceTree = "<group>"; };
+		D04CE30B27817AA900BD47B3 /* BottomLeftNinthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomLeftNinthCalculation.swift; sourceTree = "<group>"; };
+		D04CE30D27817AB500BD47B3 /* BottomCenterNinthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomCenterNinthCalculation.swift; sourceTree = "<group>"; };
+		D04CE30F27817ABE00BD47B3 /* BottomRightNinthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomRightNinthCalculation.swift; sourceTree = "<group>"; };
+		D04CE31127817C9B00BD47B3 /* NinthsRepeated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NinthsRepeated.swift; sourceTree = "<group>"; };
 		DE4AE568B8BDB98BF602D588 /* Pods-RectangleMAS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RectangleMAS.release.xcconfig"; path = "Target Support Files/Pods-RectangleMAS/Pods-RectangleMAS.release.xcconfig"; sourceTree = "<group>"; };
 		E2625F45B180F733E8508494 /* Pods-RectangleMAS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RectangleMAS.debug.xcconfig"; path = "Target Support Files/Pods-RectangleMAS/Pods-RectangleMAS.debug.xcconfig"; sourceTree = "<group>"; };
 		F2D8480CC730811C953FC1B6 /* Pods_RectangleLauncher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RectangleLauncher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -387,6 +407,16 @@
 				98A6EDDC251F3F4A00F74B10 /* SixthsRepeated.swift */,
 				866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */,
 				30166BCF24F27D6A00A38608 /* SpecifiedCalculation.swift */,
+				D04CE31127817C9B00BD47B3 /* NinthsRepeated.swift */,
+				D04CE2FF2781794E00BD47B3 /* TopLeftNinthCalculation.swift */,
+				D04CE30127817A6100BD47B3 /* TopCenterNinthCalculation.swift */,
+				D04CE30327817A6F00BD47B3 /* TopRightNinthCalculation.swift */,
+				D04CE30527817A8400BD47B3 /* MiddleLeftNinthCalculation.swift */,
+				D04CE30727817A9200BD47B3 /* MiddleCenterNinthCalculation.swift */,
+				D04CE30927817A9F00BD47B3 /* MiddleRightNinthCalculation.swift */,
+				D04CE30B27817AA900BD47B3 /* BottomLeftNinthCalculation.swift */,
+				D04CE30D27817AB500BD47B3 /* BottomCenterNinthCalculation.swift */,
+				D04CE30F27817ABE00BD47B3 /* BottomRightNinthCalculation.swift */,
 			);
 			path = WindowCalculation;
 			sourceTree = "<group>";
@@ -817,6 +847,7 @@
 				9821403522B38A2B00ABFB3F /* UpperRightCalculation.swift in Sources */,
 				9824702F22AFA2E50037B409 /* AccessibilityAuthorization.swift in Sources */,
 				988D066322EB4CA5004EABD7 /* FirstTwoThirdsCalculation.swift in Sources */,
+				D04CE30A27817A9F00BD47B3 /* MiddleRightNinthCalculation.swift in Sources */,
 				98BEFA482620DEDD00D9D54F /* NSImageExtension.swift in Sources */,
 				98FA9497235A2D7600F95C4F /* RepeatedExecutionsCalculation.swift in Sources */,
 				9824705122B28D7A0037B409 /* LeftRightHalfCalculation.swift in Sources */,
@@ -825,16 +856,20 @@
 				985B9BF522B93EEC00A2E8F0 /* ApplicationToggle.swift in Sources */,
 				98D16A442592AD55005228CB /* MASShortcutMigration.swift in Sources */,
 				988D066522EB4CB6004EABD7 /* CenterThirdCalculation.swift in Sources */,
+				D04CE30827817A9200BD47B3 /* MiddleCenterNinthCalculation.swift in Sources */,
 				98A009BD251253A000CFBF0C /* BottomCenterSixthCalculation.swift in Sources */,
 				98C2755E231FF6A9009B9292 /* EventMonitor.swift in Sources */,
 				98A009AF2512517900CFBF0C /* SecondFourthCalculation.swift in Sources */,
+				D04CE30C27817AA900BD47B3 /* BottomLeftNinthCalculation.swift in Sources */,
 				9821406022B3EFB200ABFB3F /* Defaults.swift in Sources */,
 				98192DDA270F606C00015E66 /* Debounce.swift in Sources */,
+				D04CE3002781794E00BD47B3 /* TopLeftNinthCalculation.swift in Sources */,
 				9821403122B38A0500ABFB3F /* TopHalfCalculation.swift in Sources */,
 				9824704B22B189250037B409 /* StandardWindowMover.swift in Sources */,
 				9821402722B3888100ABFB3F /* ChangeSizeCalculation.swift in Sources */,
 				98B3559823CE025700E410E0 /* CenteringFixedSizedWindowMover.swift in Sources */,
 				9824704E22B189250037B409 /* QuantizedWindowMover.swift in Sources */,
+				D04CE30627817A8400BD47B3 /* MiddleLeftNinthCalculation.swift in Sources */,
 				9824703B22B139780037B409 /* CUtil.swift in Sources */,
 				988D067D22EB4E17004EABD7 /* AlmostMaximizeCalculation.swift in Sources */,
 				98C1008C2305F1FA006E5344 /* SubsequentExecutionMode.swift in Sources */,
@@ -842,14 +877,17 @@
 				988D066722EB4CC0004EABD7 /* LastTwoThirdsCalculation.swift in Sources */,
 				98192DDE2717201100015E66 /* ReverseAllManager.swift in Sources */,
 				98A009B1251252C900CFBF0C /* ThirdFourthCalculation.swift in Sources */,
+				D04CE31227817C9B00BD47B3 /* NinthsRepeated.swift in Sources */,
 				9824703F22B13FBC0037B409 /* ScreenDetection.swift in Sources */,
 				9821402B22B388A000ABFB3F /* LowerRightCalculation.swift in Sources */,
+				D04CE30427817A6F00BD47B3 /* TopRightNinthCalculation.swift in Sources */,
 				98FD7C612687BCB6009E9DAF /* LastThreeFourthsCalculation.swift in Sources */,
 				9821402522B3887200ABFB3F /* MaximizeCalculation.swift in Sources */,
 				866661F2257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift in Sources */,
 				9824704D22B189250037B409 /* WindowCalculation.swift in Sources */,
 				98C1008E230B9EF6006E5344 /* NextPrevDisplayCalculation.swift in Sources */,
 				9824703122AFA8470037B409 /* RectangleStatusItem.swift in Sources */,
+				D04CE31027817ABE00BD47B3 /* BottomRightNinthCalculation.swift in Sources */,
 				98A009B92512538D00CFBF0C /* TopRightSixthCalculation.swift in Sources */,
 				98C275672322E2DA009B9292 /* WindowHistory.swift in Sources */,
 				9821403722B3D16700ABFB3F /* MaximizeHeightCalculation.swift in Sources */,
@@ -873,6 +911,7 @@
 				98D4B6C525B6256C009C7BF6 /* TodoManager.swift in Sources */,
 				9824700D22AF9B7D0037B409 /* AppDelegate.swift in Sources */,
 				98A009BF251253AB00CFBF0C /* BottomRightSixthCalculation.swift in Sources */,
+				D04CE30227817A6100BD47B3 /* TopCenterNinthCalculation.swift in Sources */,
 				98A009B52512537800CFBF0C /* TopLeftSixthCalculation.swift in Sources */,
 				9824704F22B189250037B409 /* BestEffortWindowMover.swift in Sources */,
 				30166BD024F27D6A00A38608 /* SpecifiedCalculation.swift in Sources */,
@@ -886,6 +925,7 @@
 				988D066922EB4CCB004EABD7 /* LastThirdCalculation.swift in Sources */,
 				98A6EDEC2528FFC100F74B10 /* WindowActionCategory.swift in Sources */,
 				988D068322EB4EF3004EABD7 /* MoveUpDownCalculation.swift in Sources */,
+				D04CE30E27817AB500BD47B3 /* BottomCenterNinthCalculation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -57,7 +57,16 @@ enum WindowAction: Int {
     bottomCenterSixth = 41,
     bottomRightSixth = 42,
     specified = 43,
-    reverseAll = 44
+    reverseAll = 44,
+    topLeftNinth = 45,
+    topCenterNinth = 46,
+    topRightNinth = 47,
+    middleLeftNinth = 48,
+    middleCenterNinth = 49,
+    middleRightNinth = 50,
+    bottomLeftNinth = 51,
+    bottomCenterNinth = 52,
+    bottomRightNinth = 53
 
     // Order matters here - it's used in the menu
     static let active = [leftHalf, rightHalf, centerHalf, topHalf, bottomHalf,
@@ -68,7 +77,10 @@ enum WindowAction: Int {
                          moveLeft, moveRight, moveUp, moveDown,
                          firstFourth, secondFourth, thirdFourth, lastFourth, firstThreeFourths, lastThreeFourths,
                          topLeftSixth, topCenterSixth, topRightSixth, bottomLeftSixth, bottomCenterSixth, bottomRightSixth,
-                         specified, reverseAll
+                         specified, reverseAll,
+                         topLeftNinth, topCenterNinth, topRightNinth,
+                         middleLeftNinth, middleCenterNinth, middleRightNinth,
+                         bottomLeftNinth, bottomCenterNinth, bottomRightNinth,
     ]
 
     func post() {
@@ -136,6 +148,15 @@ enum WindowAction: Int {
         case .bottomRightSixth: return "bottomRightSixth"
         case .specified: return "specified"
         case .reverseAll: return "reverseAll"
+        case .topLeftNinth: return "topLeftNinth"
+        case .topCenterNinth: return "topCenterNinth"
+        case .topRightNinth: return "topRightNinth"
+        case .middleLeftNinth: return "middleLeftNinth"
+        case .middleCenterNinth: return "middleCenterNinth"
+        case .middleRightNinth: return "middleRightNinth"
+        case .bottomLeftNinth: return "bottomLeftNinth"
+        case .bottomCenterNinth: return "bottomCenterNinth"
+        case .bottomRightNinth: return "bottomRightNinth"
         }
     }
 
@@ -261,6 +282,8 @@ enum WindowAction: Int {
         case .bottomRightSixth:
             key = "m2F-eA-g7w.title"
             value = "Bottom Right Sixth"
+        case .topLeftNinth, .topCenterNinth, .topRightNinth, .middleLeftNinth, .middleCenterNinth, .middleRightNinth, .bottomLeftNinth, .bottomCenterNinth, .bottomRightNinth:
+            return nil
         case .specified, .reverseAll:
             return nil
         }
@@ -377,6 +400,15 @@ enum WindowAction: Int {
         case .bottomLeftSixth: return NSImage(imageLiteralResourceName: "bottomLeftSixthTemplate")
         case .bottomCenterSixth: return NSImage(imageLiteralResourceName: "bottomCenterSixthTemplate")
         case .bottomRightSixth: return NSImage(imageLiteralResourceName: "bottomRightSixthTemplate")
+        case .topLeftNinth: return NSImage()
+        case .topCenterNinth: return NSImage()
+        case .topRightNinth: return NSImage()
+        case .middleLeftNinth: return NSImage()
+        case .middleCenterNinth: return NSImage()
+        case .middleRightNinth: return NSImage()
+        case .bottomLeftNinth: return NSImage()
+        case .bottomCenterNinth: return NSImage()
+        case .bottomRightNinth: return NSImage()
         case .specified, .reverseAll: return NSImage()
         }
     }
@@ -403,7 +435,8 @@ enum WindowAction: Int {
     var gapsApplicable: Dimension {
         switch self {
         case .leftHalf, .rightHalf, .bottomHalf, .topHalf, .centerHalf, .bottomLeft, .bottomRight, .topLeft, .topRight, .firstThird, .firstTwoThirds, .centerThird, .lastTwoThirds, .lastThird,
-             .firstFourth, .secondFourth, .thirdFourth, .lastFourth, .firstThreeFourths, .lastThreeFourths, .topLeftSixth, .topCenterSixth, .topRightSixth, .bottomLeftSixth, .bottomCenterSixth, .bottomRightSixth:
+             .firstFourth, .secondFourth, .thirdFourth, .lastFourth, .firstThreeFourths, .lastThreeFourths, .topLeftSixth, .topCenterSixth, .topRightSixth, .bottomLeftSixth, .bottomCenterSixth, .bottomRightSixth,
+            .topLeftNinth, .topCenterNinth, .topRightNinth, .middleLeftNinth, .middleCenterNinth, .middleRightNinth, .bottomLeftNinth, .bottomCenterNinth, .bottomRightNinth:
             return .both
         case .moveUp, .moveDown:
             return Defaults.resizeOnDirectionalMove.enabled ? .vertical : .none;
@@ -490,6 +523,16 @@ enum SubWindowAction {
     bottomRightTwoSixthsLandscape,
     bottomRightTwoSixthsPortrait,
     
+    topLeftNinth,
+    topCenterNinth,
+    topRightNinth,
+    middleLeftNinth,
+    middleCenterNinth,
+    middleRightNinth,
+    bottomLeftNinth,
+    bottomCenterNinth,
+    bottomRightNinth,
+        
     maximize
 
     var gapSharedEdge: Edge {
@@ -538,6 +581,15 @@ enum SubWindowAction {
         case .bottomLeftTwoSixthsPortrait: return [.right, .top]
         case .bottomRightTwoSixthsLandscape: return [.left, .top]
         case .bottomRightTwoSixthsPortrait: return [.left, .top]
+        case .topLeftNinth: return [.right, .bottom]
+        case .topCenterNinth: return [.right, .left, .bottom]
+        case .topRightNinth: return [.left, .bottom]
+        case .middleLeftNinth: return [.top, .right, .bottom]
+        case .middleCenterNinth: return [.top, .right, .bottom, .left]
+        case .middleRightNinth: return [.left, .top, .bottom]
+        case .bottomLeftNinth: return [.top, .right]
+        case .bottomCenterNinth: return [.left, .top, .right]
+        case .bottomRightNinth: return [.left, .top]
         case .maximize: return .none
         }
     }

--- a/Rectangle/WindowCalculation/BottomCenterNinthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomCenterNinthCalculation.swift
@@ -1,0 +1,53 @@
+//
+//  BottomCenterNinthCalculation.swift
+//  Rectangle
+//
+//  Created by Daniel Schultz on 1/2/22.
+//  Copyright © 2022 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+class BottomCenterNinthCalculation: WindowCalculation, OrientationAware, NinthsRepeated {
+        
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+
+        guard Defaults.subsequentExecutionMode.value != .none,
+              let last = params.lastAction,
+              let lastSubAction = last.subAction
+        else {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if last.action != .bottomCenterNinth {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if let calculation = self.nextCalculation(subAction: lastSubAction, direction: .right) {
+            return calculation(visibleFrameOfScreen)
+        }
+
+        return orientationBasedRect(visibleFrameOfScreen)
+    }
+    
+    func landscapeRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY
+        rect.origin.x = visibleFrameOfScreen.minX + rect.width
+        return RectResult(rect, subAction: .bottomCenterNinth)
+    }
+    
+    func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY
+        rect.origin.x = visibleFrameOfScreen.minX + rect.width
+        return RectResult(rect, subAction: .bottomCenterNinth)
+    }
+}
+
+

--- a/Rectangle/WindowCalculation/BottomLeftNinthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomLeftNinthCalculation.swift
@@ -1,0 +1,53 @@
+//
+//  BottomLeftNinthCalculation.swift
+//  Rectangle
+//
+//  Created by Daniel Schultz on 1/2/22.
+//  Copyright © 2022 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+class BottomLeftNinthCalculation: WindowCalculation, OrientationAware, NinthsRepeated {
+        
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+
+        guard Defaults.subsequentExecutionMode.value != .none,
+              let last = params.lastAction,
+              let lastSubAction = last.subAction
+        else {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if last.action != .bottomLeftNinth {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if let calculation = self.nextCalculation(subAction: lastSubAction, direction: .right) {
+            return calculation(visibleFrameOfScreen)
+        }
+
+        return orientationBasedRect(visibleFrameOfScreen)
+    }
+    
+    func landscapeRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY
+        rect.origin.x = visibleFrameOfScreen.minX
+        return RectResult(rect, subAction: .bottomLeftNinth)
+    }
+    
+    func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY
+        rect.origin.x = visibleFrameOfScreen.minX
+        return RectResult(rect, subAction: .bottomLeftNinth)
+    }
+}
+
+

--- a/Rectangle/WindowCalculation/BottomRightNinthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomRightNinthCalculation.swift
@@ -1,0 +1,53 @@
+//
+//  BottomRightNinthCalculation.swift
+//  Rectangle
+//
+//  Created by Daniel Schultz on 1/2/22.
+//  Copyright © 2022 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+class BottomRightNinthCalculation: WindowCalculation, OrientationAware, NinthsRepeated {
+        
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+
+        guard Defaults.subsequentExecutionMode.value != .none,
+              let last = params.lastAction,
+              let lastSubAction = last.subAction
+        else {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if last.action != .bottomRightNinth {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if let calculation = self.nextCalculation(subAction: lastSubAction, direction: .right) {
+            return calculation(visibleFrameOfScreen)
+        }
+
+        return orientationBasedRect(visibleFrameOfScreen)
+    }
+    
+    func landscapeRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY
+        rect.origin.x = visibleFrameOfScreen.minX + (2.0 * rect.width)
+        return RectResult(rect, subAction: .bottomRightNinth)
+    }
+    
+    func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY
+        rect.origin.x = visibleFrameOfScreen.minX + (2.0 * rect.width)
+        return RectResult(rect, subAction: .bottomRightNinth)
+    }
+}
+
+

--- a/Rectangle/WindowCalculation/MiddleCenterNinthCalculation.swift
+++ b/Rectangle/WindowCalculation/MiddleCenterNinthCalculation.swift
@@ -1,0 +1,53 @@
+//
+//  MiddleCenterNinthCalculation.swift
+//  Rectangle
+//
+//  Created by Daniel Schultz on 1/2/22.
+//  Copyright © 2022 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+class MiddleCenterNinthCalculation: WindowCalculation, OrientationAware, NinthsRepeated {
+        
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+
+        guard Defaults.subsequentExecutionMode.value != .none,
+              let last = params.lastAction,
+              let lastSubAction = last.subAction
+        else {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if last.action != .middleCenterNinth {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if let calculation = self.nextCalculation(subAction: lastSubAction, direction: .right) {
+            return calculation(visibleFrameOfScreen)
+        }
+
+        return orientationBasedRect(visibleFrameOfScreen)
+    }
+    
+    func landscapeRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + rect.height
+        rect.origin.x = visibleFrameOfScreen.minX + rect.width
+        return RectResult(rect, subAction: .middleCenterNinth)
+    }
+    
+    func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + rect.height
+        rect.origin.x = visibleFrameOfScreen.minX + rect.width
+        return RectResult(rect, subAction: .middleCenterNinth)
+    }
+}
+
+

--- a/Rectangle/WindowCalculation/MiddleLeftNinthCalculation.swift
+++ b/Rectangle/WindowCalculation/MiddleLeftNinthCalculation.swift
@@ -1,0 +1,53 @@
+//
+//  MiddleLeftNinthCalculation.swift
+//  Rectangle
+//
+//  Created by Daniel Schultz on 1/2/22.
+//  Copyright © 2022 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+class MiddleLeftNinthCalculation: WindowCalculation, OrientationAware, NinthsRepeated {
+        
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+
+        guard Defaults.subsequentExecutionMode.value != .none,
+              let last = params.lastAction,
+              let lastSubAction = last.subAction
+        else {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if last.action != .middleLeftNinth {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if let calculation = self.nextCalculation(subAction: lastSubAction, direction: .right) {
+            return calculation(visibleFrameOfScreen)
+        }
+
+        return orientationBasedRect(visibleFrameOfScreen)
+    }
+    
+    func landscapeRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + rect.height
+        rect.origin.x = visibleFrameOfScreen.minX
+        return RectResult(rect, subAction: .middleLeftNinth)
+    }
+    
+    func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + rect.height
+        rect.origin.x = visibleFrameOfScreen.minX
+        return RectResult(rect, subAction: .middleLeftNinth)
+    }
+}
+
+

--- a/Rectangle/WindowCalculation/MiddleRightNinthCalculation.swift
+++ b/Rectangle/WindowCalculation/MiddleRightNinthCalculation.swift
@@ -1,0 +1,53 @@
+//
+//  MiddleRightNinthCalculation.swift
+//  Rectangle
+//
+//  Created by Daniel Schultz on 1/2/22.
+//  Copyright © 2022 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+class MiddleRightNinthCalculation: WindowCalculation, OrientationAware, NinthsRepeated {
+        
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+
+        guard Defaults.subsequentExecutionMode.value != .none,
+              let last = params.lastAction,
+              let lastSubAction = last.subAction
+        else {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if last.action != .middleRightNinth {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if let calculation = self.nextCalculation(subAction: lastSubAction, direction: .right) {
+            return calculation(visibleFrameOfScreen)
+        }
+
+        return orientationBasedRect(visibleFrameOfScreen)
+    }
+    
+    func landscapeRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + rect.height
+        rect.origin.x = visibleFrameOfScreen.minX + (2.0 * rect.width)
+        return RectResult(rect, subAction: .middleRightNinth)
+    }
+    
+    func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + rect.height
+        rect.origin.x = visibleFrameOfScreen.minX + (2.0 * rect.width)
+        return RectResult(rect, subAction: .middleRightNinth)
+    }
+}
+
+

--- a/Rectangle/WindowCalculation/NinthsRepeated.swift
+++ b/Rectangle/WindowCalculation/NinthsRepeated.swift
@@ -1,0 +1,68 @@
+//
+//  NinthsRepeated.swift
+//  Rectangle
+//
+//  Created by Daniel Schultz on 1/2/22.
+//  Copyright © 2022 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+protocol NinthsRepeated {
+    func nextCalculation(subAction: SubWindowAction, direction: Direction) -> SimpleCalc?
+}
+
+extension NinthsRepeated {
+    func nextCalculation(subAction: SubWindowAction, direction: Direction) -> SimpleCalc? {
+        
+        if direction == .left {
+            switch subAction {
+            case .topLeftNinth:
+                return WindowCalculationFactory.bottomRightNinthCalculation.orientationBasedRect
+            case .topCenterNinth:
+                return WindowCalculationFactory.topLeftNinthCalculation.orientationBasedRect
+            case .topRightNinth:
+                return WindowCalculationFactory.topCenterNinthCalculation.orientationBasedRect
+            case .middleLeftNinth:
+                return WindowCalculationFactory.topRightNinthCalculation.orientationBasedRect
+            case .middleCenterNinth:
+                return WindowCalculationFactory.middleLeftNinthCalculation.orientationBasedRect
+            case .middleRightNinth:
+                return WindowCalculationFactory.middleCenterNinthCalculation.orientationBasedRect
+            case .bottomLeftNinth:
+                return WindowCalculationFactory.middleRightNinthCalculation.orientationBasedRect
+            case .bottomCenterNinth:
+                return WindowCalculationFactory.bottomLeftNinthCalculation.orientationBasedRect
+            case .bottomRightNinth:
+                return WindowCalculationFactory.bottomCenterNinthCalculation.orientationBasedRect
+            default: break
+            }
+        }
+        
+        else if direction == .right {
+            switch subAction {
+            case .topLeftNinth:
+                return WindowCalculationFactory.topCenterNinthCalculation.orientationBasedRect
+            case .topCenterNinth:
+                return WindowCalculationFactory.topRightNinthCalculation.orientationBasedRect
+            case .topRightNinth:
+                return WindowCalculationFactory.middleLeftNinthCalculation.orientationBasedRect
+            case .middleLeftNinth:
+                return WindowCalculationFactory.middleCenterNinthCalculation.orientationBasedRect
+            case .middleCenterNinth:
+                return WindowCalculationFactory.middleRightNinthCalculation.orientationBasedRect
+            case .middleRightNinth:
+                return WindowCalculationFactory.bottomLeftNinthCalculation.orientationBasedRect
+            case .bottomLeftNinth:
+                return WindowCalculationFactory.bottomCenterNinthCalculation.orientationBasedRect
+            case .bottomCenterNinth:
+                return WindowCalculationFactory.bottomRightNinthCalculation.orientationBasedRect
+            case .bottomRightNinth:
+                return WindowCalculationFactory.topLeftNinthCalculation.orientationBasedRect
+            default: break
+            }
+        }
+        
+        return nil
+    }
+}

--- a/Rectangle/WindowCalculation/TopCenterNinthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopCenterNinthCalculation.swift
@@ -1,0 +1,51 @@
+//
+//  TopCenterNinthCalculation.swift
+//  Rectangle
+//
+//  Created by Daniel Schultz on 1/2/22.
+//  Copyright © 2022 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+class TopCenterNinthCalculation: WindowCalculation, OrientationAware, NinthsRepeated {
+        
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+
+        guard Defaults.subsequentExecutionMode.value != .none,
+              let last = params.lastAction,
+              let lastSubAction = last.subAction
+        else {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if last.action != .topCenterNinth {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if let calculation = self.nextCalculation(subAction: lastSubAction, direction: .right) {
+            return calculation(visibleFrameOfScreen)
+        }
+
+        return orientationBasedRect(visibleFrameOfScreen)
+    }
+    
+    func landscapeRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + (2.0 * rect.height)
+        rect.origin.x = visibleFrameOfScreen.minX + rect.width
+        return RectResult(rect, subAction: .topCenterNinth)
+    }
+    
+    func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + (2.0 * rect.height)
+        rect.origin.x = visibleFrameOfScreen.minX + rect.width
+        return RectResult(rect, subAction: .topCenterNinth)
+    }
+}

--- a/Rectangle/WindowCalculation/TopLeftNinthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopLeftNinthCalculation.swift
@@ -1,0 +1,51 @@
+//
+//  TopLeftNinthCalculation.swift
+//  Rectangle
+//
+//  Created by Daniel Schultz on 1/2/22.
+//  Copyright © 2022 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+class TopLeftNinthCalculation: WindowCalculation, OrientationAware, NinthsRepeated {
+        
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+
+        guard Defaults.subsequentExecutionMode.value != .none,
+              let last = params.lastAction,
+              let lastSubAction = last.subAction
+        else {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if last.action != .topLeftNinth {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if let calculation = self.nextCalculation(subAction: lastSubAction, direction: .right) {
+            return calculation(visibleFrameOfScreen)
+        }
+
+        return orientationBasedRect(visibleFrameOfScreen)
+    }
+    
+    func landscapeRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + (2.0 * rect.height)
+        rect.origin.x = visibleFrameOfScreen.minX
+        return RectResult(rect, subAction: .topLeftNinth)
+    }
+    
+    func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + (2.0 * rect.height)
+        rect.origin.x = visibleFrameOfScreen.minX
+        return RectResult(rect, subAction: .topLeftNinth)
+    }
+}

--- a/Rectangle/WindowCalculation/TopRightNinthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopRightNinthCalculation.swift
@@ -1,0 +1,52 @@
+//
+//  TopRightNinthCalculation.swift
+//  Rectangle
+//
+//  Created by Daniel Schultz on 1/2/22.
+//  Copyright © 2022 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+class TopRightNinthCalculation: WindowCalculation, OrientationAware, NinthsRepeated {
+        
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+
+        guard Defaults.subsequentExecutionMode.value != .none,
+              let last = params.lastAction,
+              let lastSubAction = last.subAction
+        else {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if last.action != .topRightNinth {
+            return orientationBasedRect(visibleFrameOfScreen)
+        }
+        
+        if let calculation = self.nextCalculation(subAction: lastSubAction, direction: .right) {
+            return calculation(visibleFrameOfScreen)
+        }
+
+        return orientationBasedRect(visibleFrameOfScreen)
+    }
+    
+    func landscapeRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + (2.0 * rect.height)
+        rect.origin.x = visibleFrameOfScreen.minX + (2.0 * rect.width)
+        return RectResult(rect, subAction: .topRightNinth)
+    }
+    
+    func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floor(visibleFrameOfScreen.width / 3.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 3.0)
+        rect.origin.y = visibleFrameOfScreen.minY + (2.0 * rect.height)
+        rect.origin.x = visibleFrameOfScreen.minX + (2.0 * rect.width)
+        return RectResult(rect, subAction: .topRightNinth)
+    }
+}
+

--- a/Rectangle/WindowCalculation/WindowCalculation.swift
+++ b/Rectangle/WindowCalculation/WindowCalculation.swift
@@ -146,6 +146,15 @@ class WindowCalculationFactory {
     static let bottomLeftSixthCalculation = BottomLeftSixthCalculation()
     static let bottomCenterSixthCalculation = BottomCenterSixthCalculation()
     static let bottomRightSixthCalculation = BottomRightSixthCalculation()
+    static let topLeftNinthCalculation = TopLeftNinthCalculation()
+    static let topCenterNinthCalculation = TopCenterNinthCalculation()
+    static let topRightNinthCalculation = TopRightNinthCalculation()
+    static let middleLeftNinthCalculation = MiddleLeftNinthCalculation()
+    static let middleCenterNinthCalculation = MiddleCenterNinthCalculation()
+    static let middleRightNinthCalculation = MiddleRightNinthCalculation()
+    static let bottomLeftNinthCalculation = BottomLeftNinthCalculation()
+    static let bottomCenterNinthCalculation = BottomCenterNinthCalculation()
+    static let bottomRightNinthCalculation = BottomRightNinthCalculation()
     static let specifiedCalculation = SpecifiedCalculation()
 
     static let calculationsByAction: [WindowAction: WindowCalculation] = [
@@ -187,6 +196,15 @@ class WindowCalculationFactory {
      .bottomLeftSixth: bottomLeftSixthCalculation,
      .bottomCenterSixth: bottomCenterSixthCalculation,
      .bottomRightSixth: bottomRightSixthCalculation,
+     .topLeftNinth: topLeftNinthCalculation,
+     .topCenterNinth: topCenterNinthCalculation,
+     .topRightNinth: topRightNinthCalculation,
+     .middleLeftNinth: middleLeftNinthCalculation,
+     .middleCenterNinth: middleCenterNinthCalculation,
+     .middleRightNinth: middleRightNinthCalculation,
+     .bottomLeftNinth: bottomLeftNinthCalculation,
+     .bottomCenterNinth: bottomCenterNinthCalculation,
+     .bottomRightNinth: bottomRightNinthCalculation,
      .specified: specifiedCalculation
         //     .restore: nil
     ]

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -100,6 +100,28 @@ defaults write com.knollsoft.Rectangle specifiedHeight -float 1050
 defaults write com.knollsoft.Rectangle specifiedWidth -float 1680
 ```
 
+## Add extra "ninths" sizing commands
+
+Commands for resizing to screen ninths are not available in the UI.  Similar to extra centering you will need to know which keycode and modifier flags you want.
+
+The key codes are:
+
+* topLeftNinth
+* topCenterNinth
+* topRightNinth
+* middleLeftNinth
+* middleCenterNinth
+* middleRightNinth
+* bottomLeftNinth
+* bottomCenterNinth
+* bottomRightNinth
+
+For example, the command for setting the top left ninth shortcut to `ctrl opt shift 1` would be:
+
+```bash
+defaults write com.knollsoft.Rectangle topLeftNinth -dict-add keyCode -float 18 modifierFlags -float 917504
+```
+
 ## Modify the "footprint" displayed for drag to snap area
 
 Adjust the alpha (transparency). Default is 0.3.

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -100,7 +100,7 @@ defaults write com.knollsoft.Rectangle specifiedHeight -float 1050
 defaults write com.knollsoft.Rectangle specifiedWidth -float 1680
 ```
 
-## Add extra "ninths" sizing commands
+## Add extra "ninths" sizing commands (Available in v0.50)
 
 Commands for resizing to screen ninths are not available in the UI.  Similar to extra centering you will need to know which keycode and modifier flags you want.
 


### PR DESCRIPTION
Thank you for this project!

I personally love ninths, as 4k screens are pretty common in the mac ecosystem and it's handy to be able to stack things like terminals.  I saw in [this discussion](https://github.com/rxhanson/Rectangle/discussions/396) that you would be open to a PR for adding ninths to Rectangle so I thought I'd give it a whirl.

**What's added**

1. Support for "ninths" calculations, without a UX, meaning it is possible to configure hotkeys via terminal commands for folks who are interested in that sort of thing.

-- 

Note that an earlier version of this PR included UI / UX for setting shortcuts and accessing ninths via the menu.  This was removed as part of the PR review, though the UI still exists [in this commit](https://github.com/slifty/Rectangle/commit/2b22a084017896dfeb975e7dafd9ca4e1daee4c2) if anybody is interested in that kind of thing down the line.