### PR TITLE
add action cascadeActiveApp; add cascadeActiveAppWindowsOnScreen

### DIFF
--- a/Rectangle/MultiWindow/MultiWindowManager.swift
+++ b/Rectangle/MultiWindow/MultiWindowManager.swift
@@ -124,12 +124,23 @@ class MultiWindowManager {
 
         let delta = CGFloat(Defaults.cascadeAllDeltaSize.value)
 
-        for (ind, w) in windows.enumerated() {
-            if let pid = w.pid {
-                if pid == frontWindowElement.pid {
-                    cascadeWindow(w, screenFrame: screenFrame, delta: delta, index: ind)
-                }
-            }
+        // keep windows with a pid equal to the front window's pid
+        var filtered = windows.filter(hasFrontWindowPid(_:))
+
+        // move the first to become the last
+        if let first = filtered.first, hasFrontWindowPid(first) {
+            filtered.removeFirst()
+            filtered.append(first)
+        }
+
+        // cascade the filtered windows
+        for (ind, w) in filtered.enumerated() {
+            cascadeWindow(w, screenFrame: screenFrame, delta: delta, index: ind)
+        }
+
+        // func returning true for a pid equal to the front window's pid
+        func hasFrontWindowPid(_ w: AccessibilityElement) -> Bool {
+            return w.pid == frontWindowElement.pid
         }
     }
 

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -82,7 +82,8 @@ enum WindowAction: Int, Codable {
     tileAll = 66,
     cascadeAll = 67,
     leftTodo = 68,
-    rightTodo = 69
+    rightTodo = 69,
+    cascadeActiveApp = 70
 
     // Order matters here - it's used in the menu
     static let active = [leftHalf, rightHalf, centerHalf, topHalf, bottomHalf,
@@ -101,7 +102,8 @@ enum WindowAction: Int, Codable {
                          topLeftEighth, topCenterLeftEighth, topCenterRightEighth, topRightEighth,
                          bottomLeftEighth, bottomCenterLeftEighth, bottomCenterRightEighth, bottomRightEighth,
                          tileAll, cascadeAll,
-                         leftTodo, rightTodo
+                         leftTodo, rightTodo,
+                         cascadeActiveApp
     ]
 
     func post() {
@@ -202,6 +204,7 @@ enum WindowAction: Int, Codable {
         case .cascadeAll: return "cascadeAll"
         case .leftTodo: return "leftTodo"
         case .rightTodo: return "rightTodo"
+        case .cascadeActiveApp: return "cascadeActiveApp"
         }
     }
 
@@ -334,7 +337,7 @@ enum WindowAction: Int, Codable {
         case .topLeftEighth, .topCenterLeftEighth, .topCenterRightEighth, .topRightEighth,
                 .bottomLeftEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth, .bottomRightEighth:
             return nil
-        case .specified, .reverseAll, .tileAll, .cascadeAll, .leftTodo, .rightTodo:
+        case .specified, .reverseAll, .tileAll, .cascadeAll, .leftTodo, .rightTodo, .cascadeActiveApp:
             return nil
         }
 
@@ -362,7 +365,7 @@ enum WindowAction: Int, Codable {
     
     var isDragSnappable: Bool {
         switch self {
-        case .restore, .previousDisplay, .nextDisplay, .moveUp, .moveDown, .moveLeft, .moveRight, .specified, .reverseAll, .tileAll, .cascadeAll, .smaller, .larger,
+        case .restore, .previousDisplay, .nextDisplay, .moveUp, .moveDown, .moveLeft, .moveRight, .specified, .reverseAll, .tileAll, .cascadeAll, .smaller, .larger, .cascadeActiveApp,
             // Ninths
             .topLeftNinth, .topCenterNinth, .topRightNinth, .middleLeftNinth, .middleCenterNinth, .middleRightNinth, .bottomLeftNinth, .bottomCenterNinth, .bottomRightNinth,
             // Corner thirds
@@ -491,6 +494,7 @@ enum WindowAction: Int, Codable {
         case .cascadeAll: return NSImage()
         case .leftTodo: return NSImage()
         case .rightTodo: return NSImage()
+        case .cascadeActiveApp: return NSImage()
         }
     }
 
@@ -531,7 +535,7 @@ enum WindowAction: Int, Codable {
             return Defaults.applyGapsToMaximize.userDisabled ? .none : .both;
         case .maximizeHeight:
             return Defaults.applyGapsToMaximizeHeight.userDisabled ? .none : .vertical;
-        case .almostMaximize, .previousDisplay, .nextDisplay, .larger, .smaller, .center, .restore, .specified, .reverseAll, .tileAll, .cascadeAll:
+        case .almostMaximize, .previousDisplay, .nextDisplay, .larger, .smaller, .center, .restore, .specified, .reverseAll, .tileAll, .cascadeAll, .cascadeActiveApp:
             return .none
         }
     }

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -16,6 +16,7 @@ The preferences window is purposefully slim, but there's a lot that can be modif
 - [Add extra "ninths" sizing commands](#add-extra-ninths-sizing-commands)
 - [Add extra "eighths" sizing commands](#add-extra-eighths-sizing-commands)
 - [Add additional "thirds" sizing commands](#add-additional-thirds-sizing-commands)
+- [Add additional tiling and cascading commands](#add-additional-tiling-and-cascading-commands)
 - [Modify the "footprint" displayed for drag to snap area](#modify-the-footprint-displayed-for-drag-to-snap-area)
 - [Move Up/Down/Left/Right: Don't center on edge](#move-updownleftright-dont-center-on-edge)
 - [Make Smaller limits](#make-smaller-limits)
@@ -203,6 +204,26 @@ For example, the command for setting the top left two-thirds shortcut to `ctrl o
 
 ```bash
 defaults write com.knollsoft.Rectangle topLeftThird -dict-add keyCode -float 18 modifierFlags -float 917504
+```
+
+## Add additional tiling and cascading commands
+
+Commands for tiling and cascading the visible windows are not available in the UI but can be configured via CLI.
+
+The key codes are:
+
+* tileAll
+* cascadeAll
+* cascadeActiveApp
+
+_tileAll_ and _cascadeAll_ act on all visible windows.
+
+_cascadeActiveApp_ cascades and brings to the front only windows belonging too the currently active (foremost) app, leaving all other windows alonne.
+
+For example, the command for setting the cascadeActiveApp shortcut to `ctrl shift 2` would be:
+
+```bash
+defaults write com.knollsoft.Rectangle cascadeActiveApp -dict-add keyCode -float 2 modifierFlags -float 393475
 ```
 
 ## Modify the "footprint" displayed for drag to snap area


### PR DESCRIPTION
Changes:
- enum `WindowAction`: add `case cascadeActiveApp` and update functions that handle the cases
- `class MultiWindowManager`: add `cascadeActiveAppWindowsOnScreen()` and a call from `execute()`
- `TerminalCommands.md`: add section `## Add additional tiling and cascading commands`

@rxhanson @dirondin 

Please review the proposed changes and test them.

I tested the debug build on my Intel Mac (2017), and it works to my satisfaction.

Let me know if I missed anything. Kudos to both of you for the clean and understandable code, easy to extend.

@rudifa