### PR TITLE
docs: Improve troubleshooting order - easier steps first

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,15 +99,27 @@ See issue [317](https://github.com/rxhanson/Rectangle/issues/317).
 
 If windows aren't resizing or moving as you expect, here's some initial steps to get to the bottom of it. Most issues of this type have been caused by other apps.
 
-1. Enable debug logging, as per the instructions in the following section.
-1. The logs are pretty straightforward. If your calculated rect and your resulting rect are identical, chances are that there is another application causing issues. Save your logs if needed to attach to an issue if you create one.
+**Quick fixes (try these first):**
+
+1. **Lock and unlock your Mac** – This simple step resolves many issues, especially after system updates.
 1. Make sure macOS is up to date.
-1. Lock and unlock your Mac
 1. Restart your Mac (this often fixes things right after a macOS update).
-1. Make sure there are no other window manager applications running.
+
+**Diagnose the issue:**
+
+4. **Enable debug logging** (see instructions in the following section) – This helps identify whether Rectangle is working correctly.
+1. The logs are straightforward. If your calculated rect and your resulting rect are identical, chances are that there is another application causing issues.
+
+**Check for conflicts:**
+
+6. Make sure there are no other window manager applications running.
 1. Make sure that the app whose windows are not behaving properly does not have any conflicting keyboard shortcuts.
 1. Try using the menu items to execute a window action or changing the keyboard shortcut to something different so we can tell if it's a keyboard shortcut issue or not.
-1. If you suspect there may be another application causing issues, try creating and logging in as a new macOS user.
+
+**Advanced troubleshooting:**
+
+9. If you suspect there may be another application causing issues, try creating and logging in as a new macOS user.
+1. Save your logs to attach to an issue if you need to create one.
 
 #### Try resetting the macOS accessibility permissions for Rectangle:
 


### PR DESCRIPTION
## Summary
Reorganizes the troubleshooting section to put simpler and faster fixes at the top.

## Changes
- **Lock/unlock Mac** is now step 1 (this resolves many issues quickly, as noted in #1655)
- Grouped steps into logical sections for clarity:
  - Quick fixes (try these first)
  - Diagnose the issue
  - Check for conflicts  
  - Advanced troubleshooting
- Added bold formatting to highlight key actionable steps

## Before
Steps were ordered with debug logging first, which requires more effort to understand.

## After
Quick fixes like lock/unlock and checking macOS updates come first, making it faster for users to resolve common issues.

Addresses #1668