### PR TITLE
Preserve relative position when moving to another display

### DIFF
--- a/Rectangle/WindowCalculation/NextPrevDisplayCalculation.swift
+++ b/Rectangle/WindowCalculation/NextPrevDisplayCalculation.swift
@@ -24,28 +24,45 @@ class NextPrevDisplayCalculation: WindowCalculation {
         }
 
         if let screen = screen {
-            let rectParams = params.asRectParams(visibleFrame: screen.adjustedVisibleFrame(params.ignoreTodo))
-            
+            let destFrame = screen.adjustedVisibleFrame(params.ignoreTodo)
+            let rectParams = params.asRectParams(visibleFrame: destFrame)
+
             if Defaults.attemptMatchOnNextPrevDisplay.userEnabled {
                 if let lastAction = params.lastAction,
                    let calculation = WindowCalculationFactory.calculationsByAction[lastAction.action] {
-                    
+
                     AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: params.window.id)
-                    
+
                     let newCalculationParams = RectCalculationParameters(
                         window: rectParams.window,
                         visibleFrameOfScreen: rectParams.visibleFrameOfScreen,
                         action: lastAction.action,
                         lastAction: nil)
                     let rectResult = calculation.calculateRect(newCalculationParams)
-                    
+
                     return WindowCalculationResult(rect: rectResult.rect, screen: screen, resultingAction: lastAction.action)
                 }
             }
-            
-            let rectResult = calculateRect(rectParams)
-            let resultingAction: WindowAction = rectResult.resultingAction ?? params.action
-            return WindowCalculationResult(rect: rectResult.rect, screen: screen, resultingAction: resultingAction)
+
+            if params.lastAction?.action == .maximize && !Defaults.autoMaximize.userDisabled {
+                let rectResult = WindowCalculationFactory.maximizeCalculation.calculateRect(rectParams)
+                return WindowCalculationResult(rect: rectResult.rect, screen: screen, resultingAction: .maximize)
+            }
+
+            let sourceFrame = usableScreens.currentScreen.adjustedVisibleFrame(params.ignoreTodo)
+            let windowRect = params.window.rect
+
+            let relativeX = (windowRect.minX - sourceFrame.minX) / sourceFrame.width
+            let relativeY = (windowRect.minY - sourceFrame.minY) / sourceFrame.height
+
+            var newRect = windowRect
+            newRect.origin.x = round(destFrame.minX + relativeX * destFrame.width)
+            newRect.origin.y = round(destFrame.minY + relativeY * destFrame.height)
+
+            newRect.origin.x = max(destFrame.minX, min(newRect.origin.x, destFrame.maxX - newRect.width))
+            newRect.origin.y = max(destFrame.minY, min(newRect.origin.y, destFrame.maxY - newRect.height))
+
+            return WindowCalculationResult(rect: newRect, screen: screen, resultingAction: params.action)
         }
         
         return nil

--- a/Rectangle/WindowCalculation/SpecificDisplayCalculation.swift
+++ b/Rectangle/WindowCalculation/SpecificDisplayCalculation.swift
@@ -25,7 +25,8 @@ class SpecificDisplayCalculation: WindowCalculation {
 
         if targetScreen == usableScreens.currentScreen { return nil }
 
-        let rectParams = params.asRectParams(visibleFrame: targetScreen.adjustedVisibleFrame(params.ignoreTodo))
+        let destFrame = targetScreen.adjustedVisibleFrame(params.ignoreTodo)
+        let rectParams = params.asRectParams(visibleFrame: destFrame)
 
         if Defaults.attemptMatchOnNextPrevDisplay.userEnabled {
             if let lastAction = params.lastAction,
@@ -44,9 +45,20 @@ class SpecificDisplayCalculation: WindowCalculation {
             }
         }
 
-        let rectResult = calculateRect(rectParams)
-        let resultingAction: WindowAction = rectResult.resultingAction ?? params.action
-        return WindowCalculationResult(rect: rectResult.rect, screen: targetScreen, resultingAction: resultingAction)
+        let sourceFrame = usableScreens.currentScreen.adjustedVisibleFrame(params.ignoreTodo)
+        let windowRect = params.window.rect
+
+        let relativeX = (windowRect.minX - sourceFrame.minX) / sourceFrame.width
+        let relativeY = (windowRect.minY - sourceFrame.minY) / sourceFrame.height
+
+        var newRect = windowRect
+        newRect.origin.x = round(destFrame.minX + relativeX * destFrame.width)
+        newRect.origin.y = round(destFrame.minY + relativeY * destFrame.height)
+
+        newRect.origin.x = max(destFrame.minX, min(newRect.origin.x, destFrame.maxX - newRect.width))
+        newRect.origin.y = max(destFrame.minY, min(newRect.origin.y, destFrame.maxY - newRect.height))
+
+        return WindowCalculationResult(rect: newRect, screen: targetScreen, resultingAction: params.action)
     }
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {


### PR DESCRIPTION
Previously, moving a window to the next/previous display (or a specific display) would always center it on the destination screen when no prior Rectangle action was recorded (e.g. manually positioned windows).

Fix: compute the window's proportional position on the source screen and apply it to the destination screen, clamping to stay within bounds. The `attemptMatchOnNextPrevDisplay` path and maximize special-case are unchanged.

Fixes #1723

- [x] Tested on my machine and it is working as expected