### PR TITLE
Add link to Mac keyboard shortcut guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install --cask rectangle
 
 ## How to use it
 
-The keyboard shortcuts are self explanatory, but the snap areas can use some explanation if you've never used them on Windows or other window management apps.
+The [keyboard shortcuts](https://support.apple.com/guide/mac-help/what-are-those-symbols-shown-in-menus-cpmh0011/mac) are self explanatory, but the snap areas can use some explanation if you've never used them on Windows or other window management apps.
 
 Drag a window to the edge of the screen. When the mouse cursor reaches the edge of the screen, you'll see a footprint that Rectangle will attempt to resize and move the window to when the click is released.
 


### PR DESCRIPTION
Adds a link to the keyboard shortcuts guide to make it easier to see what key each shortcut maps to.