### PR TITLE
add quarter column snap windows

### DIFF
--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -68,6 +68,7 @@ class Defaults {
     static let shortEdgeSnapAreaSize = FloatDefault(key: "shortEdgeSnapAreaSize", defaultValue: 145)
     static let cascadeAllDeltaSize = FloatDefault(key: "cascadeAllDeltaSize", defaultValue: 30)
     static let sixthsSnapArea = OptionalBoolDefault(key: "sixthsSnapArea")
+    static let quarterColumnsSnapAera = OptionalBoolDefault(key: "quarterColumnsSnapAera")
     static let eightsSnapArea = OptionalBoolDefault(key: "eightsSnapArea")
     static let stageSize = FloatDefault(key: "stageSize", defaultValue: 190)
 

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -68,6 +68,7 @@ class Defaults {
     static let shortEdgeSnapAreaSize = FloatDefault(key: "shortEdgeSnapAreaSize", defaultValue: 145)
     static let cascadeAllDeltaSize = FloatDefault(key: "cascadeAllDeltaSize", defaultValue: 30)
     static let sixthsSnapArea = OptionalBoolDefault(key: "sixthsSnapArea")
+    static let eightsSnapArea = OptionalBoolDefault(key: "eightsSnapArea")
     static let stageSize = FloatDefault(key: "stageSize", defaultValue: 190)
 
     static var array: [Default] = [

--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -408,19 +408,21 @@ class SnappingManager {
             let quarterWidth = floor(frame.width / 4)
             
             // check first quarter column
-            if loc.x >= frame.minX && loc.x <= frame.minX + quarterWidth {
-                if Defaults.eightsSnapArea.userEnabled {
-                    if let priorAction = priorSnapArea?.action {
-                        let action: WindowAction
-                        switch priorAction {
-                        case .bottomLeft, .bottomLeftSixth, .bottomLeftEighth:
-                            action = .bottomLeftEighth
-                        default: action = .firstFourth
+            if Defaults.quarterColumnsSnapAera.userEnabled {
+                if loc.x >= frame.minX && loc.x <= frame.minX + quarterWidth {
+                    if Defaults.eightsSnapArea.userEnabled {
+                        if let priorAction = priorSnapArea?.action {
+                            let action: WindowAction
+                            switch priorAction {
+                            case .bottomLeft, .bottomLeftSixth, .bottomLeftEighth:
+                                action = .bottomLeftEighth
+                            default: action = .firstFourth
+                            }
+                            return SnapArea(screen: screen, action: action)
                         }
-                        return SnapArea(screen: screen, action: action)
                     }
+                    return SnapArea(screen: screen, action: .firstFourth)
                 }
-                return SnapArea(screen: screen, action: .firstFourth)
             }
             
             // check first third column
@@ -440,25 +442,27 @@ class SnappingManager {
             }
             
             // check second quarter column
-            if loc.x >= frame.minX + quarterWidth && loc.x <= frame.maxX - quarterWidth*2{
-                if let priorAction = priorSnapArea?.action {
-                    let action: WindowAction
-                    switch priorAction {
-                    case .firstFourth, .leftHalf:
-                        action = .firstThreeFourths
-                    case .lastFourth, .rightHalf:
-                        action = .lastThreeFourths
-                    case .bottomLeftEighth, .bottomRightEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth:
-                        if Defaults.eightsSnapArea.userEnabled {
-                            action = .bottomCenterLeftEighth
-                        } else {
-                            action = .secondFourth
+            if Defaults.quarterColumnsSnapAera.userEnabled {
+                if loc.x >= frame.minX + quarterWidth && loc.x <= frame.maxX - quarterWidth*2{
+                    if let priorAction = priorSnapArea?.action {
+                        let action: WindowAction
+                        switch priorAction {
+                        case .firstFourth, .leftHalf:
+                            action = .firstThreeFourths
+                        case .lastFourth, .rightHalf:
+                            action = .lastThreeFourths
+                        case .bottomLeftEighth, .bottomRightEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth:
+                            if Defaults.eightsSnapArea.userEnabled {
+                                action = .bottomCenterLeftEighth
+                            } else {
+                                action = .secondFourth
+                            }
+                        default: action = .secondFourth
                         }
-                    default: action = .secondFourth
+                        return SnapArea(screen: screen, action: action)
                     }
-                    return SnapArea(screen: screen, action: action)
+                    return SnapArea(screen: screen, action: .secondFourth)
                 }
-                return SnapArea(screen: screen, action: .secondFourth)
             }
             
             // check second third column
@@ -484,25 +488,27 @@ class SnappingManager {
             }
             
             // check third quarter column
-            if loc.x >= frame.minX + quarterWidth*2  && loc.x <= frame.maxX - quarterWidth {
-                if let priorAction = priorSnapArea?.action {
-                    let action: WindowAction
-                    switch priorAction {
-                    case .firstFourth, .leftHalf:
-                        action = .firstThreeFourths
-                    case .lastFourth, .rightHalf:
-                        action = .lastThreeFourths
-                    case .bottomLeftEighth, .bottomRightEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth:
-                        if Defaults.eightsSnapArea.userEnabled {
-                            action = .bottomCenterRightEighth
-                        } else {
-                            action = .thirdFourth
+            if Defaults.quarterColumnsSnapAera.userEnabled {
+                if loc.x >= frame.minX + quarterWidth*2  && loc.x <= frame.maxX - quarterWidth {
+                    if let priorAction = priorSnapArea?.action {
+                        let action: WindowAction
+                        switch priorAction {
+                        case .firstFourth, .leftHalf:
+                            action = .firstThreeFourths
+                        case .lastFourth, .rightHalf:
+                            action = .lastThreeFourths
+                        case .bottomLeftEighth, .bottomRightEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth:
+                            if Defaults.eightsSnapArea.userEnabled {
+                                action = .bottomCenterRightEighth
+                            } else {
+                                action = .thirdFourth
+                            }
+                        default: action = .thirdFourth
                         }
-                    default: action = .thirdFourth
+                        return SnapArea(screen: screen, action: action)
                     }
-                    return SnapArea(screen: screen, action: action)
+                    return SnapArea(screen: screen, action: .thirdFourth)
                 }
-                return SnapArea(screen: screen, action: .thirdFourth)
             }
             
             // check third third column
@@ -522,19 +528,21 @@ class SnappingManager {
             }
             
             // check fourth quarther column
-            if loc.x >= frame.minX + quarterWidth*2 && loc.x <= frame.maxX {
-                if Defaults.eightsSnapArea.userEnabled {
-                    if let priorAction = priorSnapArea?.action {
-                        let action: WindowAction
-                        switch priorAction {
-                        case .bottomRight, .bottomRightSixth, .bottomCenterSixth, .bottomCenterRightEighth, .bottomRightEighth:
-                            action = .bottomRightEighth
-                        default: action = .lastFourth
+            if Defaults.quarterColumnsSnapAera.userEnabled {
+                if loc.x >= frame.minX + quarterWidth*2 && loc.x <= frame.maxX {
+                    if Defaults.eightsSnapArea.userEnabled {
+                        if let priorAction = priorSnapArea?.action {
+                            let action: WindowAction
+                            switch priorAction {
+                            case .bottomRight, .bottomRightSixth, .bottomCenterSixth, .bottomCenterRightEighth, .bottomRightEighth:
+                                action = .bottomRightEighth
+                            default: action = .lastFourth
+                            }
+                            return SnapArea(screen: screen, action: action)
                         }
-                        return SnapArea(screen: screen, action: action)
                     }
+                    return SnapArea(screen: screen, action: .lastFourth)
                 }
-                return SnapArea(screen: screen, action: .lastFourth)
             }
         }
         return nil

--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -405,6 +405,25 @@ class SnappingManager {
         
         if loc.y >= frame.minY && loc.y < frame.minY + marginBottom && !ignoredSnapAreas.contains(.bottom) {
             let thirdWidth = floor(frame.width / 3)
+            let quarterWidth = floor(frame.width / 4)
+            
+            // check first quarter column
+            if loc.x >= frame.minX && loc.x <= frame.minX + quarterWidth {
+                if Defaults.eightsSnapArea.userEnabled {
+                    if let priorAction = priorSnapArea?.action {
+                        let action: WindowAction
+                        switch priorAction {
+                        case .bottomLeft, .bottomLeftSixth, .bottomLeftEighth:
+                            action = .bottomLeftEighth
+                        default: action = .firstFourth
+                        }
+                        return SnapArea(screen: screen, action: action)
+                    }
+                }
+                return SnapArea(screen: screen, action: .firstFourth)
+            }
+            
+            // check first third column
             if loc.x >= frame.minX && loc.x <= frame.minX + thirdWidth {
                 if Defaults.sixthsSnapArea.userEnabled {
                     if let priorAction = priorSnapArea?.action {
@@ -419,6 +438,30 @@ class SnappingManager {
                 }
                 return SnapArea(screen: screen, action: .firstThird)
             }
+            
+            // check second quarter column
+            if loc.x >= frame.minX + quarterWidth && loc.x <= frame.maxX - quarterWidth*2{
+                if let priorAction = priorSnapArea?.action {
+                    let action: WindowAction
+                    switch priorAction {
+                    case .firstFourth, .leftHalf:
+                        action = .firstThreeFourths
+                    case .lastFourth, .rightHalf:
+                        action = .lastThreeFourths
+                    case .bottomLeftEighth, .bottomRightEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth:
+                        if Defaults.eightsSnapArea.userEnabled {
+                            action = .bottomCenterLeftEighth
+                        } else {
+                            action = .secondFourth
+                        }
+                    default: action = .secondFourth
+                    }
+                    return SnapArea(screen: screen, action: action)
+                }
+                return SnapArea(screen: screen, action: .secondFourth)
+            }
+            
+            // check second third column
             if loc.x >= frame.minX + thirdWidth && loc.x <= frame.maxX - thirdWidth{
                 if let priorAction = priorSnapArea?.action {
                     let action: WindowAction
@@ -439,7 +482,31 @@ class SnappingManager {
                 }
                 return SnapArea(screen: screen, action: .centerThird)
             }
-            if loc.x >= frame.minX + thirdWidth && loc.x <= frame.maxX {
+            
+            // check third quarter column
+            if loc.x >= frame.minX + quarterWidth*2  && loc.x <= frame.maxX - quarterWidth {
+                if let priorAction = priorSnapArea?.action {
+                    let action: WindowAction
+                    switch priorAction {
+                    case .firstFourth, .leftHalf:
+                        action = .firstThreeFourths
+                    case .lastFourth, .rightHalf:
+                        action = .lastThreeFourths
+                    case .bottomLeftEighth, .bottomRightEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth:
+                        if Defaults.eightsSnapArea.userEnabled {
+                            action = .bottomCenterRightEighth
+                        } else {
+                            action = .thirdFourth
+                        }
+                    default: action = .thirdFourth
+                    }
+                    return SnapArea(screen: screen, action: action)
+                }
+                return SnapArea(screen: screen, action: .thirdFourth)
+            }
+            
+            // check third third column
+            if loc.x >= frame.minX + thirdWidth && loc.x <= frame.maxX - quarterWidth/2 {
                 if Defaults.sixthsSnapArea.userEnabled {
                     if let priorAction = priorSnapArea?.action {
                         let action: WindowAction
@@ -452,6 +519,22 @@ class SnappingManager {
                     }
                 }
                 return SnapArea(screen: screen, action: .lastThird)
+            }
+            
+            // check fourth quarther column
+            if loc.x >= frame.minX + quarterWidth*2 && loc.x <= frame.maxX {
+                if Defaults.eightsSnapArea.userEnabled {
+                    if let priorAction = priorSnapArea?.action {
+                        let action: WindowAction
+                        switch priorAction {
+                        case .bottomRight, .bottomRightSixth, .bottomCenterSixth, .bottomCenterRightEighth, .bottomRightEighth:
+                            action = .bottomRightEighth
+                        default: action = .lastFourth
+                        }
+                        return SnapArea(screen: screen, action: action)
+                    }
+                }
+                return SnapArea(screen: screen, action: .lastFourth)
             }
         }
         return nil

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -313,6 +313,28 @@ defaults write com.knollsoft.Rectangle sixthsSnapArea -bool true
 
 Once enabled, you can drag a window to the corner, then move it along the edge towards the thirds area to snap to a sixth.
 
+## Enabling snap areas for quarter columns
+
+To enable snap areas for quarter columns and not just thirds, execute: 
+
+```bash
+defaults write com.knollsoft.Rectangle quarterColumnsSnapAera -bool true
+```
+
+Once enabled, you can drag a window to the bottom, like you would do for thirds anyway, but now you have the option to snap to quarters OR thirds.
+
+
+## Enabling snap areas for eights
+
+To enable snap areas for eight corners, execute: 
+
+```bash
+defaults write com.knollsoft.Rectangle eightsSnapArea -bool true
+```
+
+Once enabled, you can drag a window to the corner, then move it along the edge towards the thirds area to snap to a eight.
+
+
 ## Move cursor with window
 
 There's an option in the UI for moving the cursor with the window when going across displays, but here's an option for moving it with any shortcut:


### PR DESCRIPTION
Adding seemless support for snapping to thrids and quarterWidth snap areas.

This might sound a bit stupid at first, but here I am:
I recently got a super ultra-wide screen (49" 32:9) as my main screen and I use my "old" ultra-wide screen (34" 21:9) as a second monitor stacked on top of the super ultra-wide one.
The problem I'm facing is, while the thirds snap areas work extremely well on the ultra-wide screen, they are just too big for my super ultra-wide screen. I would prefer to have quarters instead.
I looked around with other software, but turns out: no other software supports snap-areas for quarter columns. Magnet does thirds and sixths columns (but I only noticed this after purchasing it).

Since Rectangle is OpenSource I decided to just try and implement the quarter snap areas myself and see if I can make it work. Turns out: I somehow made it work 🤣 
I hid  the quarter snap areas behind a feature-flag that needs manual enabling, since I suspect most people will use standard wide screens (16:9) or at best ultra-wide screens and therefore won't really need or want this feature.

Let me know what you think about it and please let me know if the code(-style/-quality) is okay. 
Actually, I never wrote a single line of Swift in my life before. But this bothered me so much, that I decided to just give it a shot.

Cheers,
Cedric