### PR TITLE
Allow configuration option for stageSize to be treated as a percentage if less than 1

### DIFF
--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -69,7 +69,7 @@ class Defaults {
     static let cascadeAllDeltaSize = FloatDefault(key: "cascadeAllDeltaSize", defaultValue: 30)
     static let sixthsSnapArea = OptionalBoolDefault(key: "sixthsSnapArea")
     static let stageSize = FloatDefault(key: "stageSize", defaultValue: 190)
-    static let stagePercentageWidth = IntDefault(key: "stagePercentageWidth", defaultValue: 10)
+    static let stagePercentageWidth = IntDefault(key: "stagePercentageWidth", defaultValue: 0)
     static let dragFromStage = OptionalBoolDefault(key: "dragFromStage")
     static let landscapeSnapAreas = JSONDefault<[Directional:SnapAreaConfig]>(key: "landscapeSnapAreas")
     static let portraitSnapAreas = JSONDefault<[Directional:SnapAreaConfig]>(key: "portraitSnapAreas")

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -69,6 +69,7 @@ class Defaults {
     static let cascadeAllDeltaSize = FloatDefault(key: "cascadeAllDeltaSize", defaultValue: 30)
     static let sixthsSnapArea = OptionalBoolDefault(key: "sixthsSnapArea")
     static let stageSize = FloatDefault(key: "stageSize", defaultValue: 190)
+    static let stagePercentageWidth = IntDefault(key: "stagePercentageWidth", defaultValue: 10)
     static let dragFromStage = OptionalBoolDefault(key: "dragFromStage")
     static let landscapeSnapAreas = JSONDefault<[Directional:SnapAreaConfig]>(key: "landscapeSnapAreas")
     static let portraitSnapAreas = JSONDefault<[Directional:SnapAreaConfig]>(key: "portraitSnapAreas")
@@ -137,6 +138,7 @@ class Defaults {
         cascadeAllDeltaSize,
         sixthsSnapArea,
         stageSize,
+        stagePercentageWidth,
         dragFromStage,
         landscapeSnapAreas,
         portraitSnapAreas,

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -69,7 +69,6 @@ class Defaults {
     static let cascadeAllDeltaSize = FloatDefault(key: "cascadeAllDeltaSize", defaultValue: 30)
     static let sixthsSnapArea = OptionalBoolDefault(key: "sixthsSnapArea")
     static let stageSize = FloatDefault(key: "stageSize", defaultValue: 190)
-    static let stagePercentageWidth = IntDefault(key: "stagePercentageWidth", defaultValue: 0)
     static let dragFromStage = OptionalBoolDefault(key: "dragFromStage")
     static let landscapeSnapAreas = JSONDefault<[Directional:SnapAreaConfig]>(key: "landscapeSnapAreas")
     static let portraitSnapAreas = JSONDefault<[Directional:SnapAreaConfig]>(key: "portraitSnapAreas")
@@ -138,7 +137,6 @@ class Defaults {
         cascadeAllDeltaSize,
         sixthsSnapArea,
         stageSize,
-        stagePercentageWidth,
         dragFromStage,
         landscapeSnapAreas,
         portraitSnapAreas,

--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -131,12 +131,17 @@ extension NSScreen {
         get {
             var newFrame = visibleFrame
             
-            if Defaults.stageSize.value > 0 {
+            if Defaults.stageSize.value > 0 || Defaults.stagePercentageWidth.value > 0 {
                 if StageUtil.stageCapable && StageUtil.stageEnabled && StageUtil.stageStripShow && StageUtil.getStageStripWindowGroups().count > 0 {
+                    let percentageInt = Defaults.stagePercentageWidth.value > 100 ? 100 : Defaults.stagePercentageWidth.value
+                    let adjustValue = Defaults.stageSize.value > 0
+                        ? Defaults.stageSize.cgFloat
+                        : CGFloat(newFrame.size.width * CGFloat((percentageInt / 100)))
+                    
                     if StageUtil.stageStripPosition == .left {
-                        newFrame.origin.x += Defaults.stageSize.cgFloat
+                        newFrame.origin.x += adjustValue
                     }
-                    newFrame.size.width -= Defaults.stageSize.cgFloat
+                    newFrame.size.width -= adjustValue
                 }
             }
 

--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -131,11 +131,10 @@ extension NSScreen {
         get {
             var newFrame = visibleFrame
             
-            if Defaults.stageSize.value > 0 || Defaults.stagePercentageWidth.value > 0 {
+            if Defaults.stageSize.value > 0 {
                 if StageUtil.stageCapable && StageUtil.stageEnabled && StageUtil.stageStripShow && StageUtil.getStageStripWindowGroups().count > 0 {
-                    let percentageInt = Defaults.stagePercentageWidth.value > 100 ? 100 : Defaults.stagePercentageWidth.value
-                    let adjustValue = percentageInt > 0
-                        ? CGFloat(newFrame.size.width * CGFloat((percentageInt / 100)))
+                    let adjustValue = Defaults.stageSize.value < 1
+                        ? newFrame.size.width * Defaults.stageSize.cgFloat
                         : Defaults.stageSize.cgFloat
                     
                     if StageUtil.stageStripPosition == .left {

--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -133,14 +133,14 @@ extension NSScreen {
             
             if Defaults.stageSize.value > 0 {
                 if StageUtil.stageCapable && StageUtil.stageEnabled && StageUtil.stageStripShow && StageUtil.getStageStripWindowGroups().count > 0 {
-                    let adjustValue = Defaults.stageSize.value < 1
+                    let stageSize = Defaults.stageSize.value < 1
                         ? newFrame.size.width * Defaults.stageSize.cgFloat
                         : Defaults.stageSize.cgFloat
                     
                     if StageUtil.stageStripPosition == .left {
-                        newFrame.origin.x += adjustValue
+                        newFrame.origin.x += stageSize
                     }
-                    newFrame.size.width -= adjustValue
+                    newFrame.size.width -= stageSize 
                 }
             }
 

--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -134,9 +134,9 @@ extension NSScreen {
             if Defaults.stageSize.value > 0 || Defaults.stagePercentageWidth.value > 0 {
                 if StageUtil.stageCapable && StageUtil.stageEnabled && StageUtil.stageStripShow && StageUtil.getStageStripWindowGroups().count > 0 {
                     let percentageInt = Defaults.stagePercentageWidth.value > 100 ? 100 : Defaults.stagePercentageWidth.value
-                    let adjustValue = Defaults.stageSize.value > 0
-                        ? Defaults.stageSize.cgFloat
-                        : CGFloat(newFrame.size.width * CGFloat((percentageInt / 100)))
+                    let adjustValue = percentageInt > 0
+                        ? CGFloat(newFrame.size.width * CGFloat((percentageInt / 100)))
+                        : Defaults.stageSize.cgFloat
                     
                     if StageUtil.stageStripPosition == .left {
                         newFrame.origin.x += adjustValue

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -76,6 +76,20 @@ Note that if subsequent execution mode is set to cycle displays when this is ena
 defaults write com.knollsoft.Rectangle resizeOnDirectionalMove -bool true
 ```
 
+## Adjust macOS Ventura Stage Manager size
+
+By default, the Stage Manager area will be set to 190, if enabled.
+
+```bash
+defaults write com.knollsoft.Rectangle stageSize -float <VALUE>
+```
+
+To set it to a proportion of your screen's width, set it to a value between 0 and 1.
+
+```bash
+defaults write com.knollsoft.Rectangle stageSize -float <VALUE_BETWEEN_0_AND_1>
+```
+
 ## Enable Todo Mode
 
 See the [wiki](https://github.com/rxhanson/Rectangle/wiki/Todo-Mode) for more info.


### PR DESCRIPTION
Hi!

Love this app, thanks for all your work on this. 

Since macOS Ventura, I️ am a huge fan of Stage Manager, but I️ switch from my desktop monitor setup to my laptop quite often. With the screens being vastly different sizes, the absolute pixel width value that Rectangle currently allows for is too much when using my laptop dimensions. Like, setting it to the perfect width when on my monitor resulted in the stage area being too large on my laptop. 

This PR adds an option to set a percentage of the screen width rather than a simple absolute value. If the percentage is set (defaults to 0), it is used over any set "stageSize" value. I️ did not add UI for this, as it is quite niche, just a reference from the config file if set. 

Locally my build works fine, but I️ was _not_ able to fully test as I️ couldn't get the debug .app file to be authorized via Accessibility (probably due to me having the release Rectangle installed as well).

Let me know if there are any issues or questions! I️ would absolutely love if this got shipped, it's been driving me nuts!