### PR TITLE
Invert calculation for the "Eights" in portrait mode

### DIFF
--- a/Rectangle/WindowCalculation/BottomCenterLeftEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomCenterLeftEighthCalculation.swift
@@ -42,8 +42,8 @@ class BottomCenterLeftEighthCalculation: WindowCalculation, OrientationAware, Ei
     
     func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 4.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
         rect.origin.y = visibleFrameOfScreen.minY
         rect.origin.x = visibleFrameOfScreen.minX + rect.width
         return RectResult(rect, subAction: .bottomCenterLeftEighth)

--- a/Rectangle/WindowCalculation/BottomCenterRightEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomCenterRightEighthCalculation.swift
@@ -42,8 +42,8 @@ class BottomCenterRightEighthCalculation: WindowCalculation, OrientationAware, E
     
     func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 4.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
         rect.origin.y = visibleFrameOfScreen.minY
         rect.origin.x = visibleFrameOfScreen.minX + (2.0 * rect.width)
         return RectResult(rect, subAction: .bottomCenterRightEighth)

--- a/Rectangle/WindowCalculation/BottomRightEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomRightEighthCalculation.swift
@@ -42,8 +42,8 @@ class BottomRightEighthCalculation: WindowCalculation, OrientationAware, Eighths
     
     func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 4.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
         rect.origin.y = visibleFrameOfScreen.minY
         rect.origin.x = visibleFrameOfScreen.minX + (3.0 * rect.width)
         return RectResult(rect, subAction: .bottomRightEighth)

--- a/Rectangle/WindowCalculation/TopCenterLeftEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopCenterLeftEighthCalculation.swift
@@ -42,8 +42,8 @@ class TopCenterLeftEighthCalculation: WindowCalculation, OrientationAware, Eight
     
     func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 4.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
         rect.origin.y = visibleFrameOfScreen.maxY - rect.height
         rect.origin.x = visibleFrameOfScreen.minX + rect.width
         return RectResult(rect, subAction: .topCenterLeftEighth)

--- a/Rectangle/WindowCalculation/TopCenterRightEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopCenterRightEighthCalculation.swift
@@ -42,8 +42,8 @@ class TopCenterRightEighthCalculation: WindowCalculation, OrientationAware, Eigh
     
     func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 4.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
         rect.origin.y = visibleFrameOfScreen.maxY - rect.height
         rect.origin.x = visibleFrameOfScreen.minX + (2.0 * rect.width)
         return RectResult(rect, subAction: .topCenterRightEighth)

--- a/Rectangle/WindowCalculation/TopLeftEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopLeftEighthCalculation.swift
@@ -42,8 +42,8 @@ class TopLeftEighthCalculation: WindowCalculation, OrientationAware, EighthsRepe
     
     func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 4.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
         rect.origin.y = visibleFrameOfScreen.maxY - rect.height
         rect.origin.x = visibleFrameOfScreen.minX
         return RectResult(rect, subAction: .topLeftEighth)

--- a/Rectangle/WindowCalculation/TopRightEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopRightEighthCalculation.swift
@@ -42,8 +42,8 @@ class TopRightEighthCalculation: WindowCalculation, OrientationAware, EighthsRep
     
     func portraitRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 4.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
+        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
+        rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
         rect.origin.y = visibleFrameOfScreen.maxY - rect.height
         rect.origin.x = visibleFrameOfScreen.minX + (3.0 * rect.width)
         return RectResult(rect, subAction: .topRightEighth)


### PR DESCRIPTION
When I was configuring my screen that's on portrait mode with the Eights, the only one that fit my expectation was when it was on the **Bottom Left** corner of my screen. That's when I noticed on the code for [Rectangle/WindowCalculation/BottomLeftEighthCalculation.swift](https://github.com/rxhanson/Rectangle/blob/e481b024e450cef30fb9866b7c905b2f88f4a225/Rectangle/WindowCalculation/BottomLeftEighthCalculation.swift#L45) the divisors are switched for the height and the width, while on the other calculations for the Eights are equal for both landscape and portrait mode.

This PR just switches them for the portrait mode for the other calculations.