### PR TITLE
Bug Fix for #713

### DIFF
--- a/Rectangle/TodoMode/TodoManager.swift
+++ b/Rectangle/TodoMode/TodoManager.swift
@@ -55,12 +55,12 @@ class TodoManager {
                     let wScreen = sd.detectScreens(using: w)?.currentScreen
                     if w.getIdentifier() != todoWindow.getIdentifier() &&
                         wScreen == TodoManager.todoScreen {
-                        shiftWindowOffSidebar(w, screenFrame: screenFrame)
+                        shiftWindowOffSidebar(w, screenVisibleFrame: screen.adjustedVisibleFrame)
                     }
                 }
 
                 var rect = todoWindow.rectOfElement()
-                rect.origin.x = screenFrame.maxX - CGFloat(Defaults.todoSidebarWidth.value)
+                rect.origin.x = screen.adjustedVisibleFrame.maxX
                 rect.origin.y = screenFrame.minY
                 rect.size.height = screen.adjustedVisibleFrame.height
                 rect.size.width = CGFloat(Defaults.todoSidebarWidth.value)
@@ -81,16 +81,16 @@ class TodoManager {
         TodoManager.todoScreen = screens?.currentScreen
     }
     
-    private static func shiftWindowOffSidebar(_ w: AccessibilityElement, screenFrame: CGRect) {
+    private static func shiftWindowOffSidebar(_ w: AccessibilityElement, screenVisibleFrame: CGRect) {
         var rect = w.rectOfElement()
-
-        if (rect.maxX > (screenFrame.maxX - CGFloat(Defaults.todoSidebarWidth.value))) {
+        
+        if (rect.maxX > screenVisibleFrame.maxX) {
             // Shift it to the left
-            rect.origin.x = max (0, rect.origin.x - (rect.maxX - (screenFrame.maxX - CGFloat(Defaults.todoSidebarWidth.value))))
-
+            rect.origin.x = min (rect.origin.x, max (screenVisibleFrame.minX, (rect.origin.x - (rect.maxX - screenVisibleFrame.maxX))))
+            
             // If it's still too wide, scale it down
-            if (rect.origin.x == 0) {
-                rect.size.width = min(rect.size.width, screenFrame.maxX - CGFloat(Defaults.todoSidebarWidth.value))
+            if(rect.maxX > screenVisibleFrame.maxX){
+                rect.size.width = rect.size.width - (rect.maxX - screenVisibleFrame.maxX)
             }
 
             w.setRectOf(rect)


### PR DESCRIPTION
Rectangle Version 0.50 (55)
Fix for #713 

Application windows now consider the dock positition and will not be placed underneath the dock

1. todoWindow uses the adjustedVisibleFrame(which uses visibleFrame). When the dock is set to the right side, todoWindow will now placed next to it rather than under it
2. adjustedVisibleFrame is now used to calculate the positions for all non-todo application windows.
3. Changed the following in the shiftWindowOffSidebar function
	a. Uses adjustedVisibleFrame instead of screenFrame. Helps when dock is placed on the left side
	b. Handles an edge case where an application window is already placed at left edge or even further left. Origin X will be its current x in this case
	c. The condition for checking if the application window is too wide. It now considers the edge case above.