### PR TITLE
Silence warning in AXExtension

### DIFF
--- a/Rectangle/Utilities/AXExtension.swift
+++ b/Rectangle/Utilities/AXExtension.swift
@@ -23,7 +23,9 @@ extension AXValue {
     
     static func from<T>(value: T, type: AXValueType) -> AXValue? {
         var value = value
-        return AXValueCreate(type, &value)
+        return withUnsafePointer(to: &value) { valuePointer in
+            AXValueCreate(type, valuePointer)
+        }
     }
 }
 


### PR DESCRIPTION
## Aim

Due to a change implemented in Swift 5.9, [Constrain implicit raw pointer conversion to bitwise-copyable values](https://github.com/atrick/swift-evolution/blob/diagnose-implicit-raw-bitwise/proposals/nnnn-implicit-raw-bitwise-conversion.md), a conversion to a raw pointer produces the warning: `Forming an 'UnsafeRawPointer' to a variable of type 'T'; this is likely incorrect because 'T' may contain an object reference.`

Since the affected function is only used with `CGPoint` and `CGSize`, the current implementation—that raises the warning—should be harmless.

## Possible Solutions

The warning has been silenced by wrapping the code in `withUnsafePointer(to:) {}`.

---

Another possible solution could be to constrain `T` to the [`BitwiseCopyable`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0426-bitwise-copyable.md) protocol, new in **Swift 6**. This will make the compiler check if the type is safe to convert to an UnsafeRawPointer. In order to use this approach, the project needs to be migrated to Swift 6.

```swift
static func from<T: BitwiseCopyable>(value: T, type: AXValueType) -> AXValue? {
    var value = value
    return AXValueCreate(type, &value)
}
```

## Considerations

- It could be desirable to keep this warning as a way to remember to be careful with what types this utility-function is given. If so, feel free to close this PR.