### PR TITLE
Sort the JSON keys of the exported configuration

### DIFF
--- a/Rectangle/PrefsWindow/Config.swift
+++ b/Rectangle/PrefsWindow/Config.swift
@@ -32,6 +32,9 @@ extension Defaults {
         
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
+        if #available(macOS 10.13, *) {
+            encoder.outputFormatting.update(with: .sortedKeys)
+        }
         if let encodedJson = try? encoder.encode(config) {
             if let jsonString = String(data: encodedJson, encoding: .utf8) {
                 print(jsonString)


### PR DESCRIPTION
This results in a more stable (and diff-able) configuration file.

`JSONEncoder.OutputFormatting.sortedKeys` was introduced in macOS
10.13, so this is protected by a runtime availability check.