### PR TITLE
Update Korean Translation

### DIFF
--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -33424,7 +33424,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "가운데 3분의 2"
+            "value" : "가운데 2/3"
           }
         },
         "ms" : {


### PR DESCRIPTION
This change makes Korean option labels consistent, as all others use the "/" format while this one used "3분의 2".

<img width="167" height="164" alt="Rectangle korean translation issue" src="https://github.com/user-attachments/assets/84f0f5ec-46af-4794-9e39-142c5156933b" />
