### PR TITLE
Stage Manager: avoid footprint window being moved

### DIFF
--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -226,8 +226,9 @@ class SnappingManager {
                         if box == nil {
                             box = FootprintWindow()
                         }
-                        box?.setFrame(newBoxRect, display: true)
+                        box?.setFrame(.zero, display: false)
                         box?.makeKeyAndOrderFront(nil)
+                        box?.setFrame(newBoxRect, display: true)
                     }
                     
                     currentSnapArea = snapArea


### PR DESCRIPTION
When Stage Manager is enabled, it seems that new windows are moved away from the lateral edges of the screen, which is an issue for the footprint window. The proposed fix is to "show" the window before adjusting its frame.