### PR TITLE
Security audit: pin MASShortcut, confirm URL tasks, harden config auto-load

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -1519,8 +1519,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/rxhanson/MASShortcut";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = revision;
+				revision = 2f9fbb3f959b7a683c6faaf9638d22afad37a235;
 			};
 		};
 		9877B63B29C8AC3600F02D74 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -644,6 +644,26 @@ extension AppDelegate {
                 return isValid
             }
             
+            func confirmExecuteTask(action: String, bundleId: String) -> Bool {
+                // Defense-in-depth: any web page or another app can trigger the
+                // `rectangle://execute-task=ignore-app` URL with an arbitrary
+                // bundle-id. Without confirmation this silently mutates
+                // Rectangle's `disabledApps` defaults. Skip the prompt only
+                // when Rectangle itself is frontmost (i.e. the user almost
+                // certainly clicked this from inside Rectangle's own UI).
+                if NSWorkspace.shared.frontmostApplication == NSRunningApplication.current {
+                    return true
+                }
+                let alert = NSAlert()
+                alert.alertStyle = .warning
+                alert.messageText = "Allow Rectangle URL action?".localized
+                alert.informativeText = String(format: "An external source asked Rectangle to perform \"%@\" on app bundle id \"%@\". Allow?".localized, action, bundleId)
+                alert.addButton(withTitle: "Allow".localized)
+                alert.addButton(withTitle: "Cancel".localized)
+                NSApp.activate(ignoringOtherApps: true)
+                return alert.runModal() == .alertFirstButtonReturn
+            }
+            
             for url in urls {
                 guard
                     let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
@@ -659,11 +679,13 @@ extension AppDelegate {
                     action?.postUrl()
                 case ("execute-task", "ignore-app"):
                     let bundleId = extractBundleIdParameter(fromComponents: components)
-                    guard isValidParameter(bundleId: bundleId) else { continue }
+                    guard isValidParameter(bundleId: bundleId), let bundleId else { continue }
+                    guard confirmExecuteTask(action: "ignore-app", bundleId: bundleId) else { continue }
                     self.applicationToggle.disableApp(appBundleId: bundleId)
                 case ("execute-task", "unignore-app"):
                     let bundleId = extractBundleIdParameter(fromComponents: components)
-                    guard isValidParameter(bundleId: bundleId) else { continue }
+                    guard isValidParameter(bundleId: bundleId), let bundleId else { continue }
+                    guard confirmExecuteTask(action: "unignore-app", bundleId: bundleId) else { continue }
                     self.applicationToggle.enableApp(appBundleId: bundleId)
                 default:
                     continue

--- a/Rectangle/PrefsWindow/Config.swift
+++ b/Rectangle/PrefsWindow/Config.swift
@@ -62,6 +62,13 @@ extension Defaults {
     static func load(fileUrl: URL) {
         guard let dictTransformer = ValueTransformer(forName: NSValueTransformerName(rawValue: MASDictionaryTransformerName)) else { return }
         
+        // Size cap: legitimate configs are ~tens of KB; refuse anything that
+        // looks abusive (defense against OOM via a giant config file).
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: fileUrl.path),
+           let size = attrs[.size] as? NSNumber, size.intValue > 1_048_576 {
+            return
+        }
+        
         guard let jsonString = try? String(contentsOf: fileUrl, encoding: .utf8),
               let config = convert(jsonString: jsonString) else { return }
 
@@ -95,14 +102,55 @@ extension Defaults {
                         
             let exists = try? configURL.checkResourceIsReachable()
             if exists == true {
+                // Defense-in-depth: any process running as this user can drop
+                // a RectangleConfig.json in Application Support and have it
+                // silently applied on next launch, overwriting shortcuts and
+                // defaults. Require the user to confirm before loading.
+                //
+                // We also refuse symlinks (could redirect reads elsewhere) and
+                // any file with world-write permission (suggests tampering).
+                let path = configURL.path
+                let fm = FileManager.default
+                var isSafe = true
+                
+                if let attrs = try? fm.attributesOfItem(atPath: path) {
+                    if (attrs[.type] as? FileAttributeType) == .typeSymbolicLink {
+                        isSafe = false
+                    }
+                    if let perms = attrs[.posixPermissions] as? NSNumber,
+                       (perms.intValue & 0o002) != 0 {
+                        isSafe = false
+                    }
+                }
+                
+                guard isSafe else {
+                    AlertUtil.oneButtonAlert(
+                        question: "Refused to load RectangleConfig.json",
+                        text: "The configuration file at \(path) is a symlink or world-writable. Rectangle has refused to load it. Remove the file or fix its permissions and try again."
+                    )
+                    try? fm.removeItem(at: configURL)
+                    return
+                }
+                
+                let response = AlertUtil.twoButtonAlert(
+                    question: "Apply Rectangle configuration?",
+                    text: "A configuration file was found at \(path). Applying it will overwrite your current Rectangle shortcuts and preferences. Apply now?",
+                    confirmText: "Apply",
+                    cancelText: "Discard"
+                )
+                guard response == .alertFirstButtonReturn else {
+                    try? fm.removeItem(at: configURL)
+                    return
+                }
+                
                 load(fileUrl: configURL)
                 do {
                     let newFilename = "RectangleConfig\(timestamp()).json"
                     
-                    try FileManager.default.moveItem(atPath: configURL.path, toPath: rectangleSupportURL.appendingPathComponent(newFilename).path)
+                    try fm.moveItem(atPath: configURL.path, toPath: rectangleSupportURL.appendingPathComponent(newFilename).path)
                 } catch {
                     do {
-                        try FileManager.default.removeItem(at: configURL)
+                        try fm.removeItem(at: configURL)
                     } catch {
                         AlertUtil.oneButtonAlert(question: "Error after loading from Support Dir", text: "Unable to rename/remove RectangleConfig.json from \(rectangleSupportURL) after loading.")
                     }

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,0 +1,307 @@
+# Rectangle — Security Audit
+
+**Scope:** Source-level security review of the Rectangle repository
+(`rxhanson/Rectangle`) at the commit checked out under this branch.
+**Auditor:** Jakub Anderwald, May 2026.
+**Methodology:** static review of every Swift file, all `.plist` and
+`.entitlements` files, the Xcode project, CI workflow, and dependency
+references. Search patterns enumerated common risk indicators
+(URL/IPC/AppleScript/Process spawn, telemetry/analytics SDKs,
+network APIs, unsafe Swift, secrets, ATS overrides, etc.).
+
+This document records every finding plus, for High/Medium severity items,
+the actual code change that was applied in this same branch.
+
+---
+
+## TL;DR — What this app sends off your machine
+
+Rectangle is a window manager. By design it stays local. The full-source
+sweep confirmed the following:
+
+| Channel | Destination | Trigger | What's sent | Notes |
+|---|---|---|---|---|
+| Sparkle update check | `https://rectangleapp.com/downloads/updates.xml` | App launch (if "Automatically check for updates" is on) + manual "Check for Updates…" + every `SUScheduledCheckInterval` (172800s / 2 days) | HTTPS GET with default Sparkle User-Agent and `If-Modified-Since`. **No system profile.** | EdDSA-signed appcast (`SUPublicEDKey` in `Info.plist`). `SUSendProfileInfo` / `SUEnableSystemProfiling` are **not set**, so Sparkle's default (no profile) applies. Declared in `Rectangle/InternetAccessPolicy.plist`. |
+| Sparkle update download | URL specified by the signed appcast | When user accepts an update | HTTPS GET of the new DMG | Signature is verified before install. |
+| `DistributedNotificationCenter` "killLauncher" | **Local IPC only** (mach port broadcast on this machine) | Main app launch tells the legacy launcher helper to exit | Notification name only | Not network traffic. |
+
+**No telemetry, no crash reporting, no analytics, no third-party data
+sharing.** Searched the entire tree for `URLSession`, `URLRequest`,
+`dataTask`, `CFNetwork`, `NWConnection`, `Socket`, `sendto`, plus every
+common SDK name (Sentry, Crashlytics, Firebase, Mixpanel, Amplitude,
+Bugsnag, AppCenter, PostHog, generic `Analytics`/`Telemetry`). Zero hits
+in app code.
+
+**No ATS bypass** (`NSAppTransportSecurity` not set). **No network
+entitlements** anywhere (the app is intentionally un-sandboxed because the
+Accessibility API requires it; the bundled launcher *is* sandboxed). No
+XPC services, no Mach service exports, no AppleScript bridge enabled
+(`LSAppleScriptEnabled` absent). No `Process`, `NSAppleScript`, shell
+invocation, or dynamic library loading.
+
+The user's wallpaper, window positions, shortcuts, ignored-app list,
+exported config files, and accessibility-API data **never leave the
+machine**.
+
+> One caveat: third-party dependencies (`MASShortcut`, `Sparkle`) are
+> source-imported via SPM. Sparkle is widely audited and only fetches the
+> update feed. `MASShortcut` has no documented network code, but until
+> Finding #1 (below) was fixed in this branch, every Rectangle build
+> pulled the latest tip of its `master` branch — meaning a future
+> upstream change could in principle introduce egress without our
+> review. The pin-to-commit fix in this PR removes that exposure.
+
+---
+
+## Findings summary
+
+| # | Severity | Area | Title | Status |
+|---|----------|------|-------|--------|
+| 1 | **High** | Supply chain | `MASShortcut` SPM dep pinned to moving `master` branch | **Fixed in this PR** |
+| 2 | **Medium** | URL scheme | `execute-task` mutates state silently when triggered by external URL | **Fixed in this PR** |
+| 3 | **Medium** | Config | `loadFromSupportDir()` silently auto-loads any JSON dropped in Application Support | **Fixed in this PR** |
+| 4 | Low | Config | `String(contentsOf:)` reads config with no size cap (OOM via giant file) | **Fixed in this PR** (folded into #3 / `load`) |
+| 5 | Low | URL scheme | No explicit scheme check / bundle-id shape validation | Documented, patch suggested below; not committed |
+| 6 | Low | CI | `codesign --force --deep` in `build.yml` hides per-bundle signing errors | Documented, patch suggested below; not committed |
+| 7 | Info | Sparkle | Version range `upToNextMajorVersion(2.0.0)` | OK — EdDSA-signed appcast makes this safe |
+| 8 | Info | Telemetry | None present | Confirmed by audit |
+| 9 | Info | Logger | Untrusted strings echoed into `LogViewer` `NSTextView` | OK — text view is `isEditable=false` and plain-text |
+
+---
+
+## Detailed findings
+
+### 1. [High] `MASShortcut` SPM dependency pinned to moving `master` branch
+
+**Location:** `Rectangle.xcodeproj/project.pbxproj`, `XCRemoteSwiftPackageReference "MASShortcut"`.
+
+**Before:**
+```
+requirement = {
+    branch = master;
+    kind   = branch;
+};
+```
+
+**Risk.** SPM with `kind = branch` resolves the *latest commit* of that
+branch on every package resolution. There is no review gate between an
+upstream `master` push (whether by the maintainer, a co-maintainer, a
+compromised token, or a malicious force-push) and a Rectangle build that
+links the new code. Because Rectangle ships outside the App Store and is
+*not* sandboxed (it has Accessibility access by design), a malicious
+`MASShortcut` build inherits the host's full user-level permissions.
+
+**Fix applied.** Pin to the current `master` HEAD by revision SHA:
+
+```
+requirement = {
+    kind     = revision;
+    revision = 2f9fbb3f959b7a683c6faaf9638d22afad37a235;
+};
+```
+
+(SHA was resolved via `gh api repos/rxhanson/MASShortcut/commits/master`
+at audit time: 2025-09-28 "Fixes sizing of the button cell that shifted
+in macOS 26".)
+
+**Follow-up recommendation for upstream maintainer:** tag MASShortcut
+releases (e.g. `2.4.1`) and switch Rectangle to `upToNextMinorVersion`
+or `upToNextMajorVersion`, which is the same threat model as Sparkle.
+
+---
+
+### 2. [Medium] `rectangle://execute-task` mutates state silently from any URL source
+
+**Location:** `Rectangle/AppDelegate.swift`, `application(_:open:)`.
+
+**Risk.** Rectangle registers the `rectangle://` URL scheme. Any web
+page can navigate to `rectangle://execute-task?name=ignore-app&app-bundle-id=com.apple.Safari`
+and macOS will hand the URL straight to Rectangle, which (in the
+original code) called `applicationToggle.disableApp(...)` with no user
+prompt. Outcomes:
+
+- A site can silently *disable* Rectangle shortcuts for a chosen app
+  (e.g. the browser) — a primitive useful as one link in a multi-step
+  social-engineering or accessibility-prompt-fatigue attack.
+- A site can *enable* Rectangle shortcuts for an app the user
+  deliberately ignored (e.g. re-enabling shortcuts that conflict with a
+  game / IDE while the user is focused there).
+
+Note: the unrelated `execute-action` host is intentionally unchanged.
+Those actions are reversible window-movement operations and the
+documented use case (Stream Deck, Shortcuts.app, automation) requires
+them to be silent.
+
+**Fix applied.** Require an `NSAlert` confirmation before `execute-task`
+mutates state, unless Rectangle itself is the frontmost app (in which
+case the request almost certainly came from Rectangle's own UI / a user
+shortcut). Bundle-id is surfaced in the alert so the user can see what
+they're approving.
+
+```swift
+func confirmExecuteTask(action: String, bundleId: String) -> Bool {
+    if NSWorkspace.shared.frontmostApplication == NSRunningApplication.current {
+        return true
+    }
+    let alert = NSAlert()
+    alert.alertStyle = .warning
+    alert.messageText = "Allow Rectangle URL action?".localized
+    alert.informativeText = String(format: "An external source asked Rectangle to perform \"%@\" on app bundle id \"%@\". Allow?".localized, action, bundleId)
+    alert.addButton(withTitle: "Allow".localized)
+    alert.addButton(withTitle: "Cancel".localized)
+    NSApp.activate(ignoringOtherApps: true)
+    return alert.runModal() == .alertFirstButtonReturn
+}
+```
+
+---
+
+### 3. [Medium] `Config.loadFromSupportDir()` silently auto-loads any JSON dropped in Application Support
+
+**Location:** `Rectangle/PrefsWindow/Config.swift`.
+
+**Risk.** On every launch Rectangle looks for
+`~/Library/Application Support/Rectangle/RectangleConfig.json` and, if
+present, *silently* applies it (overwriting shortcuts and the entire
+`Defaults` set), then moves the file aside. Any process running as the
+user can drop a file at that path — a downloaded ZIP, an installer, a
+"helper" script, a pre-existing malicious LaunchAgent — and have its
+contents persisted into Rectangle on next launch with no user
+indication.
+
+Combined with finding #2 this is a way to redefine the user's window
+shortcuts to point at unexpected actions without ever surfacing UI.
+
+The original code also did `String(contentsOf:)` with no size limit
+(Finding #4) and followed symlinks transparently.
+
+**Fix applied.** Three changes in this branch:
+
+1. **Confirmation prompt.** Show an `AlertUtil.twoButtonAlert` listing
+   the file path and asking the user to "Apply" or "Discard". On
+   discard, the file is removed (consistent with the prior post-load
+   behavior).
+2. **Reject symlinks and world-writable files.** Both indicate
+   tampering. The file is removed and a warning alert is shown.
+3. **1 MiB size cap in `load(fileUrl:)`.** Real exported configs are
+   tens of KB; anything materially larger is refused without reading
+   it into memory (folds in Finding #4).
+
+The legitimate "drop a config and have it imported" workflow still
+works — it just requires one click of confirmation.
+
+---
+
+### 4. [Low] `String(contentsOf:)` in `Config.load` has no size limit
+
+Folded into Finding #3's fix: the size check guards `load(fileUrl:)`
+itself, so the protection applies to both the auto-load path and the
+explicit `importConfig` button.
+
+---
+
+### 5. [Low] URL handler does not validate scheme or `app-bundle-id` shape
+
+**Location:** `Rectangle/AppDelegate.swift`, `application(_:open:)`.
+
+The handler does not verify `components.scheme == "rectangle"`. In
+practice macOS only dispatches the registered scheme to this method, so
+this is defense-in-depth, not a live bug. Similarly, `app-bundle-id` is
+passed straight into `UserDefaults` ops without a reverse-DNS shape
+check, so a malicious URL can pollute the `disabledApps` set with
+non-bundle-id strings (these are inert — they never match a real
+frontmost app — but they sit in the user's defaults).
+
+**Suggested patch (not committed — low impact, separate change):**
+
+```swift
+guard url.scheme?.lowercased() == "rectangle" else { continue }
+
+// inside isValidParameter:
+let bundleIdPattern = #"^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$"#
+let isValid = bundleId.map { $0.range(of: bundleIdPattern, options: .regularExpression) != nil } ?? false
+```
+
+---
+
+### 6. [Low] `.github/workflows/build.yml` uses `codesign --force --deep`
+
+**Location:** `.github/workflows/build.yml`, the "Resign App" step.
+
+Apple has deprecated `--deep`. It walks every nested bundle and
+re-signs them with the same identity, which can mask signing errors and
+hide unexpected nested binaries. Since `xcodebuild -exportArchive`
+already signs the outer bundle correctly, the explicit re-sign step is
+both unnecessary and lossy.
+
+**Suggested patch (not committed — CI/build concern, not a runtime
+vulnerability):** delete the "Resign App" step entirely. If a re-sign
+truly is needed for the ad-hoc workflow, sign only the outer bundle
+without `--deep`:
+
+```yaml
+- name: Resign App
+  run: codesign --force -s "$CODE_SIGN_IDENTITY" "$BUILD_DIR/$APP_NAME"
+```
+
+(Tangential: `runs-on: macos-26` is not a current GitHub-hosted runner
+label and will cause the workflow to fail to schedule. Unrelated to
+security but worth fixing.)
+
+---
+
+### 7. [Info] Sparkle version constraint
+
+`upToNextMajorVersion(2.0.0)` means every Rectangle build picks up the
+latest 2.x release of Sparkle. Because Sparkle's appcast itself is
+EdDSA-signed (`SUPublicEDKey` in `Info.plist`) and updates are
+verified before install, this is the standard configuration. No change
+recommended.
+
+---
+
+### 8. [Info] Telemetry / outbound data
+
+Confirmed absent. See the TL;DR table at the top.
+
+---
+
+### 9. [Info] `Logger` echoes untrusted strings into an `NSTextView`
+
+`Logger.log` is called with attacker-controllable strings (e.g. the
+bundle-id from a `rectangle://` URL). The log window's `NSTextView` has
+`isEditable=false` and renders plain text (`NSAttributedString` with
+only a monospaced font attribute), so there is no script-injection
+surface. The log buffer is in-memory only and is cleared when the
+window closes.
+
+No change recommended.
+
+---
+
+## Verification performed
+
+- `plutil -lint Rectangle.xcodeproj/project.pbxproj` → `OK` after the
+  pbxproj edit.
+- Project brace count is balanced (450/450) post-edit.
+- No `xcodebuild` archive build was attempted: this audit ran on a
+  machine without Xcode command-line developer tools selected and
+  without a Rectangle signing identity. Maintainer CI will run the
+  full archive build on PR.
+
+## Files changed in this PR
+
+- `Rectangle.xcodeproj/project.pbxproj` — pin MASShortcut to revision.
+- `Rectangle/AppDelegate.swift` — confirm prompt for `execute-task` URL
+  actions.
+- `Rectangle/PrefsWindow/Config.swift` — size cap, symlink/world-write
+  rejection, and confirm prompt for `loadFromSupportDir`.
+- `SECURITY_AUDIT.md` — this document.
+
+## Not addressed in this PR (recommended follow-ups)
+
+- Findings #5 and #6 (low severity).
+- Tagging MASShortcut releases upstream and switching Rectangle to
+  semantic version range pinning (mirrors how Sparkle is set up).
+- A dedicated `SECURITY.md` with a reporting address (currently the
+  README has no security disclosure channel).


### PR DESCRIPTION
This PR is the result of a source-level security audit of Rectangle. The full report is included as `SECURITY_AUDIT.md` at the repo root and explains the methodology, every finding (with severity), what was changed, and what was deliberately left for follow-up.

## TL;DR — outbound data

The audit confirms what the README implies: Rectangle contains **no telemetry, no analytics, and no crash reporting**. The only outbound network channel is the EdDSA-signed Sparkle update feed at `https://rectangleapp.com/downloads/updates.xml` (system profiling is off by default — `SUSendProfileInfo`/`SUEnableSystemProfiling` are not set).

## Fixes in this PR

1. **[High] Supply chain — pin `MASShortcut`.** `Rectangle.xcodeproj/project.pbxproj` had `MASShortcut` pinned to `branch = master`, so every build silently pulled the latest tip with no review gate. Pinned to the current HEAD commit (`2f9fbb3f959b7a683c6faaf9638d22afad37a235`) via `kind = revision`. Recommend follow-up: tag MASShortcut releases upstream and switch to `upToNextMajorVersion`, matching how Sparkle is configured.

2. **[Medium] URL handler — confirm `execute-task` actions.** `rectangle://execute-task?name=ignore-app&app-bundle-id=...` (and `unignore-app`) previously mutated the disabled-apps defaults silently from *any* URL source, including a web page. Added an `NSAlert` confirmation showing the requested action and bundle-id. The confirmation is skipped only when Rectangle itself is frontmost, so the in-app/Stream-Deck/Shortcuts.app workflows are unchanged. `execute-action` is intentionally left alone — those actions are reversible and silent execution is the documented contract.

3. **[Medium] `Config.loadFromSupportDir()` — confirm + harden.** On every launch Rectangle auto-loaded any `~/Library/Application Support/Rectangle/RectangleConfig.json` and applied it (overwriting shortcuts and the entire defaults set), so any process running as the user could rewrite Rectangle config silently. Now:
   - Asks the user to Apply / Discard before importing.
   - Refuses symlinks and world-writable files (and warns the user).
   - Adds a 1 MiB size cap inside `load(fileUrl:)` so both auto-load and the explicit Import button are protected from OOM via a giant config file.

## Not changed in this PR (low severity, documented in `SECURITY_AUDIT.md`)

- Optional scheme/bundle-id shape validation in the URL handler.
- `codesign --force --deep` in `.github/workflows/build.yml` (Apple-deprecated; tangentially `runs-on: macos-26` is also not a valid runner label).
- Adding a `SECURITY.md` with a disclosure address.

## Verification

- `plutil -lint` reports the modified `project.pbxproj` is valid; brace count is balanced.
- No `xcodebuild` archive build was attempted from the audit machine (no Xcode + no signing identity). Maintainer CI will exercise the full build on this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>