### PR TITLE
fix: Exclude desktop widgets from tile-all and cascade-all

### DIFF
--- a/Rectangle/AccessibilityElement.swift
+++ b/Rectangle/AccessibilityElement.swift
@@ -378,8 +378,14 @@ extension AccessibilityElement {
         return AccessibilityElement(pid).windowElements?.first { $0.windowId == windowId }
     }
     
+    private static let excludedProcessNames: Set<String> = ["Dock", "WindowManager", "Notification Center"]
+
     static func getAllWindowElements() -> [AccessibilityElement] {
-        return WindowUtil.getWindowList().uniqueMap { $0.pid }.compactMap { AccessibilityElement($0).windowElements }.flatMap { $0 }
+        return WindowUtil.getWindowList()
+            .filter { !excludedProcessNames.contains($0.processName ?? "") }
+            .uniqueMap { $0.pid }
+            .compactMap { AccessibilityElement($0).windowElements }
+            .flatMap { $0 }
     }
 }
 


### PR DESCRIPTION
## Summary

- Filters out windows belonging to system processes (Dock, WindowManager, Notification Center) in `getAllWindowElements()`
- On macOS Sonoma+, desktop widgets are rendered by the Notification Center process — excluding it prevents widgets from being tiled, cascaded, or reversed
- This follows the same pattern already used in `getWindowInfo()` (line 323) which excludes Dock and WindowManager for cursor-based window detection

## Details

The root cause: `getAllWindowElements()` extracts unique PIDs from `CGWindowListCopyWindowInfo` (which uses `.excludeDesktopElements`), then queries the Accessibility API for **all** windows belonging to each PID. If the Notification Center process has any visible window in the CG window list, all of its windows — including desktop widgets — are returned and subsequently included in multi-window operations.

The fix adds a process name filter before PID extraction, excluding known system processes that don't have user-tileable windows. This affects all callers of `getAllWindowElements()`:
- `MultiWindowManager` (tile-all, cascade-all, tile-active-app, cascade-active-app)
- `ReverseAllManager` (reverse-all)
- `TodoManager` (todo mode filtering)

## Test plan

- [ ] Verify `tile-all` no longer repositions desktop widgets on macOS Sonoma+
- [ ] Verify `cascade-all` no longer includes desktop widgets
- [ ] Verify `reverse-all` no longer includes desktop widgets
- [ ] Verify normal application windows still tile/cascade/reverse correctly
- [ ] Verify Stage Manager windows ("WindowManager") are excluded
- [ ] Test with both built-in and third-party desktop widgets

Fixes #1701

🤖 Generated with [Claude Code](https://claude.com/claude-code)