### PR TITLE
Update readme files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,4 @@ By contributing to Rectangle you agree that your contributions will be licensed 
 
 ## Incentives
 
-Logic from Rectangle is used in the Multitouch app. The Hookshot app is entirely built on top of Rectangle. If you contribute significant code or localizations that get merged into Rectangle, you get a free license of Multitouch or Hookshot. Contributors to Sparkle, MASShortcut, or Spectacle can also receive free Multitouch or Hookshot licenses. Either send me a message on [Gitter](https://gitter.im) or email me from the email address specified on your GitHub profile after you're pull request has been merged.
+Logic from Rectangle is used in the [Multitouch](https://multitouch.app) app. The [Rectangle Pro](https://rectangleapp.com/pro) app is entirely built on top of Rectangle. If you contribute significant code or localizations that get merged into Rectangle, you get a free license of Multitouch or Rectangle Pro. Contributors to Sparkle, MASShortcut, or Spectacle can also receive free Multitouch or Rectangle Pro licenses (just send me a direct message on [Gitter](https://gitter.im)).

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ defaults delete com.knollsoft.Rectangle
 
 ## Contributing
 
-Logic from Rectangle is used in the [Multitouch](https://multitouch.app) app. The [Hookshot](https://hookshot.app) app is entirely built on top of Rectangle. If you contribute significant code or localizations that get merged into Rectangle, you get a free license of Multitouch or Hookshot. Contributors to Sparkle, MASShortcut, or Spectacle can also receive free Multitouch or Hookshot licenses (just send me a direct message on [Gitter](https://gitter.im)).
+Logic from Rectangle is used in the [Multitouch](https://multitouch.app) app. The [Rectangle Pro](https://rectangleapp.com/pro) app is entirely built on top of Rectangle. If you contribute significant code or localizations that get merged into Rectangle, you get a free license of Multitouch or Rectangle Pro. Contributors to Sparkle, MASShortcut, or Spectacle can also receive free Multitouch or Rectangle Pro licenses (just send me a direct message on [Gitter](https://gitter.im)).
 
 ### Localization
 

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -100,7 +100,7 @@ defaults write com.knollsoft.Rectangle specifiedHeight -float 1050
 defaults write com.knollsoft.Rectangle specifiedWidth -float 1680
 ```
 
-## Add extra "ninths" sizing commands (Available in v0.50)
+## Add extra "ninths" sizing commands
 
 Commands for resizing to screen ninths are not available in the UI.  Similar to extra centering you will need to know which keycode and modifier flags you want.
 
@@ -243,7 +243,7 @@ To disable the Top Half and Bottom Half snap areas, the bit field would be 1111 
 defaults write com.knollsoft.Rectangle ignoredSnapAreas -int 3840
 ```
 
-## Disabling gaps when maximizing (Available in v0.50)
+## Disabling gaps when maximizing
 
 By default, the "Gaps between windows" setting applies to "Maximize" and "Maximize Height".
 


### PR DESCRIPTION
Replaces references to Hookshot with Rectangle Pro and removes the 'Available in v0.50' notices from TerminalCommands.md