### PR TITLE
fix: add missing SF Symbol icons to menu items

### DIFF
--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -77,6 +77,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             : unauthorizedMenu
         
         mainStatusMenu.autoenablesItems = false
+        addMenuIcons()
         addWindowActionMenuItems()
 
         NotificationCenter.default.addObserver(self, selector: #selector(rebuildMenu), name: .showAdditionalSizesInMenuChanged, object: nil)
@@ -130,6 +131,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Notification.Name.appWillBecomeActive.post()
     }
     
+    private func addMenuIcons() {
+        guard #available(macOS 11, *) else { return }
+        for item in mainStatusMenu.items {
+            switch item.action {
+            case #selector(openPreferences):
+                item.image = NSImage(systemSymbolName: "gear", accessibilityDescription: nil)
+            case #selector(viewLogging):
+                item.image = NSImage(systemSymbolName: "doc.text", accessibilityDescription: nil)
+            case #selector(checkForUpdates):
+                item.image = NSImage(systemSymbolName: "arrow.down.circle", accessibilityDescription: nil)
+            default:
+                break
+            }
+        }
+    }
+
     func checkAutoCheckForUpdates() {
         updaterController.updater.automaticallyChecksForUpdates = Defaults.SUEnableAutomaticChecks.enabled
     }


### PR DESCRIPTION
## Summary

Adds SF Symbol icons to the Settings, View Logging, and Check for Updates menu items in Rectangle's status bar menu.

## Changes

**Rectangle/AppDelegate.swift** — new `addMenuIcons()` method called in `applicationDidFinishLaunching` (line 80):

| Menu Item | Symbol | Selector |
|-----------|--------|----------|
| Settings… | `gear` | `openPreferences:` |
| View Logging… | `doc.text` | `viewLogging:` |
| Check for Updates… | `arrow.down.circle` | `checkForUpdates:` |

Menu items are matched by action selector rather than title text, which is resilient to localization changes. Guarded with `@available(macOS 11, *)` since the project deployment target is macOS 10.15 and SF Symbols were introduced in macOS 11.

Closes #1741