### PR TITLE
Add Japanese localization about state manager

### DIFF
--- a/Rectangle/ja.lproj/Main.strings
+++ b/Rectangle/ja.lproj/Main.strings
@@ -709,7 +709,7 @@
 "q9C-qZ-xw5.title" = "ToDoモードのウィンドウ配置を復元するには、ToDoモードのときに、Rectangleのメニューにある\"ToDoモードを再設定\"を選択するか、指定されたキーボードショートカットを押します。";
 
 /* Class = "NSTextFieldCell"; title = "Stage Manager recent apps area"; ObjectID = "ayu-YO-10p"; */
-"ayu-YO-10p.title" = "Stage Manager recent apps area";
+"ayu-YO-10p.title" = "ステージマネージャの最近使用したアプリエリア";
 
 /* Class = "NSTextFieldCell"; title = "If the area is too small, recent apps will be hidden"; ObjectID = "xE6-jw-EPt"; */
-"xE6-jw-EPt.title" = "If the area is too small, recent apps will be hidden";
+"xE6-jw-EPt.title" = "エリアが小さい場合、最近使用したアプリは非表示になります";


### PR DESCRIPTION
The wordings are adapted as much as possible to those of the official Apple website in Japan.