### PR TITLE
Add option to apply gaps to the main screen only

### DIFF
--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -38,6 +38,7 @@ class Defaults {
     static let screenEdgeGapBottom = FloatDefault(key: "screenEdgeGapBottom", defaultValue: 0)
     static let screenEdgeGapLeft = FloatDefault(key: "screenEdgeGapLeft", defaultValue: 0)
     static let screenEdgeGapRight = FloatDefault(key: "screenEdgeGapRight", defaultValue: 0)
+    static let screenEdgeGapsOnMainScreenOnly = BoolDefault(key: "screenEdgeGapsOnMainScreenOnly")
     static let lastVersion = StringDefault(key: "lastVersion")
     static let showAllActionsInMenu = OptionalBoolDefault(key: "showAllActionsInMenu")
     static var SUHasLaunchedBefore: Bool { UserDefaults.standard.bool(forKey: "SUHasLaunchedBefore") }
@@ -97,6 +98,7 @@ class Defaults {
         screenEdgeGapBottom,
         screenEdgeGapLeft,
         screenEdgeGapRight,
+        screenEdgeGapsOnMainScreenOnly,
         showAllActionsInMenu,
         footprintAlpha,
         footprintBorderWidth,

--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -129,10 +129,10 @@ struct AdjacentScreens {
 extension NSScreen {
     var adjustedVisibleFrame: CGRect {
         get {
-            let topGap = CGFloat(Defaults.screenEdgeGapTop.value)
-            let bottomGap = CGFloat(Defaults.screenEdgeGapBottom.value)
-            let leftGap = CGFloat(Defaults.screenEdgeGapLeft.value)
-            var rightGap = CGFloat(Defaults.screenEdgeGapRight.value)
+            let topGap = CGFloat(Defaults.screenEdgeGapsOnMainScreenOnly.enabled && isMainDisplay ? Defaults.screenEdgeGapTop.value : 0)
+            let bottomGap = CGFloat(Defaults.screenEdgeGapsOnMainScreenOnly.enabled && isMainDisplay ? Defaults.screenEdgeGapBottom.value : 0)
+            let leftGap = CGFloat(Defaults.screenEdgeGapsOnMainScreenOnly.enabled && isMainDisplay ? Defaults.screenEdgeGapLeft.value : 0)
+            var rightGap = CGFloat(Defaults.screenEdgeGapsOnMainScreenOnly.enabled && isMainDisplay ? Defaults.screenEdgeGapRight.value : 0)
 
             if Defaults.todo.userEnabled, Defaults.todoMode.enabled, TodoManager.todoScreen == self {
                 rightGap += CGFloat(Defaults.todoSidebarWidth.value)
@@ -149,6 +149,12 @@ extension NSScreen {
             
             return CGRect(origin: origin, size: size)
         }
+    }
+    var displayID: CGDirectDisplayID {
+      return deviceDescription[NSDeviceDescriptionKey(rawValue: "NSScreenNumber")] as? CGDirectDisplayID ?? 0
+    }
+    var isMainDisplay: Bool {
+        return displayID == CGMainDisplayID()
     }
 }
 

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -250,6 +250,12 @@ defaults write com.knollsoft.Rectangle screenEdgeGapLeft -int 10
 defaults write com.knollsoft.Rectangle screenEdgeGapRight -int 10
 ```
 
+If you want these gaps to be applied on your main screen only you can set screenEdgeGapsOnMainScreenOnly. Useful for multi display setups where only one screen has some dock replacement.
+
+```bash
+defaults write com.knollsoft.Rectangle screenEdgeGapsOnMainScreenOnly -bool true
+```
+
 ## Ignore specific drag to snap areas
 
 Each drag to snap area on the edge of a screen can be ignored with a single Terminal command, but it's a bit field setting so you'll have to determine the bit field for which ones you want to disable.


### PR DESCRIPTION
Hi there 👋 
This PR adds another hidden preference to apply the screen gaps only to the main/primary screen.
I find it quite useful since I have uBar as dock replacement on the primary screen only. Without that the set gaps will be applied on non primary screens too which don't have any dock leaving some unused screen space.