### PR TITLE
Check if window snapping is enabled prior to prompting user to disable it

### DIFF
--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -193,7 +193,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func checkForBuiltInTiling() {
-        guard #available(macOS 15, *), !Defaults.internalTilingNotified.enabled
+        guard #available(macOS 15, *), 
+                !Defaults.internalTilingNotified.enabled,
+                !Defaults.windowSnapping.userDisabled
         else {
             return
         }


### PR DESCRIPTION
I forgot to add a check for this in my last pull request.