### PR TITLE
Added support for corner sixth snap areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Drag a window to the edge of the screen. When the mouse cursor reaches the edge 
 | Left or right edge, just above or below a corner       | Top or bottom half                     |
 | Bottom left, center, or right third                    | Respective third                       |
 | Bottom left or right third, then drag to bottom center | First or last two thirds, respectively |
+| Corners, then drag to respective third                 | Respective sixth                       |
 
 ### Ignore an app
 

--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -257,6 +257,24 @@ class SnappingManager {
         let shortEdgeSize = CGFloat(Defaults.shortEdgeSnapAreaSize.value)
         let frame = screen.frame
         
+        if loc.y >= frame.maxY - marginTop - cornerSize && loc.y <= frame.maxY && !ignoredSnapAreas.contains(.top) {
+            let thirdWidth = floor(frame.width / 3)
+            if loc.x >= frame.minX + cornerSize && loc.x <= frame.minX + thirdWidth {
+                if let priorAction = priorSnapArea?.action {
+                    if priorAction == .topLeft || priorAction == .topLeftSixth {
+                        return SnapArea(screen: screen, action: .topLeftSixth)
+                    }
+                }
+            }
+            if loc.x >= frame.minX + thirdWidth && loc.x <= frame.maxX - cornerSize {
+                if let priorAction = priorSnapArea?.action {
+                    if priorAction == .topRight || priorAction == .topRightSixth {
+                        return SnapArea(screen: screen, action: .topRightSixth)
+                    }
+                }
+            }
+        }
+        
         if loc.x >= frame.minX {
             if loc.x < frame.minX + marginLeft + cornerSize {
                 if loc.y >= frame.maxY - marginTop - cornerSize && loc.y <= frame.maxY {
@@ -334,6 +352,15 @@ class SnappingManager {
         if loc.y >= frame.minY && loc.y < frame.minY + marginBottom && !ignoredSnapAreas.contains(.bottom) {
             let thirdWidth = floor(frame.width / 3)
             if loc.x >= frame.minX && loc.x <= frame.minX + thirdWidth {
+                if let priorAction = priorSnapArea?.action {
+                    let action: WindowAction
+                    switch priorAction {
+                    case .bottomLeft, .bottomLeftSixth:
+                        action = .bottomLeftSixth
+                    default: action = .firstThird
+                    }
+                    return SnapArea(screen: screen, action: action)
+                }
                 return SnapArea(screen: screen, action: .firstThird)
             }
             if loc.x >= frame.minX + thirdWidth && loc.x <= frame.maxX - thirdWidth{
@@ -351,6 +378,15 @@ class SnappingManager {
                 return SnapArea(screen: screen, action: .centerThird)
             }
             if loc.x >= frame.minX + thirdWidth && loc.x <= frame.maxX {
+                if let priorAction = priorSnapArea?.action {
+                    let action: WindowAction
+                    switch priorAction {
+                    case .bottomRight, .bottomRightSixth:
+                        action = .bottomRightSixth
+                    default: action = .lastThird
+                    }
+                    return SnapArea(screen: screen, action: action)
+                }
                 return SnapArea(screen: screen, action: .lastThird)
             }
         }


### PR DESCRIPTION
Added support for snapping to corner sixths, as I like sixths for a wide screen but don't like keyboard shortcuts. I used similar logic to the two thirds snap areas, but starting from the corner and dragging inwards, to the thirds position, and the equivalent at the top.
I couldn't work out what `topLeftShort`, etc. meant and my logic works with and without the dock. Let me know if I need to add some logic to deal with "short" options.
I didn't add any region for centre sixths, as I can't think of any good gestures.
I also didn't add the logic for portrait mode. Would this be useful? I don't think I have any way to actually test this.