### PR TITLE
Add centerProminently command

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		6490B39D27BF984D0056C220 /* BottomCenterLeftEighthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6490B39C27BF984D0056C220 /* BottomCenterLeftEighthCalculation.swift */; };
 		6490B39F27BF98840056C220 /* BottomCenterRightEighthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6490B39E27BF98840056C220 /* BottomCenterRightEighthCalculation.swift */; };
 		6490B3A127BF98C70056C220 /* BottomRightEighthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6490B3A027BF98C70056C220 /* BottomRightEighthCalculation.swift */; };
+		729E0A982AFF76B1006E2F48 /* CenterProminentlyCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729E0A972AFF76B1006E2F48 /* CenterProminentlyCalculation.swift */; };
 		866661F2257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */; };
 		9818E00D28B59205004AA524 /* CompoundSnapArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9818E00C28B59205004AA524 /* CompoundSnapArea.swift */; };
 		9818E01028B59396004AA524 /* HalvesCompoundCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9818E00F28B59396004AA524 /* HalvesCompoundCalculation.swift */; };
@@ -180,6 +181,7 @@
 		6490B39C27BF984D0056C220 /* BottomCenterLeftEighthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomCenterLeftEighthCalculation.swift; sourceTree = "<group>"; };
 		6490B39E27BF98840056C220 /* BottomCenterRightEighthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomCenterRightEighthCalculation.swift; sourceTree = "<group>"; };
 		6490B3A027BF98C70056C220 /* BottomRightEighthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomRightEighthCalculation.swift; sourceTree = "<group>"; };
+		729E0A972AFF76B1006E2F48 /* CenterProminentlyCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterProminentlyCalculation.swift; sourceTree = "<group>"; };
 		866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatedExecutionsInThirdsCalculation.swift; sourceTree = "<group>"; };
 		9808018523D05C0B0077774A /* RectangleRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RectangleRelease.entitlements; sourceTree = "<group>"; };
 		9808018623D05C1F0077774A /* RectangleLauncherRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RectangleLauncherRelease.entitlements; sourceTree = "<group>"; };
@@ -406,6 +408,7 @@
 				9821402022B3884600ABFB3F /* BottomHalfCalculation.swift */,
 				9821403022B38A0500ABFB3F /* TopHalfCalculation.swift */,
 				9821402222B3886100ABFB3F /* CenterCalculation.swift */,
+				729E0A972AFF76B1006E2F48 /* CenterProminentlyCalculation.swift */,
 				9821402422B3887200ABFB3F /* MaximizeCalculation.swift */,
 				9821402622B3888100ABFB3F /* ChangeSizeCalculation.swift */,
 				9821402822B3889100ABFB3F /* LowerLeftCalculation.swift */,
@@ -866,6 +869,7 @@
 				9821402722B3888100ABFB3F /* ChangeSizeCalculation.swift in Sources */,
 				6490B39927BF97BB0056C220 /* TopCenterRightEighthCalculation.swift in Sources */,
 				98B3559823CE025700E410E0 /* CenteringFixedSizedWindowMover.swift in Sources */,
+				729E0A982AFF76B1006E2F48 /* CenterProminentlyCalculation.swift in Sources */,
 				9824704E22B189250037B409 /* QuantizedWindowMover.swift in Sources */,
 				AA536C2729005DD000579AC6 /* TimeoutCache.swift in Sources */,
 				D04CE30627817A8400BD47B3 /* MiddleLeftNinthCalculation.swift in Sources */,

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -90,7 +90,7 @@ enum WindowAction: Int, Codable {
     static let active = [leftHalf, rightHalf, centerHalf, topHalf, bottomHalf,
                          topLeft, topRight, bottomLeft, bottomRight,
                          firstThird, centerThird, lastThird, firstTwoThirds, lastTwoThirds,
-                         maximize, almostMaximize, maximizeHeight, smaller, larger, center, restore,
+                         maximize, almostMaximize, maximizeHeight, smaller, larger, center, centerProminently, restore,
                          nextDisplay, previousDisplay,
                          moveLeft, moveRight, moveUp, moveDown,
                          firstFourth, secondFourth, thirdFourth, lastFourth, firstThreeFourths, lastThreeFourths,

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -83,7 +83,8 @@ enum WindowAction: Int, Codable {
     cascadeAll = 67,
     leftTodo = 68,
     rightTodo = 69,
-    cascadeActiveApp = 70
+    cascadeActiveApp = 70,
+    centerProminently = 71
 
     // Order matters here - it's used in the menu
     static let active = [leftHalf, rightHalf, centerHalf, topHalf, bottomHalf,
@@ -205,6 +206,7 @@ enum WindowAction: Int, Codable {
         case .leftTodo: return "leftTodo"
         case .rightTodo: return "rightTodo"
         case .cascadeActiveApp: return "cascadeActiveApp"
+        case .centerProminently: return "centerProminently"
         }
     }
 
@@ -339,6 +341,8 @@ enum WindowAction: Int, Codable {
             return nil
         case .specified, .reverseAll, .tileAll, .cascadeAll, .leftTodo, .rightTodo, .cascadeActiveApp:
             return nil
+        case .centerProminently:
+            return nil
         }
 
         return NSLocalizedString(key, tableName: "Main", value: value, comment: "")
@@ -357,7 +361,7 @@ enum WindowAction: Int, Codable {
 
     var resizes: Bool {
         switch self {
-        case .center, .nextDisplay, .previousDisplay: return false
+        case .center, .centerProminently, .nextDisplay, .previousDisplay: return false
         case .moveUp, .moveDown, .moveLeft, .moveRight: return Defaults.resizeOnDirectionalMove.enabled
         default: return true
         }
@@ -495,6 +499,7 @@ enum WindowAction: Int, Codable {
         case .leftTodo: return NSImage()
         case .rightTodo: return NSImage()
         case .cascadeActiveApp: return NSImage()
+        case .centerProminently: return NSImage()
         }
     }
 
@@ -535,7 +540,7 @@ enum WindowAction: Int, Codable {
             return Defaults.applyGapsToMaximize.userDisabled ? .none : .both;
         case .maximizeHeight:
             return Defaults.applyGapsToMaximizeHeight.userDisabled ? .none : .vertical;
-        case .almostMaximize, .previousDisplay, .nextDisplay, .larger, .smaller, .center, .restore, .specified, .reverseAll, .tileAll, .cascadeAll, .cascadeActiveApp:
+        case .almostMaximize, .previousDisplay, .nextDisplay, .larger, .smaller, .center, .centerProminently, .restore, .specified, .reverseAll, .tileAll, .cascadeAll, .cascadeActiveApp:
             return .none
         }
     }

--- a/Rectangle/WindowCalculation/CenterProminentlyCalculation.swift
+++ b/Rectangle/WindowCalculation/CenterProminentlyCalculation.swift
@@ -1,0 +1,38 @@
+//
+//  CenterProminentlyCalculation.swift
+//  Rectangle
+//
+//  Copyright © 2019 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+class CenterProminentlyCalculation: WindowCalculation {
+    
+    override func calculate(_ params: WindowCalculationParameters) -> WindowCalculationResult? {
+        
+        var screenFrame: CGRect?
+        if !Defaults.alwaysAccountForStage.userEnabled {
+            screenFrame = params.usableScreens.currentScreen.adjustedVisibleFrame(params.ignoreTodo, true)
+        }
+                
+        let rectResult = calculateRect(params.asRectParams(visibleFrame: screenFrame))
+        
+        let resultingAction: WindowAction = rectResult.resultingAction ?? params.action
+
+        return WindowCalculationResult(rect: rectResult.rect,
+                                       screen: params.usableScreens.currentScreen,
+                                       resultingAction: resultingAction,
+                                       resultingScreenFrame: screenFrame)
+    }
+    
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        
+        let rectResult = WindowCalculationFactory.centerCalculation.calculateRect(params)
+        var rect = rectResult.rect
+        rect.origin.y += -0.25 * rect.height + 0.25 * params.visibleFrameOfScreen.height
+        return RectResult(rect)
+
+    }
+    
+}

--- a/Rectangle/WindowCalculation/CenterProminentlyCalculation.swift
+++ b/Rectangle/WindowCalculation/CenterProminentlyCalculation.swift
@@ -31,7 +31,7 @@ class CenterProminentlyCalculation: WindowCalculation {
         let rectResult = WindowCalculationFactory.centerCalculation.calculateRect(params)
         var rect = rectResult.rect
         rect.origin.y += -0.25 * rect.height + 0.25 * params.visibleFrameOfScreen.height
-        return RectResult(rect)
+        return RectResult(rect, resultingAction: rectResult.resultingAction)
 
     }
     

--- a/Rectangle/WindowCalculation/WindowCalculation.swift
+++ b/Rectangle/WindowCalculation/WindowCalculation.swift
@@ -128,6 +128,7 @@ class WindowCalculationFactory {
     static let bottomHalfCalculation = BottomHalfCalculation()
     static let topHalfCalculation = TopHalfCalculation()
     static let centerCalculation = CenterCalculation()
+    static let centerProminentlyCalculation = CenterProminentlyCalculation()
     static let nextPrevDisplayCalculation = NextPrevDisplayCalculation()
     static let maximizeCalculation = MaximizeCalculation()
     static let changeSizeCalculation = ChangeSizeCalculation()
@@ -194,6 +195,7 @@ class WindowCalculationFactory {
      .bottomHalf: bottomHalfCalculation,
      .topHalf: topHalfCalculation,
      .center: centerCalculation,
+     .centerProminently: centerProminentlyCalculation,
      .bottomLeft: lowerLeftCalculation,
      .bottomRight: lowerRightCalculation,
      .topLeft: upperLeftCalculation,

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -144,9 +144,24 @@ defaults write com.knollsoft.Rectangle specifiedHeight -float 1050
 defaults write com.knollsoft.Rectangle specifiedWidth -float 1680
 ```
 
+## Add an extra centering with prominence command
+
+There is an extra command that horizontally centers the window but moves up the window vertically slightly from the center to add visual weight. Similar to extra centering you will need to know which keycode and modifier flags you want.
+
+The key code is:
+
+* centerProminently
+
+For example, the command for setting the shortcut to `ctrl option command C` would be:
+
+```bash
+defaults write com.knollsoft.Rectangle centerProminently -dict-add keyCode -float 8 modifierFlags -float 1835305
+```
+
+
 ## Add extra "ninths" sizing commands
 
-Commands for resizing to screen ninths are not available in the UI.  Similar to extra centering you will need to know which keycode and modifier flags you want.
+Commands for resizing to screen ninths are not available in the UI.
 
 The key codes are:
 


### PR DESCRIPTION
Changes:

- Add a `CenterProminently` command that centers the window horizontally, but moves the window up vertically slightly from the center to give visual importance.
- Add documentation to `TerminalCommands.md`

This follows from the discussion here https://github.com/rxhanson/Rectangle/discussions/1285. Thank you for making the code easy to follow!