### PR TITLE
Bump GitHub action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install Dependencies
       run: |
         pod repo update
@@ -35,14 +35,14 @@ jobs:
             "method": "mac-application"
           }
         EOF
-        
+
         xcodebuild -exportArchive -archivePath "$BUILD_DIR/$XCODE_ARCHIVE" -exportPath "$BUILD_DIR" -exportOptionsPlist "$EXPORT_OPTIONS_PLIST"
     - name: Resign App
       run: codesign --force --deep -s "$CODE_SIGN_IDENTITY" "$BUILD_DIR/$APP_NAME"
     - name: Make DMG
       run: hdiutil create -srcdir "$BUILD_DIR" -volname "$DMG_NAME" "$DMG_FILE_NAME"
     - name: Upload
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Build
         path: ${{ env.DMG_FILE_NAME }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rectangle
 
-![Build status](https://github.com/rxhanson/Rectangle/workflows/Build/badge.svg)
+[![Build](https://github.com/rxhanson/Rectangle/actions/workflows/build.yml/badge.svg)](https://github.com/rxhanson/Rectangle/actions/workflows/build.yml)
 [![Monthly downloads](https://badgen.net/homebrew/cask/dm/rectangle)](https://formulae.brew.sh/cask/rectangle)
 
 Rectangle is a window management app based on Spectacle, written in Swift.
@@ -38,8 +38,8 @@ Drag a window to the edge of the screen. When the mouse cursor reaches the edge 
 
 ### Ignore an app
 
-   1. Focus the app that you want to ignore (make a window from that app frontmost).
-   2. Open the Rectangle menu and select "Ignore app"
+1. Focus the app that you want to ignore (make a window from that app frontmost).
+1. Open the Rectangle menu and select "Ignore app"
 
 ## Terminal Commands for Hidden Preferences
 


### PR DESCRIPTION
Building on the fine work by @Aaron-Rumpler in #812 - this bumps the actions to `@v3` major versions.

Also regenerated the `Build` button using GitHub's own "Create status badge" UI, which adds a URL to make button link to workflow run log page.