### PR TITLE
Stage Manager: clean up workaround

### DIFF
--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -131,9 +131,13 @@ extension NSScreen {
         get {
             var newFrame = visibleFrame
             
-            if Defaults.stageSize.value > 0 && StageUtil.stageCapable && StageUtil.stageEnabled && StageUtil.stageStripShow && StageUtil.isStageStripVisible() {
-                if StageUtil.stageStripPosition == .left { newFrame.origin.x += Defaults.stageSize.cgFloat }
-                newFrame.size.width -= Defaults.stageSize.cgFloat
+            if Defaults.stageSize.value > 0 {
+                if StageUtil.stageCapable && StageUtil.stageEnabled && StageUtil.stageStripShow && StageUtil.getStageStripWindowGroups().count > 0 {
+                    if StageUtil.stageStripPosition == .left {
+                        newFrame.origin.x += Defaults.stageSize.cgFloat
+                    }
+                    newFrame.size.width -= Defaults.stageSize.cgFloat
+                }
             }
 
             if Defaults.todo.userEnabled, Defaults.todoMode.enabled, TodoManager.todoScreen == self {

--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -173,10 +173,8 @@ class SnappingManager {
             }
         }
         if let windowId = windowId {
-            if StageUtil.stageCapable && StageUtil.stageEnabled && StageUtil.isStageStripVisible() {
-                if (StageUtil.getStageStripGroups().contains { $0.windowIds.contains(windowId) }) {
-                    return false
-                }
+            if StageUtil.stageCapable && StageUtil.stageEnabled && StageUtil.getStageStripWindowGroup(windowId) != nil {
+                return false
             }
         }
         return true

--- a/Rectangle/Utilities/AXExtension.swift
+++ b/Rectangle/Utilities/AXExtension.swift
@@ -16,13 +16,14 @@ extension AXValue {
     func toValue<T>() -> T? {
         let pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
         let success = AXValueGetValue(self, AXValueGetType(self), pointer)
-        return success ? pointer.pointee : nil
+        let value = pointer.pointee
+        pointer.deallocate()
+        return success ? value : nil
     }
     
     static func from<T>(value: T, type: AXValueType) -> AXValue? {
-        let pointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
-        pointer.pointee = value
-        return AXValueCreate(type, pointer)
+        var value = value
+        return AXValueCreate(type, &value)
     }
 }
 

--- a/Rectangle/Utilities/StageUtil.swift
+++ b/Rectangle/Utilities/StageUtil.swift
@@ -25,39 +25,30 @@ class StageUtil {
         return !defaults.bool(forKey: "AutoHide")
     }
     
-    static func isStageStripVisible() -> Bool {
-        let infos = WindowUtil.getWindowList().filter { $0.bundleIdentifier == "com.apple.WindowManager" }
-        // A single window could be for the dragged window
-        return infos.count >= 2
-    }
-    
     static var stageStripPosition: StageStripPosition {
         guard let defaults = UserDefaults(suiteName: "com.apple.dock"), defaults.object(forKey: "orientation") != nil
         else { return .left }
         return defaults.string(forKey: "orientation") == "left" ? .right : .left
     }
     
-    static func getStageStripGroups() -> [StageStripGroup] {
-        var groups = [StageStripGroup]()
+    static func getStageStripWindowGroups() -> [[CGWindowID]] {
+        var groups = [[CGWindowID]]()
         if let appElement = AccessibilityElement("com.apple.WindowManager"),
            let groupElements = appElement.getChildElement(.group)?.getChildElement(.list)?.getChildElements(.button) {
             for groupElement in groupElements {
-                let frame = groupElement.frame
-                guard !frame.isNull, let windowIds = groupElement.windowIds else { continue }
-                let group = StageStripGroup(frame: frame, windowIds: windowIds)
-                groups.append(group)
+                guard let windowIds = groupElement.windowIds else { continue }
+                groups.append(windowIds)
             }
         }
         return groups
+    }
+    
+    static func getStageStripWindowGroup(_ windowId: CGWindowID) -> [CGWindowID]? {
+        return getStageStripWindowGroups().first { $0.contains(windowId) }
     }
 }
 
 enum StageStripPosition {
     case left
     case right
-}
-
-struct StageStripGroup {
-    let frame: CGRect
-    let windowIds: [CGWindowID]
 }

--- a/Rectangle/Utilities/WindowUtil.swift
+++ b/Rectangle/Utilities/WindowUtil.swift
@@ -29,11 +29,10 @@ class WindowUtil {
             for i in 0..<count {
                 let dictionary = array.getValue(i) as CFDictionary
                 let id = dictionary.getValue(kCGWindowNumber) as CFNumber
-                let layer = dictionary.getValue(kCGWindowLayer) as CFNumber
                 let frame = (dictionary.getValue(kCGWindowBounds) as CFDictionary).toRect()
                 let pid = dictionary.getValue(kCGWindowOwnerPID) as CFNumber
                 if let frame = frame {
-                    let info = WindowInfo(id: id as! CGWindowID, layer: layer as! Int, frame: frame, pid: pid as! pid_t)
+                    let info = WindowInfo(id: id as! CGWindowID, frame: frame, pid: pid as! pid_t)
                     infos.append(info)
                 }
             }
@@ -45,7 +44,6 @@ class WindowUtil {
 
 struct WindowInfo {
     let id: CGWindowID
-    let layer: Int
     let frame: CGRect
     let pid: pid_t
     var bundleIdentifier: String? { NSRunningApplication(processIdentifier: pid)?.bundleIdentifier }


### PR DESCRIPTION
It seems to be unnecessary for the main window since at least the release of macOS 13.