### PR TITLE
Add screen presets feature

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -133,7 +133,7 @@
 		98D1441324560B1E0090C603 /* AlertUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D1441224560B1E0090C603 /* AlertUtil.swift */; };
 		98D16A442592AD55005228CB /* MASShortcutMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D16A432592AD55005228CB /* MASShortcutMigration.swift */; };
 		98D16A492592B460005228CB /* NotificationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D16A482592B460005228CB /* NotificationExtension.swift */; };
-		98D4B6C525B6256C009C7BF6 /* TodoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D4B6C425B6256C009C7BF6 /* TodoManager.swift */; };
+				98D4B6C525B6256C009C7BF6 /* TodoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D4B6C425B6256C009C7BF6 /* TodoManager.swift */; };
 		98FA9497235A2D7600F95C4F /* RepeatedExecutionsCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FA9496235A2D7600F95C4F /* RepeatedExecutionsCalculation.swift */; };
 		98FD7C5F2687BC14009E9DAF /* FirstThreeFourthsCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FD7C5E2687BC14009E9DAF /* FirstThreeFourthsCalculation.swift */; };
 		98FD7C612687BCB6009E9DAF /* LastThreeFourthsCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FD7C602687BCB6009E9DAF /* LastThreeFourthsCalculation.swift */; };
@@ -189,6 +189,10 @@
 		F7B6C43BB57F8064F49DDBB6 /* BottomLeftSixteenthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE147786B2CD7350FAFB700 /* BottomLeftSixteenthCalculation.swift */; };
 		FA34D0FF2F7E896E00EEBEF1 /* SpecificDisplayCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA34D0FE2F7E896E00EEBEF1 /* SpecificDisplayCalculation.swift */; };
 		FDE8FCE027C2950400EACCAA /* MultiWindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE8FCDF27C2950400EACCAA /* MultiWindowManager.swift */; };
+		EE1100000000000000000003 /* ScreenPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1100000000000000000002 /* ScreenPreset.swift */; };
+		EE1100000000000000000005 /* PresetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1100000000000000000004 /* PresetManager.swift */; };
+		EE1100000000000000000007 /* MonitorVisualizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1100000000000000000006 /* MonitorVisualizationView.swift */; };
+		EE1100000000000000000009 /* PresetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1100000000000000000008 /* PresetsViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -406,6 +410,10 @@
 		FD222258713B13274FB651B0 /* TopRightSixteenthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopRightSixteenthCalculation.swift; sourceTree = "<group>"; };
 		FDE8FCDF27C2950400EACCAA /* MultiWindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowManager.swift; sourceTree = "<group>"; };
 		FEE147786B2CD7350FAFB700 /* BottomLeftSixteenthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomLeftSixteenthCalculation.swift; sourceTree = "<group>"; };
+		EE1100000000000000000002 /* ScreenPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenPreset.swift; sourceTree = "<group>"; };
+		EE1100000000000000000004 /* PresetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetManager.swift; sourceTree = "<group>"; };
+		EE1100000000000000000006 /* MonitorVisualizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorVisualizationView.swift; sourceTree = "<group>"; };
+		EE1100000000000000000008 /* PresetsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -693,6 +701,7 @@
 				989DA30C243FC0C3008C7AA4 /* WelcomeWindow */,
 				98C2755F231FF6AE009B9292 /* Snapping */,
 				98D4B6C925B625B6009C7BF6 /* TodoMode */,
+				EE1100000000000000000001 /* Presets */,
 				985B9BFA22BE218C00A2E8F0 /* Popover */,
 				982140EA22B7DB0400ABFB3F /* WindowMover */,
 				982140E922B7DA3100ABFB3F /* WindowCalculation */,
@@ -766,6 +775,17 @@
 				98D4B6C425B6256C009C7BF6 /* TodoManager.swift */,
 			);
 			path = TodoMode;
+			sourceTree = "<group>";
+		};
+		EE1100000000000000000001 /* Presets */ = {
+			isa = PBXGroup;
+			children = (
+				EE1100000000000000000002 /* ScreenPreset.swift */,
+				EE1100000000000000000004 /* PresetManager.swift */,
+				EE1100000000000000000006 /* MonitorVisualizationView.swift */,
+				EE1100000000000000000008 /* PresetsViewController.swift */,
+			);
+			path = Presets;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1066,6 +1086,10 @@
 				98910B3E231130AF0066EC23 /* SettingsViewController.swift in Sources */,
 				98A009AD2512498000CFBF0C /* FirstFourthCalculation.swift in Sources */,
 				AA4DA2FB28FDC94A00355CEB /* DispatchTimeExtension.swift in Sources */,
+								EE1100000000000000000003 /* ScreenPreset.swift in Sources */,
+				EE1100000000000000000005 /* PresetManager.swift in Sources */,
+				EE1100000000000000000007 /* MonitorVisualizationView.swift in Sources */,
+				EE1100000000000000000009 /* PresetsViewController.swift in Sources */,
 				98D4B6C525B6256C009C7BF6 /* TodoManager.swift in Sources */,
 				B4780A322BD4C75900732B9E /* HalfOrDoubleDimensionCalculation.swift in Sources */,
 				AA69F83C29909A95001A81AF /* RightTodoCalculation.swift in Sources */,

--- a/Rectangle/AccessibilityElement.swift
+++ b/Rectangle/AccessibilityElement.swift
@@ -79,7 +79,7 @@ class AccessibilityElement {
         return role == .staticText
     }
     
-    private var subrole: NSAccessibility.Subrole? {
+    var subrole: NSAccessibility.Subrole? {
         guard let value = wrappedElement.getValue(.subrole) as? String else { return nil }
         return NSAccessibility.Subrole(rawValue: value)
     }

--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -142,6 +142,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.snappingManager = SnappingManager()
         self.titleBarManager = TitleBarManager()
         self.initializeTodo()
+        PresetManager.shared.registerAllShortcuts()
         checkForProblematicApps()
         MacTilingDefaults.checkForBuiltInTiling(skipIfAlreadyNotified: true)
     }
@@ -246,9 +247,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBAction func openPreferences(_ sender: Any) {
         if prefsWindowController == nil {
             prefsWindowController = NSStoryboard(name: "Main", bundle: nil).instantiateController(withIdentifier: "PrefsWindowController") as? NSWindowController
+            injectPresetsTab()
         }
         NSApp.activate(ignoringOtherApps: true)
         prefsWindowController?.showWindow(self)
+    }
+
+    private func injectPresetsTab() {
+        guard let tabVC = prefsWindowController?.contentViewController as? NSTabViewController else { return }
+        let presetsVC = PresetsViewController()
+        let item = NSTabViewItem(viewController: presetsVC)
+        item.label = "Presets"
+        if #available(macOS 11, *) {
+            item.image = NSImage(systemSymbolName: "rectangle.3.group", accessibilityDescription: "Presets")
+        } else {
+            item.image = NSImage(named: NSImage.preferencesGeneralName)
+        }
+        tabVC.addTabViewItem(item)
     }
     
     @IBAction func showAbout(_ sender: Any) {
@@ -648,6 +663,8 @@ extension AppDelegate {
                     let bundleId = extractBundleIdParameter(fromComponents: components)
                     guard isValidParameter(bundleId: bundleId) else { continue }
                     self.applicationToggle.enableApp(appBundleId: bundleId)
+                case ("open-preferences", _):
+                    self.openPreferences(self)
                 default:
                     continue
                 }

--- a/Rectangle/Presets/MonitorVisualizationView.swift
+++ b/Rectangle/Presets/MonitorVisualizationView.swift
@@ -1,0 +1,100 @@
+import Cocoa
+
+class MonitorVisualizationView: NSView {
+
+    private var screenRects: [(frame: NSRect, label: String, isPrimary: Bool)] = []
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        refresh()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        refresh()
+    }
+
+    func refresh() {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { return }
+        let primaryScreen = PresetManager.primaryScreen()
+
+        screenRects = screens.map { screen in
+            let label: String
+            if screen == primaryScreen {
+                label = "Primary Display\n\(screen.localizedName)\n\(Int(screen.frame.width))×\(Int(screen.frame.height))"
+            } else {
+                label = "Secondary Display\n\(screen.localizedName)\n\(Int(screen.frame.width))×\(Int(screen.frame.height))"
+            }
+            return (frame: screen.frame, label: label, isPrimary: screen == primaryScreen)
+        }
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        guard !screenRects.isEmpty else { return }
+
+        // Compute bounding box of all screens in NSScreen coords
+        let allX = screenRects.flatMap { [$0.frame.minX, $0.frame.maxX] }
+        let allY = screenRects.flatMap { [$0.frame.minY, $0.frame.maxY] }
+        let minX = allX.min()!, maxX = allX.max()!
+        let minY = allY.min()!, maxY = allY.max()!
+        let totalW = maxX - minX
+        let totalH = maxY - minY
+        guard totalW > 0, totalH > 0 else { return }
+
+        let padding: CGFloat = 10
+        let availW = bounds.width - padding * 2
+        let availH = bounds.height - padding * 2
+        let scale = min(availW / totalW, availH / totalH)
+
+        // Center the drawing
+        let drawW = totalW * scale
+        let drawH = totalH * scale
+        let offsetX = (bounds.width - drawW) / 2
+        let offsetY = (bounds.height - drawH) / 2
+
+        for item in screenRects {
+            let sx = (item.frame.minX - minX) * scale + offsetX
+            // Flip Y: NSScreen Y increases upward, view Y increases upward in flipped view context
+            let sy = (item.frame.minY - minY) * scale + offsetY
+            let sw = item.frame.width * scale
+            let sh = item.frame.height * scale
+
+            let rect = NSRect(x: sx, y: sy, width: sw, height: sh)
+
+            // Fill
+            let fillColor: NSColor = item.isPrimary
+                ? NSColor.controlAccentColor.withAlphaComponent(0.15)
+                : NSColor.tertiaryLabelColor.withAlphaComponent(0.1)
+            fillColor.setFill()
+            let path = NSBezierPath(roundedRect: rect.insetBy(dx: 2, dy: 2), xRadius: 4, yRadius: 4)
+            path.fill()
+
+            // Border
+            let borderColor: NSColor = item.isPrimary
+                ? NSColor.controlAccentColor
+                : NSColor.secondaryLabelColor
+            borderColor.setStroke()
+            path.lineWidth = item.isPrimary ? 2 : 1
+            path.stroke()
+
+            // Label
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.alignment = .center
+
+            let fontSize: CGFloat = max(8, min(11, sh / 4))
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: fontSize, weight: item.isPrimary ? .semibold : .regular),
+                .foregroundColor: item.isPrimary ? NSColor.controlAccentColor : NSColor.secondaryLabelColor,
+                .paragraphStyle: paragraphStyle
+            ]
+
+            let labelStr = item.label as NSString
+            let labelRect = rect.insetBy(dx: 4, dy: 4)
+            labelStr.draw(in: labelRect, withAttributes: attrs)
+        }
+    }
+}

--- a/Rectangle/Presets/PresetManager.swift
+++ b/Rectangle/Presets/PresetManager.swift
@@ -1,0 +1,455 @@
+import Cocoa
+import MASShortcut
+import os.log
+
+private let presetLog = OSLog(subsystem: "com.knollsoft.Rectangle", category: "presets")
+
+class PresetManager {
+    static let shared = PresetManager()
+
+    private(set) var presets: [ScreenPreset] = []
+    private let defaultsKey = "screenPresets"
+
+    private init() { load() }
+
+    // MARK: - Screen helpers
+
+    /// The system's primary display — the one with the menu bar in System Settings.
+    /// This is the screen at origin (0, 0), NOT `NSScreen.main` (which follows keyboard focus).
+    static func primaryScreen() -> NSScreen? {
+        return NSScreen.screens.first { $0.frame.origin == .zero }
+            ?? NSScreen.screens.first
+    }
+
+    static func orderedScreens() -> [NSScreen] {
+        var screens = NSScreen.screens
+        guard let primary = primaryScreen() else { return screens }
+        screens.removeAll { $0 == primary }
+        screens.sort { $0.frame.minX < $1.frame.minX }
+        return [primary] + screens
+    }
+
+    // Convert NSScreen frame to AX coordinate space (origin = top-left of primary screen, y↓)
+    static func axFrame(for screen: NSScreen) -> CGRect {
+        guard let primary = primaryScreen() else { return screen.frame }
+        let totalHeight = primary.frame.height
+        let axY = totalHeight - screen.frame.maxY
+        return CGRect(x: screen.frame.minX, y: axY, width: screen.frame.width, height: screen.frame.height)
+    }
+
+    static func screenIndex(forAXPoint point: CGPoint) -> Int {
+        let screens = orderedScreens()
+        for (i, screen) in screens.enumerated() {
+            if axFrame(for: screen).contains(point) { return i }
+        }
+        return 0
+    }
+
+    // Convert an absolute AX frame on a given screen into a 0–1 fraction relative to that screen.
+    static func relativeFrame(forAX frame: CGRect, onScreenIndex idx: Int) -> CGRect? {
+        let screens = orderedScreens()
+        guard idx >= 0, idx < screens.count else { return nil }
+        let s = axFrame(for: screens[idx])
+        guard s.width > 0, s.height > 0 else { return nil }
+        return CGRect(
+            x: (frame.minX - s.minX) / s.width,
+            y: (frame.minY - s.minY) / s.height,
+            width: frame.width / s.width,
+            height: frame.height / s.height
+        )
+    }
+
+    // Convert a 0–1 relative frame back to an absolute AX frame on the current screen at `idx`.
+    static func absoluteFrame(fromRelative rel: CGRect, onScreenIndex idx: Int) -> CGRect? {
+        let screens = orderedScreens()
+        guard idx >= 0, idx < screens.count else { return nil }
+        let s = axFrame(for: screens[idx])
+        return CGRect(
+            x: s.minX + rel.minX * s.width,
+            y: s.minY + rel.minY * s.height,
+            width: rel.width * s.width,
+            height: rel.height * s.height
+        )
+    }
+
+    private static func makeWindowState(bundleId: String, appName: String, frame: CGRect,
+                                        windowIndex: Int = 0, windowTitle: String? = nil,
+                                        id: String? = nil) -> AppWindowState {
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        let idx = screenIndex(forAXPoint: center)
+        let rel = relativeFrame(forAX: frame, onScreenIndex: idx).map(CodableCGRect.init)
+        return AppWindowState(
+            id: id ?? UUID().uuidString,
+            bundleId: bundleId,
+            appName: appName,
+            screenIndex: idx,
+            frame: CodableCGRect(frame),
+            relativeFrame: rel,
+            windowIndex: windowIndex,
+            windowTitle: windowTitle
+        )
+    }
+
+    /// Snapshot of windows owned by a PID that are currently user-visible.
+    /// AX is the source of truth, restricted to `AXStandardWindow` subrole; the window must also
+    /// appear in CG's on-screen, layer-0, alpha>0, ≥100×100 list.
+    static func cgWindows(forPID pid: pid_t) -> [(frame: CGRect, title: String?)] {
+        // Visible CG rects and their titles, for matching.
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        var visibleCG: [(frame: CGRect, title: String?)] = []
+        if let infoList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] {
+            for info in infoList {
+                guard let ownerPid = info[kCGWindowOwnerPID as String] as? Int32, ownerPid == pid,
+                      let layer = info[kCGWindowLayer as String] as? Int, layer == 0,
+                      let alpha = info[kCGWindowAlpha as String] as? Double, alpha > 0,
+                      let boundsDict = info[kCGWindowBounds as String] as? NSDictionary,
+                      let rect = CGRect(dictionaryRepresentation: boundsDict),
+                      rect.width >= 100, rect.height >= 100 else { continue }
+                let title = (info[kCGWindowName as String] as? String).flatMap { $0.isEmpty ? nil : $0 }
+                visibleCG.append((frame: rect, title: title))
+            }
+        }
+        guard !visibleCG.isEmpty else { return [] }
+
+        // Prefer AX for enumeration; only keep standard windows backed by a visible CG rect.
+        let el = AccessibilityElement(pid)
+        guard let wins = el.windowElements, !wins.isEmpty else {
+            return visibleCG
+        }
+
+        var remaining = visibleCG
+        var results: [(frame: CGRect, title: String?)] = []
+        for win in wins {
+            // Skip sheets, popovers, tooltips, drawers, floating panels, etc.
+            if let sub = win.subrole, sub != .standardWindow { continue }
+            let f = win.frame
+            guard !f.isNull, f.width >= 100, f.height >= 100 else { continue }
+            guard let nearestIdx = remaining.enumerated().min(by: { a, b in
+                let d1 = hypot(a.element.frame.origin.x - f.origin.x, a.element.frame.origin.y - f.origin.y)
+                let d2 = hypot(b.element.frame.origin.x - f.origin.x, b.element.frame.origin.y - f.origin.y)
+                return d1 < d2
+            })?.offset else { break }
+            let match = remaining[nearestIdx]
+            let dist = hypot(match.frame.origin.x - f.origin.x, match.frame.origin.y - f.origin.y)
+            guard dist < 50 else { continue }
+            results.append((frame: f, title: match.title))
+            remaining.remove(at: nearestIdx)
+        }
+        return results
+    }
+
+    // MARK: - Save
+
+    func saveCurrentLayout(name: String) -> ScreenPreset? {
+        let screens = PresetManager.orderedScreens()
+        var states = [AppWindowState]()
+
+        let runningApps = NSWorkspace.shared.runningApplications.filter {
+            $0.activationPolicy == .regular && $0.bundleIdentifier != nil
+        }
+
+        for app in runningApps {
+            guard let bundleId = app.bundleIdentifier else { continue }
+            let windows = PresetManager.cgWindows(forPID: app.processIdentifier)
+            for (i, w) in windows.enumerated() {
+                states.append(PresetManager.makeWindowState(
+                    bundleId: bundleId,
+                    appName: app.localizedName ?? bundleId,
+                    frame: w.frame,
+                    windowIndex: i,
+                    windowTitle: w.title
+                ))
+            }
+        }
+
+        guard !states.isEmpty else { return nil }
+
+        let preset = ScreenPreset(name: name, screenCount: screens.count, windowStates: states)
+        presets.append(preset)
+        persist()
+        Notification.Name.presetsChanged.post()
+        return preset
+    }
+
+    // MARK: - Restore
+
+    func restorePreset(_ preset: ScreenPreset) {
+        os_log("restorePreset '%{public}@' screenCount=%{public}d states=%{public}d axTrusted=%{public}d",
+               log: presetLog, type: .info,
+               preset.name, preset.screenCount, preset.windowStates.count, AXIsProcessTrusted() ? 1 : 0)
+        let currentScreens = PresetManager.orderedScreens()
+        guard preset.screenCount <= currentScreens.count else {
+            os_log("  screen count mismatch, aborting", log: presetLog, type: .info)
+            NSSound.beep()
+            return
+        }
+
+        // Group by bundleId, preserving the order rows were added to the preset
+        // (important so newly-added windows don't fight over windowIndex=0).
+        var grouped: [String: [AppWindowState]] = [:]
+        for state in preset.windowStates {
+            grouped[state.bundleId, default: []].append(state)
+        }
+
+        var uninstalled: [String] = []
+
+        for (bundleId, states) in grouped {
+            guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) else {
+                uninstalled.append(bundleId)
+                continue
+            }
+
+            let targets: [CGRect] = states.map { s in
+                if let rel = s.relativeFrame?.cgRect,
+                   let abs = PresetManager.absoluteFrame(fromRelative: rel, onScreenIndex: s.screenIndex) {
+                    return abs
+                }
+                return s.frame.cgRect
+            }
+
+            if let app = NSWorkspace.shared.runningApplications
+                .first(where: { $0.bundleIdentifier == bundleId }) {
+                applyFrames(to: app, states: states, targets: targets)
+            } else {
+                let config = NSWorkspace.OpenConfiguration()
+                config.activates = false
+                NSWorkspace.shared.openApplication(at: appURL, configuration: config) { [weak self] app, _ in
+                    guard let self = self, let app = app else { return }
+                    DispatchQueue.main.async {
+                        self.waitForWindowsAndApplyFrames(app: app, states: states, targets: targets, retriesLeft: 30)
+                    }
+                }
+            }
+        }
+
+        if !uninstalled.isEmpty, let i = presets.firstIndex(where: { $0.id == preset.id }) {
+            presets[i].windowStates.removeAll { uninstalled.contains($0.bundleId) }
+            persist()
+            Notification.Name.presetsChanged.post()
+        }
+    }
+
+    private func applyFrames(to app: NSRunningApplication, states: [AppWindowState], targets: [CGRect]) {
+        let name = app.localizedName ?? app.bundleIdentifier ?? "?"
+        let el = AccessibilityElement(app.processIdentifier)
+        let liveWindows = el.windowElements ?? []
+        os_log("applyFrames %{public}@ liveAXCount=%{public}d storedCount=%{public}d",
+               log: presetLog, type: .info, name, liveWindows.count, states.count)
+
+        // Map each stored state to a live window in order. If we run out of live windows, stop.
+        for (i, state) in states.enumerated() {
+            guard i < liveWindows.count else {
+                os_log("  skip: only %{public}d live windows for '%{public}@'",
+                       log: presetLog, type: .info, liveWindows.count, state.appName)
+                break
+            }
+            let win = liveWindows[i]
+            os_log("  [%{public}d] '%{public}@' screenIdx=%{public}d rel=%{public}@ target=%{public}@ before=%{public}@",
+                   log: presetLog, type: .info,
+                   i, state.windowTitle ?? "?",
+                   state.screenIndex,
+                   state.relativeFrame.map { NSStringFromRect($0.cgRect) } ?? "nil",
+                   NSStringFromRect(targets[i]),
+                   NSStringFromRect(win.frame))
+            win.setFrame(targets[i])
+            os_log("  [%{public}d] after=%{public}@",
+                   log: presetLog, type: .info, i, NSStringFromRect(win.frame))
+        }
+    }
+
+    private func waitForWindowsAndApplyFrames(app: NSRunningApplication,
+                                              states: [AppWindowState],
+                                              targets: [CGRect],
+                                              retriesLeft: Int) {
+        if app.isTerminated { return }
+        let el = AccessibilityElement(app.processIdentifier)
+        let liveCount = el.windowElements?.count ?? 0
+        if liveCount >= states.count || liveCount > 0 && retriesLeft == 0 {
+            applyFrames(to: app, states: states, targets: targets)
+            return
+        }
+        guard retriesLeft > 0 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.waitForWindowsAndApplyFrames(app: app, states: states, targets: targets, retriesLeft: retriesLeft - 1)
+        }
+    }
+
+    func restorePresetForCurrentScreenCount() {
+        let count = NSScreen.screens.count
+        // Prefer an exact match; fall back to the largest preset that still fits the current setup.
+        let exact = presets.first { $0.screenCount == count }
+        let fallback = presets
+            .filter { $0.screenCount <= count }
+            .max(by: { $0.screenCount < $1.screenCount })
+        guard let preset = exact ?? fallback else {
+            NSSound.beep()
+            return
+        }
+        restorePreset(preset)
+    }
+
+    // MARK: - CRUD
+
+    func renamePreset(id: String, newName: String) {
+        guard let i = presets.firstIndex(where: { $0.id == id }) else { return }
+        presets[i].name = newName
+        persist()
+        Notification.Name.presetsChanged.post()
+    }
+
+    func deletePreset(id: String) {
+        if let preset = presets.first(where: { $0.id == id }),
+           let key = preset.shortcutDefaultsKey {
+            MASShortcutBinder.shared()?.breakBinding(withDefaultsKey: key)
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        presets.removeAll { $0.id == id }
+        persist()
+        Notification.Name.presetsChanged.post()
+    }
+
+    /// Enumerate installed apps in standard macOS application directories.
+    static func allInstalledApps() -> [InstalledApp] {
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser
+        let dirs = [
+            "/Applications",
+            "/Applications/Utilities",
+            "/System/Applications",
+            "/System/Applications/Utilities",
+            home.appendingPathComponent("Applications").path
+        ]
+        var seenBundleIds = Set<String>()
+        var apps: [InstalledApp] = []
+        let running = Set(NSWorkspace.shared.runningApplications.compactMap { $0.bundleIdentifier })
+
+        for dir in dirs {
+            guard let entries = try? fm.contentsOfDirectory(atPath: dir) else { continue }
+            for entry in entries where entry.hasSuffix(".app") {
+                let path = "\(dir)/\(entry)"
+                let url = URL(fileURLWithPath: path)
+                guard let bundle = Bundle(url: url),
+                      let bid = bundle.bundleIdentifier,
+                      seenBundleIds.insert(bid).inserted else { continue }
+                let name = (bundle.infoDictionary?["CFBundleDisplayName"] as? String)
+                    ?? (bundle.infoDictionary?["CFBundleName"] as? String)
+                    ?? String(entry.dropLast(4))
+                let icon = NSWorkspace.shared.icon(forFile: path)
+                apps.append(InstalledApp(
+                    url: url, bundleId: bid, name: name, icon: icon,
+                    isRunning: running.contains(bid)))
+            }
+        }
+        apps.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        return apps
+    }
+
+    /// Add a single captured window to a preset.
+    func addWindowToPreset(presetId: String, bundleId: String, appName: String,
+                           frame: CGRect, windowTitle: String?) {
+        guard let i = presets.firstIndex(where: { $0.id == presetId }) else { return }
+        let existingForBundle = presets[i].windowStates.filter { $0.bundleId == bundleId }.count
+        presets[i].windowStates.append(PresetManager.makeWindowState(
+            bundleId: bundleId,
+            appName: appName,
+            frame: frame,
+            windowIndex: existingForBundle,
+            windowTitle: windowTitle
+        ))
+        persist()
+        Notification.Name.presetsChanged.post()
+    }
+
+    func updateWindowState(presetId: String, stateId: String, newFrame: CGRect) {
+        guard let i = presets.firstIndex(where: { $0.id == presetId }),
+              let j = presets[i].windowStates.firstIndex(where: { $0.id == stateId }) else { return }
+        let old = presets[i].windowStates[j]
+        presets[i].windowStates[j] = PresetManager.makeWindowState(
+            bundleId: old.bundleId, appName: old.appName, frame: newFrame,
+            windowIndex: old.windowIndex, windowTitle: old.windowTitle, id: old.id)
+        persist()
+        Notification.Name.presetsChanged.post()
+    }
+
+    func changeAppScreen(presetId: String, stateId: String, newScreenIndex: Int) {
+        guard let i = presets.firstIndex(where: { $0.id == presetId }),
+              let j = presets[i].windowStates.firstIndex(where: { $0.id == stateId }) else { return }
+        let old = presets[i].windowStates[j]
+        let rel = old.relativeFrame?.cgRect
+            ?? CGRect(x: 0.1, y: 0.1, width: 0.5, height: 0.5)
+        let absFrame = PresetManager.absoluteFrame(fromRelative: rel, onScreenIndex: newScreenIndex)
+            ?? old.frame.cgRect
+        presets[i].windowStates[j] = AppWindowState(
+            id: old.id,
+            bundleId: old.bundleId,
+            appName: old.appName,
+            screenIndex: newScreenIndex,
+            frame: CodableCGRect(absFrame),
+            relativeFrame: CodableCGRect(rel),
+            windowIndex: old.windowIndex,
+            windowTitle: old.windowTitle
+        )
+        persist()
+        Notification.Name.presetsChanged.post()
+    }
+
+    func removeWindowState(presetId: String, stateId: String) {
+        guard let i = presets.firstIndex(where: { $0.id == presetId }) else { return }
+        presets[i].windowStates.removeAll { $0.id == stateId }
+        persist()
+        Notification.Name.presetsChanged.post()
+    }
+
+    // MARK: - Shortcuts
+
+    func registerAllShortcuts() {
+        for preset in presets {
+            guard let key = preset.shortcutDefaultsKey else { continue }
+            bindShortcut(for: preset, key: key)
+        }
+    }
+
+    func assignShortcut(presetId: String) -> String? {
+        guard let i = presets.firstIndex(where: { $0.id == presetId }) else { return nil }
+        let key = "preset_restore_\(presetId)"
+        presets[i].shortcutDefaultsKey = key
+        persist()
+        bindShortcut(for: presets[i], key: key)
+        return key
+    }
+
+    func removeShortcut(presetId: String) {
+        guard let i = presets.firstIndex(where: { $0.id == presetId }),
+              let key = presets[i].shortcutDefaultsKey else { return }
+        MASShortcutBinder.shared()?.breakBinding(withDefaultsKey: key)
+        UserDefaults.standard.removeObject(forKey: key)
+        presets[i].shortcutDefaultsKey = nil
+        persist()
+    }
+
+    private func bindShortcut(for preset: ScreenPreset, key: String) {
+        let presetId = preset.id
+        MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: key, toAction: {
+            guard let p = PresetManager.shared.presets.first(where: { $0.id == presetId }) else { return }
+            PresetManager.shared.restorePreset(p)
+        })
+    }
+
+    // MARK: - Persistence
+
+    func persist() {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(presets),
+              let json = String(data: data, encoding: .utf8) else { return }
+        UserDefaults.standard.set(json, forKey: defaultsKey)
+    }
+
+    private func load() {
+        guard let json = UserDefaults.standard.string(forKey: defaultsKey),
+              let data = json.data(using: .utf8) else { return }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        presets = (try? decoder.decode([ScreenPreset].self, from: data)) ?? []
+    }
+}

--- a/Rectangle/Presets/PresetsViewController.swift
+++ b/Rectangle/Presets/PresetsViewController.swift
@@ -1,0 +1,840 @@
+import Cocoa
+import MASShortcut
+
+class PresetsViewController: NSViewController {
+
+    // MARK: - Subviews
+
+    private var monitorView: MonitorVisualizationView!
+    private var screenInfoLabel: NSTextField!
+    private var presetsTableView: NSTableView!
+    private var windowStatesTableView: NSTableView!
+
+    private var addButton: NSButton!
+    private var removeButton: NSButton!
+    private var restoreButton: NSButton!
+    private var refreshAllButton: NSButton!
+    private var removeAppButton: NSButton!
+    private var addAppButton: NSButton!
+    private var editAppButton: NSButton!
+
+    private var shortcutView: MASShortcutView!
+    private var capturedForLabel: NSTextField!
+
+    // MARK: - State
+
+    private var selectedPresetIndex: Int = -1
+    private var observers: [NSObjectProtocol] = []
+
+    private var manager: PresetManager { .shared }
+
+    private var selectedPreset: ScreenPreset? {
+        let i = selectedPresetIndex
+        guard i >= 0, i < manager.presets.count else { return nil }
+        return manager.presets[i]
+    }
+
+    private var sortedStates: [AppWindowState] {
+        guard let p = selectedPreset else { return [] }
+        return p.windowStates.sorted {
+            if $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedSame {
+                return $0.windowIndex < $1.windowIndex
+            }
+            return $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedAscending
+        }
+    }
+
+    private func displayName(for state: AppWindowState) -> String {
+        guard let p = selectedPreset else { return state.appName }
+        let sameBundle = p.windowStates.filter { $0.bundleId == state.bundleId }
+            .sorted { $0.windowIndex < $1.windowIndex }
+        guard sameBundle.count > 1, let pos = sameBundle.firstIndex(where: { $0.id == state.id }) else {
+            return state.appName
+        }
+        return "\(state.appName) (\(pos + 1))"
+    }
+
+    // MARK: - View lifecycle
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 720, height: 600))
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        buildUI()
+        reloadUI()
+        setupObservers()
+    }
+
+    deinit {
+        observers.forEach(NotificationCenter.default.removeObserver)
+    }
+
+    // MARK: - UI construction
+
+    private func buildUI() {
+        let p: CGFloat = 16
+
+        // Monitor visualization
+        let monLabel = boldLabel("Connected Displays")
+        monitorView = MonitorVisualizationView(frame: .zero)
+        monitorView.wantsLayer = true
+        monitorView.layer?.cornerRadius = 8
+        screenInfoLabel = smallLabel("")
+
+        let sep1 = separator()
+
+        // Presets list (full width)
+        let preLabel = boldLabel("Presets")
+        presetsTableView = makeTableView(columns: [
+            ("name", "Name", 220),
+            ("shortcut", "Shortcut", 140),
+        ], rowHeight: 22)
+        presetsTableView.columnAutoresizingStyle = .lastColumnOnlyAutoresizingStyle
+        presetsTableView.target = self
+        presetsTableView.doubleAction = #selector(presetsTableDoubleClick(_:))
+        let presetsScroll = inScrollView(presetsTableView)
+
+        addButton = NSButton(title: "+", target: self, action: #selector(addPreset))
+        addButton.bezelStyle = .smallSquare
+        removeButton = NSButton(title: "−", target: self, action: #selector(removePreset))
+        removeButton.bezelStyle = .smallSquare
+        restoreButton = NSButton(title: "Restore Now", target: self, action: #selector(restoreNow))
+        restoreButton.bezelStyle = .rounded
+
+        shortcutView = MASShortcutView(frame: NSRect(x: 0, y: 0, width: 180, height: 24))
+        shortcutView.translatesAutoresizingMaskIntoConstraints = false
+        shortcutView.shortcutValueChange = { [weak self] _ in
+            self?.presetsTableView.reloadData()
+        }
+
+        let presetButtons = row([addButton, removeButton, restoreButton, shortcutView])
+
+        capturedForLabel = smallLabel("")
+        capturedForLabel.font = .systemFont(ofSize: 11, weight: .medium)
+
+        let sep2 = separator()
+
+        // App window states
+        let stateLabel = boldLabel("App Windows in Preset")
+        windowStatesTableView = makeTableView(columns: [
+            ("app", "App / Window", 220),
+            ("screen", "Display", 110),
+            ("frame", "Frame (x, y, w×h)", 240),
+        ], rowHeight: 20)
+        windowStatesTableView.columnAutoresizingStyle = .lastColumnOnlyAutoresizingStyle
+        let statesScroll = inScrollView(windowStatesTableView)
+
+        addAppButton = NSButton(title: "Add App…", target: self, action: #selector(showAddAppPicker(_:)))
+        addAppButton.bezelStyle = .rounded
+        editAppButton = NSButton(title: "Edit App…", target: self, action: #selector(showEditAppMenu(_:)))
+        editAppButton.bezelStyle = .rounded
+        refreshAllButton = NSButton(title: "Refresh All Positions", target: self, action: #selector(refreshAllPositions))
+        refreshAllButton.bezelStyle = .rounded
+        removeAppButton = NSButton(title: "Remove App", target: self, action: #selector(removeApp))
+        removeAppButton.bezelStyle = .rounded
+        let stateButtons = row([addAppButton, editAppButton, refreshAllButton, removeAppButton])
+
+        // Add all views
+        let subviews: [NSView] = [
+            monLabel, monitorView, screenInfoLabel,
+            sep1, preLabel, presetsScroll, presetButtons,
+            capturedForLabel, sep2,
+            stateLabel, statesScroll, stateButtons
+        ]
+        subviews.forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+
+        let statesHeight = statesScroll.heightAnchor.constraint(greaterThanOrEqualToConstant: 120)
+        statesHeight.priority = .defaultHigh
+
+        // Layout
+        NSLayoutConstraint.activate([
+            // Min content size — forces the tab/window to grow
+            view.widthAnchor.constraint(greaterThanOrEqualToConstant: 720),
+            view.heightAnchor.constraint(greaterThanOrEqualToConstant: 580),
+
+            // Monitor section
+            monLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: p),
+            monLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+
+            monitorView.topAnchor.constraint(equalTo: monLabel.bottomAnchor, constant: 6),
+            monitorView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+            monitorView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -p),
+            monitorView.heightAnchor.constraint(equalToConstant: 70),
+
+            screenInfoLabel.topAnchor.constraint(equalTo: monitorView.bottomAnchor, constant: 4),
+            screenInfoLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+            screenInfoLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -p),
+
+            sep1.topAnchor.constraint(equalTo: screenInfoLabel.bottomAnchor, constant: 8),
+            sep1.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+            sep1.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -p),
+            sep1.heightAnchor.constraint(equalToConstant: 1),
+
+            // Presets table (full width)
+            preLabel.topAnchor.constraint(equalTo: sep1.bottomAnchor, constant: 8),
+            preLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+
+            presetsScroll.topAnchor.constraint(equalTo: preLabel.bottomAnchor, constant: 4),
+            presetsScroll.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+            presetsScroll.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -p),
+            presetsScroll.heightAnchor.constraint(equalToConstant: 110),
+
+            presetButtons.topAnchor.constraint(equalTo: presetsScroll.bottomAnchor, constant: 6),
+            presetButtons.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+
+            capturedForLabel.topAnchor.constraint(equalTo: presetButtons.bottomAnchor, constant: 6),
+            capturedForLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+
+            // Sep2
+            sep2.topAnchor.constraint(equalTo: capturedForLabel.bottomAnchor, constant: 10),
+            sep2.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+            sep2.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -p),
+            sep2.heightAnchor.constraint(equalToConstant: 1),
+
+            // App states
+            stateLabel.topAnchor.constraint(equalTo: sep2.bottomAnchor, constant: 8),
+            stateLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+
+            statesScroll.topAnchor.constraint(equalTo: stateLabel.bottomAnchor, constant: 4),
+            statesScroll.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+            statesScroll.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -p),
+            statesScroll.bottomAnchor.constraint(equalTo: stateButtons.topAnchor, constant: -6),
+            statesHeight,
+
+            stateButtons.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: p),
+            stateButtons.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -p),
+
+            // Detail inner constraints
+            shortcutView.widthAnchor.constraint(equalToConstant: 180),
+            shortcutView.heightAnchor.constraint(equalToConstant: 24),
+        ])
+    }
+
+    // MARK: - Helpers
+
+    private func boldLabel(_ s: String) -> NSTextField {
+        let t = NSTextField(labelWithString: s)
+        t.font = .boldSystemFont(ofSize: 12)
+        return t
+    }
+
+    private func smallLabel(_ s: String) -> NSTextField {
+        let t = NSTextField(labelWithString: s)
+        t.font = .systemFont(ofSize: 11)
+        t.textColor = .secondaryLabelColor
+        return t
+    }
+
+    private func separator() -> NSBox {
+        let b = NSBox(); b.boxType = .separator; return b
+    }
+
+    private func inScrollView(_ tv: NSTableView) -> NSScrollView {
+        let sv = NSScrollView()
+        sv.documentView = tv
+        sv.hasVerticalScroller = true
+        sv.borderType = .bezelBorder
+        return sv
+    }
+
+    private func row(_ views: [NSView]) -> NSStackView {
+        let s = NSStackView(views: views)
+        s.orientation = .horizontal
+        s.spacing = 6
+        s.alignment = .centerY
+        return s
+    }
+
+    private func shortcutText(for preset: ScreenPreset) -> String {
+        guard let key = preset.shortcutDefaultsKey,
+              let data = UserDefaults.standard.object(forKey: key) else { return "—" }
+        let transformer = ValueTransformer(forName: NSValueTransformerName(MASDictionaryTransformerName))
+        guard let shortcut = transformer?.reverseTransformedValue(data) as? MASShortcut else { return "—" }
+        return shortcut.modifierFlagsString + (shortcut.keyCodeString ?? "")
+    }
+
+    private func makeTableView(columns: [(String, String, CGFloat)], rowHeight: CGFloat) -> NSTableView {
+        let tv = NSTableView()
+        tv.delegate = self
+        tv.dataSource = self
+        tv.rowHeight = rowHeight
+        tv.usesAlternatingRowBackgroundColors = true
+        tv.allowsEmptySelection = true
+        for (id, title, width) in columns {
+            let col = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(id))
+            col.title = title
+            col.width = width
+            tv.addTableColumn(col)
+        }
+        return tv
+    }
+
+    // MARK: - Data reload
+
+    private func reloadUI() {
+        presetsTableView.reloadData()
+        refreshDetail()
+        windowStatesTableView.reloadData()
+        refreshMonitorSection()
+        updateButtons()
+    }
+
+    private func refreshMonitorSection() {
+        monitorView.refresh()
+        let screens = PresetManager.orderedScreens()
+        let parts = screens.enumerated().map { i, s in
+            let res = "\(Int(s.frame.width))×\(Int(s.frame.height))"
+            return i == 0 ? "Primary Display: \(s.localizedName) (\(res))" : "Secondary Display \(i): \(s.localizedName) (\(res))"
+        }
+        screenInfoLabel.stringValue = parts.joined(separator: "   |   ")
+    }
+
+    private func refreshDetail() {
+        guard let preset = selectedPreset else {
+            capturedForLabel.stringValue = ""
+            shortcutView.isEnabled = false
+            shortcutView.associatedUserDefaultsKey = nil
+            return
+        }
+
+        let windowCount = preset.windowStates.count
+        let uniqueApps = Set(preset.windowStates.map { $0.bundleId }).count
+        let displayWord = preset.screenCount == 1 ? "display" : "displays"
+        let winWord = windowCount == 1 ? "window" : "windows"
+        let appWord = uniqueApps == 1 ? "app" : "apps"
+        capturedForLabel.stringValue = "Captured for \(preset.screenCount) \(displayWord) · \(windowCount) \(winWord) across \(uniqueApps) \(appWord)"
+
+        let key: String
+        if let existing = preset.shortcutDefaultsKey {
+            key = existing
+        } else {
+            key = manager.assignShortcut(presetId: preset.id) ?? "preset_restore_\(preset.id)"
+        }
+        shortcutView.isEnabled = true
+        shortcutView.setAssociatedUserDefaultsKey(key, withTransformerName: MASDictionaryTransformerName)
+    }
+
+    private func updateButtons() {
+        let hasSel = selectedPreset != nil
+        removeButton.isEnabled = hasSel
+        restoreButton.isEnabled = hasSel
+        addAppButton.isEnabled = hasSel
+        let hasApps = hasSel && !sortedStates.isEmpty
+        refreshAllButton.isEnabled = hasApps
+        let hasAppSel = hasSel && windowStatesTableView.selectedRow >= 0
+        removeAppButton.isEnabled = hasAppSel
+        editAppButton.isEnabled = hasAppSel
+    }
+
+    // MARK: - Notifications
+
+    private func setupObservers() {
+        observers.append(Notification.Name.presetsChanged.onPost { [weak self] _ in
+            DispatchQueue.main.async { self?.reloadUI() }
+        })
+        observers.append(NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil, queue: .main
+        ) { [weak self] _ in self?.refreshMonitorSection() })
+    }
+
+    // MARK: - Actions
+
+    @objc private func addPreset() {
+        let existingNames = Set(manager.presets.map { $0.name })
+        var n = 1
+        while existingNames.contains("Preset \(n)") { n += 1 }
+        guard let preset = manager.saveCurrentLayout(name: "Preset \(n)") else {
+            let a = NSAlert()
+            if !AXIsProcessTrusted() {
+                a.messageText = "Accessibility permission required"
+                a.informativeText = "Rectangle needs Accessibility permission to read other apps' window positions.\n\nOpen System Settings → Privacy & Security → Accessibility and enable Rectangle (this debug build may need to be added separately from the App Store build)."
+                a.addButton(withTitle: "Open System Settings")
+                a.addButton(withTitle: "Cancel")
+                if a.runModal() == .alertFirstButtonReturn {
+                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
+                }
+            } else {
+                a.messageText = "No windows found"
+                a.informativeText = "No running apps currently expose a window via Accessibility. Open some apps with visible windows and try again."
+                a.runModal()
+            }
+            return
+        }
+        if let row = manager.presets.firstIndex(where: { $0.id == preset.id }) {
+            selectedPresetIndex = row
+            presetsTableView.reloadData()
+            presetsTableView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+            refreshDetail()
+            windowStatesTableView.reloadData()
+            updateButtons()
+            DispatchQueue.main.async {
+                self.presetsTableView.editColumn(0, row: row, with: nil, select: true)
+            }
+        }
+    }
+
+    @objc private func removePreset() {
+        guard let preset = selectedPreset else { return }
+        let a = NSAlert()
+        a.messageText = "Delete \"\(preset.name)\"?"
+        a.informativeText = "The preset and its keyboard shortcut will be permanently removed."
+        a.addButton(withTitle: "Delete")
+        a.addButton(withTitle: "Cancel")
+        guard a.runModal() == .alertFirstButtonReturn else { return }
+        selectedPresetIndex = -1
+        manager.deletePreset(id: preset.id)
+    }
+
+    @objc private func restoreNow() {
+        guard let preset = selectedPreset else { return }
+        manager.restorePreset(preset)
+    }
+
+    @objc private func presetNameCellEdited(_ sender: NSTextField) {
+        let row = sender.tag
+        guard row >= 0, row < manager.presets.count else { return }
+        let name = sender.stringValue.trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else {
+            sender.stringValue = manager.presets[row].name
+            return
+        }
+        manager.renamePreset(id: manager.presets[row].id, newName: name)
+    }
+
+    @objc private func presetsTableDoubleClick(_ sender: NSTableView) {
+        let row = sender.clickedRow
+        guard row >= 0, row < manager.presets.count else { return }
+        sender.editColumn(0, row: row, with: nil, select: true)
+    }
+
+    @objc private func refreshAllPositions() {
+        guard let preset = selectedPreset else { return }
+        var missing: [String] = []
+        for state in sortedStates {
+            guard let app = NSWorkspace.shared.runningApplications
+                .first(where: { $0.bundleIdentifier == state.bundleId })
+            else {
+                missing.append(displayName(for: state))
+                continue
+            }
+            let windows = PresetManager.cgWindows(forPID: app.processIdentifier)
+            let idx = state.windowIndex < windows.count ? state.windowIndex : 0
+            guard idx < windows.count else {
+                missing.append(displayName(for: state))
+                continue
+            }
+            manager.updateWindowState(presetId: preset.id, stateId: state.id, newFrame: windows[idx].frame)
+        }
+        if !missing.isEmpty {
+            let a = NSAlert()
+            a.messageText = "Couldn't refresh \(missing.count) window\(missing.count == 1 ? "" : "s")"
+            a.informativeText = "Not running or no window frame returned:\n\n" + missing.joined(separator: ", ")
+            a.runModal()
+        }
+    }
+
+    @objc private func setToCurrent() {
+        guard let preset = selectedPreset else { return }
+        let row = windowStatesTableView.selectedRow
+        guard row >= 0, row < sortedStates.count else { return }
+        let state = sortedStates[row]
+        guard let app = NSWorkspace.shared.runningApplications
+            .first(where: { $0.bundleIdentifier == state.bundleId })
+        else {
+            let a = NSAlert()
+            a.messageText = "\(state.appName) is not running"
+            a.informativeText = "Launch \(state.appName) and try again."
+            a.runModal()
+            return
+        }
+        let windows = PresetManager.cgWindows(forPID: app.processIdentifier)
+        let idx = state.windowIndex < windows.count ? state.windowIndex : 0
+        guard idx < windows.count else {
+            let a = NSAlert()
+            a.messageText = "Couldn't read window bounds"
+            a.informativeText = "\(state.appName) didn't return a usable window frame."
+            a.runModal()
+            return
+        }
+        manager.updateWindowState(presetId: preset.id, stateId: state.id, newFrame: windows[idx].frame)
+    }
+
+    @objc private func removeApp() {
+        guard let preset = selectedPreset else { return }
+        let row = windowStatesTableView.selectedRow
+        guard row >= 0, row < sortedStates.count else { return }
+        manager.removeWindowState(presetId: preset.id, stateId: sortedStates[row].id)
+    }
+
+    @objc private func showEditAppMenu(_ sender: NSButton) {
+        guard let preset = selectedPreset else { return }
+        let row = windowStatesTableView.selectedRow
+        guard row >= 0, row < sortedStates.count else { return }
+        let state = sortedStates[row]
+
+        let menu = NSMenu()
+
+        let updateItem = NSMenuItem(title: "Update Position to Current", action: #selector(setToCurrent), keyEquivalent: "")
+        updateItem.target = self
+        menu.addItem(updateItem)
+
+        let moveItem = NSMenuItem(title: "Move to", action: nil, keyEquivalent: "")
+        let submenu = NSMenu()
+        let count = max(preset.screenCount, 1)
+        for i in 0..<count {
+            let label = i == 0 ? "Primary Display" : "Secondary Display \(i)"
+            let item = NSMenuItem(title: label, action: #selector(applyScreenChange(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = i
+            item.state = (i == state.screenIndex) ? .on : .off
+            submenu.addItem(item)
+        }
+        moveItem.submenu = submenu
+        menu.addItem(moveItem)
+
+        let origin = NSPoint(x: 0, y: sender.bounds.height + 4)
+        menu.popUp(positioning: nil, at: origin, in: sender)
+    }
+
+    @objc private func applyScreenChange(_ sender: NSMenuItem) {
+        guard let preset = selectedPreset,
+              let newIndex = sender.representedObject as? Int else { return }
+        let row = windowStatesTableView.selectedRow
+        guard row >= 0, row < sortedStates.count else { return }
+        manager.changeAppScreen(presetId: preset.id, stateId: sortedStates[row].id, newScreenIndex: newIndex)
+    }
+
+    @objc private func showAddAppPicker(_ sender: NSButton) {
+        guard selectedPreset != nil else { return }
+        let picker = AddAppPickerViewController()
+        picker.onPick = { [weak self, weak picker] app in
+            picker?.view.window?.close()
+            self?.handlePickedApp(app)
+        }
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.contentViewController = picker
+        popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .maxY)
+    }
+
+    private func handlePickedApp(_ installedApp: InstalledApp) {
+        guard let preset = selectedPreset else { return }
+
+        if let app = NSWorkspace.shared.runningApplications
+            .first(where: { $0.bundleIdentifier == installedApp.bundleId }) {
+            let windows = PresetManager.cgWindows(forPID: app.processIdentifier)
+            if windows.count == 1 {
+                manager.addWindowToPreset(
+                    presetId: preset.id, bundleId: installedApp.bundleId,
+                    appName: installedApp.name,
+                    frame: windows[0].frame, windowTitle: windows[0].title)
+                return
+            } else if windows.count > 1 {
+                showWindowPickerMenu(bundleId: installedApp.bundleId,
+                                    appName: installedApp.name, windows: windows)
+                return
+            }
+        }
+
+        // Not running or no visible window: launch and capture when a window appears.
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = true
+        NSWorkspace.shared.openApplication(at: installedApp.url, configuration: config) { [weak self] app, _ in
+            guard let self = self, let app = app else { return }
+            self.waitForFirstWindow(pid: app.processIdentifier, retriesLeft: 30) { frame, title in
+                guard let frame = frame else { return }
+                self.manager.addWindowToPreset(
+                    presetId: preset.id, bundleId: installedApp.bundleId,
+                    appName: installedApp.name, frame: frame, windowTitle: title)
+            }
+        }
+    }
+
+    private func waitForFirstWindow(pid: pid_t, retriesLeft: Int,
+                                    completion: @escaping (CGRect?, String?) -> Void) {
+        let windows = PresetManager.cgWindows(forPID: pid)
+        if let first = windows.first {
+            DispatchQueue.main.async { completion(first.frame, first.title) }
+            return
+        }
+        guard retriesLeft > 0 else {
+            DispatchQueue.main.async { completion(nil, nil) }
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.waitForFirstWindow(pid: pid, retriesLeft: retriesLeft - 1, completion: completion)
+        }
+    }
+
+    private func showWindowPickerMenu(bundleId: String, appName: String,
+                                      windows: [(frame: CGRect, title: String?)]) {
+        let menu = NSMenu()
+        let header = NSMenuItem(title: "Pick a window", action: nil, keyEquivalent: "")
+        header.isEnabled = false
+        menu.addItem(header)
+        menu.addItem(.separator())
+        for (i, w) in windows.enumerated() {
+            let label = w.title ?? "Window \(i + 1)"
+            let item = NSMenuItem(title: label, action: #selector(addWindowFromMenu(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = AddWindowPayload(
+                bundleId: bundleId, appName: appName, frame: w.frame, title: w.title)
+            menu.addItem(item)
+        }
+        let origin = NSPoint(x: 0, y: addAppButton.bounds.height + 4)
+        menu.popUp(positioning: nil, at: origin, in: addAppButton)
+    }
+
+    private struct AddWindowPayload {
+        let bundleId: String
+        let appName: String
+        let frame: CGRect
+        let title: String?
+    }
+
+    @objc private func addWindowFromMenu(_ sender: NSMenuItem) {
+        guard let preset = selectedPreset,
+              let payload = sender.representedObject as? AddWindowPayload else { return }
+        manager.addWindowToPreset(
+            presetId: preset.id,
+            bundleId: payload.bundleId,
+            appName: payload.appName,
+            frame: payload.frame,
+            windowTitle: payload.title
+        )
+    }
+
+    /// Resolve the frontmost on-screen window frame for a given PID.
+    /// Prefers CGWindowList (no AX required); falls back to AX if CG doesn't return usable bounds.
+    private func frontWindowFrame(forPID pid: pid_t) -> CGRect? {
+        let cgOptions: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        let infoList = (CGWindowListCopyWindowInfo(cgOptions, kCGNullWindowID) as? [[String: Any]]) ?? []
+        let candidates = infoList.filter {
+            ($0[kCGWindowOwnerPID as String] as? Int32) == pid &&
+            ($0[kCGWindowLayer as String] as? Int) == 0
+        }
+        for info in candidates {
+            guard let boundsDict = info[kCGWindowBounds as String] as? NSDictionary,
+                  let rect = CGRect(dictionaryRepresentation: boundsDict),
+                  rect.width > 0, rect.height > 0 else { continue }
+            return rect
+        }
+
+        // AX fallback
+        let el = AccessibilityElement(pid)
+        if let win = el.windowElements?.first {
+            let f = win.frame
+            if !f.isNull, f.width > 0, f.height > 0 { return f }
+        }
+        return nil
+    }
+}
+
+// MARK: - NSTableViewDataSource
+
+extension PresetsViewController: NSTableViewDataSource {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        tableView === presetsTableView ? manager.presets.count : sortedStates.count
+    }
+}
+
+// MARK: - NSTableViewDelegate
+
+extension PresetsViewController: NSTableViewDelegate {
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let colId = tableColumn?.identifier.rawValue ?? ""
+        if tableView === presetsTableView {
+            guard row < manager.presets.count else { return nil }
+            let preset = manager.presets[row]
+            if colId == "shortcut" {
+                return textCell(for: tableView, identifier: colId, text: shortcutText(for: preset))
+            }
+            let cell = textCell(for: tableView, identifier: colId, text: preset.name)
+            if let tf = cell.textField {
+                tf.isEditable = true
+                tf.isSelectable = true
+                tf.isBordered = false
+                tf.drawsBackground = false
+                tf.focusRingType = .none
+                tf.target = self
+                tf.action = #selector(presetNameCellEdited(_:))
+                tf.cell?.sendsActionOnEndEditing = true
+                tf.tag = row
+            }
+            return cell
+        } else {
+            guard row < sortedStates.count else { return nil }
+            let state = sortedStates[row]
+            let text: String
+            switch colId {
+            case "app":    text = displayName(for: state)
+            case "screen": text = state.screenIndex == 0 ? "Primary" : "Secondary \(state.screenIndex)"
+            case "frame":
+                let f = state.frame
+                text = String(format: "%.0f, %.0f  %.0f×%.0f", f.x, f.y, f.width, f.height)
+            default: return nil
+            }
+            return textCell(for: tableView, identifier: colId, text: text)
+        }
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        guard let tv = notification.object as? NSTableView else { return }
+        if tv === presetsTableView {
+            let r = presetsTableView.selectedRow
+            selectedPresetIndex = r >= 0 ? r : -1
+            refreshDetail()
+            windowStatesTableView.reloadData()
+        }
+        updateButtons()
+    }
+
+    private func textCell(for tableView: NSTableView, identifier: String, text: String) -> NSTableCellView {
+        let id = NSUserInterfaceItemIdentifier(identifier)
+        if let cell = tableView.makeView(withIdentifier: id, owner: self) as? NSTableCellView {
+            cell.textField?.stringValue = text
+            return cell
+        }
+        let cell = NSTableCellView()
+        cell.identifier = id
+        let tf = NSTextField(labelWithString: text)
+        tf.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(tf)
+        cell.textField = tf
+        NSLayoutConstraint.activate([
+            tf.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 2),
+            tf.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -2),
+            tf.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+        ])
+        return cell
+    }
+}
+
+// MARK: - Installed-app picker popover
+
+class AddAppPickerViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate {
+    var onPick: ((InstalledApp) -> Void)?
+
+    private let searchField = NSSearchField()
+    private let tableView = NSTableView()
+    private var allApps: [InstalledApp] = []
+    private var filtered: [InstalledApp] = []
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 360, height: 440))
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        allApps = PresetManager.allInstalledApps()
+        filtered = allApps
+
+        searchField.placeholderString = "Search apps"
+        searchField.target = self
+        searchField.action = #selector(searchChanged)
+        searchField.sendsWholeSearchString = false
+        searchField.sendsSearchStringImmediately = true
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+
+        let col = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("app"))
+        col.title = "App"
+        col.width = 340
+        tableView.addTableColumn(col)
+        tableView.headerView = nil
+        tableView.rowHeight = 26
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.target = self
+        tableView.action = #selector(rowClicked)
+        tableView.usesAlternatingRowBackgroundColors = true
+
+        let scroll = NSScrollView()
+        scroll.documentView = tableView
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .bezelBorder
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(searchField)
+        view.addSubview(scroll)
+
+        NSLayoutConstraint.activate([
+            searchField.topAnchor.constraint(equalTo: view.topAnchor, constant: 12),
+            searchField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
+            searchField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+
+            scroll.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 8),
+            scroll.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
+            scroll.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+            scroll.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -12),
+        ])
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        view.window?.makeFirstResponder(searchField)
+    }
+
+    @objc private func searchChanged() {
+        let q = searchField.stringValue.trimmingCharacters(in: .whitespaces)
+        if q.isEmpty {
+            filtered = allApps
+        } else {
+            filtered = allApps.filter { $0.name.range(of: q, options: .caseInsensitive) != nil }
+        }
+        tableView.reloadData()
+    }
+
+    @objc private func rowClicked() {
+        let r = tableView.clickedRow
+        guard r >= 0, r < filtered.count else { return }
+        onPick?(filtered[r])
+    }
+
+    func numberOfRows(in tableView: NSTableView) -> Int { filtered.count }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row < filtered.count else { return nil }
+        let app = filtered[row]
+
+        let cell = NSTableCellView()
+        let imageView = NSImageView()
+        imageView.image = app.icon
+        imageView.imageScaling = .scaleProportionallyDown
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+
+        let nameField = NSTextField(labelWithString: app.name)
+        nameField.font = .systemFont(ofSize: 12)
+        nameField.translatesAutoresizingMaskIntoConstraints = false
+
+        let statusDot = NSTextField(labelWithString: app.isRunning ? "●" : "")
+        statusDot.font = .systemFont(ofSize: 9)
+        statusDot.textColor = .systemGreen
+        statusDot.translatesAutoresizingMaskIntoConstraints = false
+
+        cell.addSubview(imageView)
+        cell.addSubview(nameField)
+        cell.addSubview(statusDot)
+
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 4),
+            imageView.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 18),
+            imageView.heightAnchor.constraint(equalToConstant: 18),
+
+            nameField.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 8),
+            nameField.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+            nameField.trailingAnchor.constraint(lessThanOrEqualTo: statusDot.leadingAnchor, constant: -8),
+
+            statusDot.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -6),
+            statusDot.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+        ])
+        return cell
+    }
+}

--- a/Rectangle/Presets/ScreenPreset.swift
+++ b/Rectangle/Presets/ScreenPreset.swift
@@ -1,0 +1,70 @@
+import Foundation
+import CoreGraphics
+import AppKit
+
+struct InstalledApp {
+    let url: URL
+    let bundleId: String
+    let name: String
+    let icon: NSImage
+    let isRunning: Bool
+}
+
+struct CodableCGRect: Codable {
+    let x: CGFloat
+    let y: CGFloat
+    let width: CGFloat
+    let height: CGFloat
+
+    var cgRect: CGRect { CGRect(x: x, y: y, width: width, height: height) }
+
+    init(_ rect: CGRect) {
+        x = rect.origin.x
+        y = rect.origin.y
+        width = rect.size.width
+        height = rect.size.height
+    }
+}
+
+struct AppWindowState: Codable, Identifiable {
+    var id: String
+    let bundleId: String
+    let appName: String
+    let screenIndex: Int
+    let frame: CodableCGRect
+    let relativeFrame: CodableCGRect?
+    let windowIndex: Int       // 0-based order in the app's window list at capture time
+    let windowTitle: String?   // title at capture time, used for best-effort restore matching
+
+    init(id: String = UUID().uuidString,
+         bundleId: String, appName: String, screenIndex: Int,
+         frame: CodableCGRect, relativeFrame: CodableCGRect?,
+         windowIndex: Int = 0, windowTitle: String? = nil) {
+        self.id = id
+        self.bundleId = bundleId
+        self.appName = appName
+        self.screenIndex = screenIndex
+        self.frame = frame
+        self.relativeFrame = relativeFrame
+        self.windowIndex = windowIndex
+        self.windowTitle = windowTitle
+    }
+}
+
+struct ScreenPreset: Codable, Identifiable {
+    var id: String
+    var name: String
+    let screenCount: Int
+    var windowStates: [AppWindowState]
+    var shortcutDefaultsKey: String?
+    var createdAt: Date
+
+    init(name: String, screenCount: Int, windowStates: [AppWindowState]) {
+        self.id = UUID().uuidString
+        self.name = name
+        self.screenCount = screenCount
+        self.windowStates = windowStates
+        self.shortcutDefaultsKey = nil
+        self.createdAt = Date()
+    }
+}

--- a/Rectangle/Utilities/NotificationExtension.swift
+++ b/Rectangle/Utilities/NotificationExtension.swift
@@ -23,6 +23,7 @@ extension Notification.Name {
     static let defaultSnapAreas = Notification.Name("defaultSnapAreas")
     static let updateAvailability = Notification.Name("updateAvailability")
     static let showAdditionalSizesInMenuChanged = Notification.Name("showAdditionalSizesInMenuChanged")
+    static let presetsChanged = Notification.Name("presetsChanged")
 
     func post(
         center: NotificationCenter = NotificationCenter.default,


### PR DESCRIPTION
## Summary

Adds a new Settings tab for saving and restoring named window-layout presets, each with its own keyboard shortcut.

- **Capture**: Create a preset with `+` to snapshot every visible window of every running regular app, or use `Add App...` to pick a single installed app and capture one window at a time via a searchable popover.
- **Restore**: Each preset binds to a MASShortcut and also has a `Restore Now` button. Windows are placed proportionally using relative frames (0-1 fractions of the capture-time display), so the layout scales across different-sized displays. Apps that are installed but not running are launched first; uninstalled apps are pruned automatically.
- **Multi-display**: The primary display is the system primary (screen at origin 0, 0), not `NSScreen.main`. Each captured window records a `screenIndex` so you can move it between primary and secondary displays via `Edit App...`.
- **Storage**: Presets persist to `UserDefaults` under `screenPresets` and are deliberately kept out of the main Config export/import.

<img width="851" height="668" alt="image" src="https://github.com/user-attachments/assets/479a2ee5-20ca-4420-b63c-783238437a3c" />
