### PR TITLE
Add separate gap for notched display

### DIFF
--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -39,6 +39,7 @@ class Defaults {
     static let screenEdgeGapLeft = FloatDefault(key: "screenEdgeGapLeft", defaultValue: 0)
     static let screenEdgeGapRight = FloatDefault(key: "screenEdgeGapRight", defaultValue: 0)
     static let screenEdgeGapsOnMainScreenOnly = BoolDefault(key: "screenEdgeGapsOnMainScreenOnly")
+    static let screenEdgeGapTopNotch = FloatDefault(key: "screenEdgeGapTopNotch", defaultValue: 0)
     static let lastVersion = StringDefault(key: "lastVersion")
     static let showAllActionsInMenu = OptionalBoolDefault(key: "showAllActionsInMenu")
     static var SUHasLaunchedBefore: Bool { UserDefaults.standard.bool(forKey: "SUHasLaunchedBefore") }
@@ -118,6 +119,7 @@ class Defaults {
         screenEdgeGapLeft,
         screenEdgeGapRight,
         screenEdgeGapsOnMainScreenOnly,
+        screenEdgeGapTopNotch,
         showAllActionsInMenu,
         footprintAlpha,
         footprintBorderWidth,

--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -156,8 +156,18 @@ extension NSScreen {
         newFrame.origin.x += Defaults.screenEdgeGapLeft.cgFloat
         newFrame.origin.y += Defaults.screenEdgeGapBottom.cgFloat
         newFrame.size.width -= (Defaults.screenEdgeGapLeft.cgFloat + Defaults.screenEdgeGapRight.cgFloat)
-        newFrame.size.height -= (Defaults.screenEdgeGapTop.cgFloat + Defaults.screenEdgeGapBottom.cgFloat)
-
+        
+        if #available(macOS 12.0, *) {
+            if self.safeAreaInsets.top > 0, Defaults.screenEdgeGapTopNotch.value != 0 {
+                newFrame.size.height -= (Defaults.screenEdgeGapTopNotch.cgFloat + Defaults.screenEdgeGapBottom.cgFloat)
+            } else {
+                newFrame.size.height -= (Defaults.screenEdgeGapTop.cgFloat + Defaults.screenEdgeGapBottom.cgFloat)
+            }
+            
+        } else {
+            newFrame.size.height -= (Defaults.screenEdgeGapTop.cgFloat + Defaults.screenEdgeGapBottom.cgFloat)
+        }
+        
         return newFrame
     }
 

--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -157,13 +157,8 @@ extension NSScreen {
         newFrame.origin.y += Defaults.screenEdgeGapBottom.cgFloat
         newFrame.size.width -= (Defaults.screenEdgeGapLeft.cgFloat + Defaults.screenEdgeGapRight.cgFloat)
         
-        if #available(macOS 12.0, *) {
-            if self.safeAreaInsets.top > 0, Defaults.screenEdgeGapTopNotch.value != 0 {
-                newFrame.size.height -= (Defaults.screenEdgeGapTopNotch.cgFloat + Defaults.screenEdgeGapBottom.cgFloat)
-            } else {
-                newFrame.size.height -= (Defaults.screenEdgeGapTop.cgFloat + Defaults.screenEdgeGapBottom.cgFloat)
-            }
-            
+        if #available(macOS 12.0, *), self.safeAreaInsets.top != 0, Defaults.screenEdgeGapTopNotch.value != 0 {
+            newFrame.size.height -= (Defaults.screenEdgeGapTopNotch.cgFloat + Defaults.screenEdgeGapBottom.cgFloat)
         } else {
             newFrame.size.height -= (Defaults.screenEdgeGapTop.cgFloat + Defaults.screenEdgeGapBottom.cgFloat)
         }

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -361,6 +361,12 @@ defaults write com.knollsoft.Rectangle screenEdgeGapLeft -int 10
 defaults write com.knollsoft.Rectangle screenEdgeGapRight -int 10
 ```
 
+You can also seperately specify the gap for a screen with a notch. Useful for multi display setups if you are using a menubar replacement.
+
+```bash
+defaults write com.knollsoft.Rectangle screenEdgeGapTopNotch -int 5
+```
+
 If you want these gaps to be applied on your main screen only you can set screenEdgeGapsOnMainScreenOnly. Useful for multi display setups where only one screen has some dock replacement.
 
 ```bash


### PR DESCRIPTION
The top gap is calculated from the notch. This means windows overlap custom menubars when having external displays, as the gap is either too small on the external or huge on the built in display. Tried to explain this coherently, hope it makes sense