### PR TITLE
Handle additional tiling setting in macOS 15.1

### DIFF
--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -120,7 +120,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.titleBarManager = TitleBarManager()
         self.initializeTodo()
         checkForProblematicApps()
-        checkForBuiltInTiling()
+        MacTilingDefaults.checkForBuiltInTiling(skipIfAlreadyNotified: true)
     }
     
     func checkForConflictingApps() {
@@ -191,44 +191,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Defaults.notifiedOfProblemApps.enabled = true
         }
     }
-    
-    func checkForBuiltInTiling() {
-        guard #available(macOS 15, *), 
-                !Defaults.internalTilingNotified.enabled,
-                !Defaults.windowSnapping.userDisabled
-        else {
-            return
-        }
         
-        Defaults.internalTilingNotified.enabled = true
-        if MacTilingDefaults.tilingByEdgeDrag.enabled || MacTilingDefaults.tilingOptionAccelerator.enabled {
-            let result = AlertUtil.threeButtonAlert(
-                question: "Conflict with macOS tiling".localized,
-                text: "Drag to screen edge tiling is enabled in both Rectangle and macOS.".localized,
-                buttonOneText: "Disable in macOS".localized,
-                buttonTwoText: "Disable in Rectangle".localized,
-                buttonThreeText: "Dismiss".localized)
-            switch result {
-            case .alertFirstButtonReturn:
-                MacTilingDefaults.tilingByEdgeDrag.disable()
-                MacTilingDefaults.tilingOptionAccelerator.disable()
-                
-                let result = AlertUtil.twoButtonAlert(
-                    question: "Tiling in macOS has been disabled".localized,
-                    text: "To re-enable it, go to System Settings → Desktop & Dock → Windows".localized,
-                    cancelText: "Open System Settings".localized)
-                if result == .alertSecondButtonReturn {
-                    MacTilingDefaults.openSystemSettings()
-                }
-            case .alertSecondButtonReturn:
-                Defaults.windowSnapping.enabled = false
-                Notification.Name.windowSnapping.post(object: false)
-            default:
-                break
-            }
-        }
-    }
-    
     private func showWelcomeWindow() {
         let welcomeWindowController = NSStoryboard(name: "Main", bundle: nil)
             .instantiateController(withIdentifier: "WelcomeWindowController") as? NSWindowController

--- a/Rectangle/PrefsWindow/SnapAreaViewController.swift
+++ b/Rectangle/PrefsWindow/SnapAreaViewController.swift
@@ -40,6 +40,9 @@ class SnapAreaViewController: NSViewController {
         let newSetting: Bool = sender.state == .on
         Defaults.windowSnapping.enabled = newSetting
         Notification.Name.windowSnapping.post(object: newSetting)
+        if newSetting {
+            MacTilingDefaults.checkForBuiltInTiling(skipIfAlreadyNotified: false)
+        }
     }
     
     @IBAction func toggleUnsnapRestore(_ sender: NSButton) {
@@ -102,14 +105,16 @@ class SnapAreaViewController: NSViewController {
         Notification.Name.appWillBecomeActive.onPost() { [weak self] _ in
             self?.showHidePortrait()
         }
+        Notification.Name.windowSnapping.onPost { [weak self] _ in
+            self?.windowSnappingCheckbox.state = Defaults.windowSnapping.userDisabled ? .off : .on
+        }
         NotificationCenter.default.addObserver(forName: NSApplication.didChangeScreenParametersNotification, object: nil, queue: nil) { [weak self] _ in
             self?.showHidePortrait()
         }
     }
     
     func showHidePortrait() {
-        let hasPortraitDisplay = NSScreen.screens.contains(where: {!$0.frame.isLandscape})
-        portraitStackView.isHidden = !hasPortraitDisplay
+        portraitStackView.isHidden = !NSScreen.portraitDisplayConnected
     }
     
     func loadSnapAreas() {

--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -166,5 +166,8 @@ extension NSScreen {
         return newFrame
     }
 
+    static var portraitDisplayConnected: Bool {
+        NSScreen.screens.contains(where: {!$0.frame.isLandscape})
+    }
 }
 

--- a/Rectangle/Snapping/SnapAreaModel.swift
+++ b/Rectangle/Snapping/SnapAreaModel.swift
@@ -41,6 +41,20 @@ class SnapAreaModel {
     var portrait: [Directional:SnapAreaConfig] {
         Defaults.portraitSnapAreas.typedValue ?? SnapAreaModel.defaultPortrait
     }
+    
+    var isTopConfigured: Bool {
+        if let landscapeTop = landscape[.t] {
+            if landscapeTop.action != nil || landscapeTop.compound != nil {
+                return true
+            }
+        }
+        if NSScreen.portraitDisplayConnected, let portraitTop = portrait[.t] {
+            if portraitTop.action != nil || portraitTop.compound != nil {
+                return true
+            }
+        }
+        return false
+    }
         
     func setConfig(type: DisplayOrientation, directional: Directional, snapAreaConfig: SnapAreaConfig?) {
         switch type {

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -39929,6 +39929,9 @@
         }
       }
     },
+    "Tiling in Rectangle has been disabled" : {
+      "extractionState" : "manual"
+    },
     "tlD-Oa-oAM.title" : {
       "comment" : "Class = \"NSMenu\"; title = \"Kern\"; ObjectID = \"tlD-Oa-oAM\";",
       "extractionState" : "manual",
@@ -40060,6 +40063,9 @@
           }
         }
       }
+    },
+    "To adjust macOS tiling, go to System Settings → Desktop & Dock → Windows" : {
+      "extractionState" : "manual"
     },
     "To let Rectangle manage the title bar double click functionality, you need to disable the corresponding macOS setting." : {
       "localizations" : {
@@ -40261,6 +40267,9 @@
           }
         }
       }
+    },
+    "Top screen edge tiling in macOS is now disabled" : {
+      "extractionState" : "manual"
     },
     "Top sixths from corners; maximize" : {
       "localizations" : {


### PR DESCRIPTION
In the macOS 15.1 beta, there's an additional setting for the top snap area that needs to be checked by Rectangle.