### PR TITLE
fix: screenEdgeGapsOnMainScreenOnly logic inverted

### DIFF
--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -135,7 +135,7 @@ extension NSScreen {
                 newFrame.size.width -= Defaults.todoSidebarWidth.cgFloat
             }
             
-            if Defaults.screenEdgeGapsOnMainScreenOnly.enabled, self == NSScreen.screens.first {
+            if Defaults.screenEdgeGapsOnMainScreenOnly.enabled, self != NSScreen.screens.first {
                 return newFrame
             }
             


### PR DESCRIPTION
Hello again 😃 
It is about my [last PR](https://github.com/rxhanson/Rectangle/pull/798), you did some refactoring and inverted the logic by accident. 😬  Instead of applying the gaps to the main screen only it does it only for non main screens now. I fixed it with this PR.