### PR TITLE
Fix window width not applied correctly when resizing across displays with dock on right

### DIFF
--- a/Rectangle/AccessibilityElement.swift
+++ b/Rectangle/AccessibilityElement.swift
@@ -121,6 +121,10 @@ class AccessibilityElement {
     /// The Accessebility API only allows size & position adjustments individually.
     /// To handle moving to different displays, we have to adjust the size then the position, then the size again since macOS will enforce sizes that fit on the current display.
     /// When windows take a long time to adjust size & position, there is some visual stutter with doing each of these actions. The stutter can be slightly reduced by removing the initial size adjustment, which can make unsnap restore appear smoother.
+    /// If the target frame extends beyond the main screen's right edge, we first move the window
+    /// to a safe position (left side), resize it, then move it to the final position.
+    /// This works around a macOS constraint that can prevent windows from being resized
+    /// when their maxX would exceed the main screen's frame.maxX.
     func setFrame(_ frame: CGRect, adjustSizeFirst: Bool = true) {
         let appElement = applicationElement
         var enhancedUI: Bool? = nil
@@ -133,11 +137,27 @@ class AccessibilityElement {
             }
         }
 
-        if adjustSizeFirst {
+        // Check if target frame would extend beyond main screen's right edge,
+        // which can trigger a macOS constraint that prevents proper resizing.
+        let mainScreenFrame = NSScreen.screens[0].frame
+        let targetMaxX = frame.maxX  // frame is in screen-flipped coords, X is same as Cocoa
+
+        if targetMaxX > mainScreenFrame.maxX {
+            // Strategy: move to safe X first, resize, then move to final position
+            let safeX = mainScreenFrame.maxX - frame.width
+            let safeOrigin = CGPoint(x: safeX, y: frame.origin.y)
+            position = safeOrigin
+            size = frame.size
+            position = frame.origin
+            size = frame.size
+        } else if adjustSizeFirst {
+            size = frame.size
+            position = frame.origin
+            size = frame.size
+        } else {
+            position = frame.origin
             size = frame.size
         }
-        position = frame.origin
-        size = frame.size
 
         // If "enhanced user interface" was originally enabled for the app, turn it back on
         if Defaults.enhancedUI.value == .disableEnable, let appElement = appElement, enhancedUI == true {

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -140,16 +140,18 @@ class WindowManager {
                                                 visibleFrameOfScreen: visibleFrameOfDestinationScreen,
                                                 source: parameters.source,
                                                 isFixedSize: isFixedSize)
-        
+
         var resultingRect = apply(result: resultParameters)
-        
+
         let isMovedAcrossDisplays = usableScreens.currentScreen != calcResult.screen
         if isMovedAcrossDisplays {
-            if calcResult.rect.height != resultingRect.height {
+            let sizeMismatch = calcResult.rect.height != resultingRect.height || calcResult.rect.width != resultingRect.width
+            if sizeMismatch {
                 Logger.log("Window size wasn't applied perfectly across displays. Trying again.")
                 resultingRect = apply(result: resultParameters)
-                
-                if calcResult.rect.height != resultingRect.height {
+
+                let stillMismatch = calcResult.rect.height != resultingRect.height || calcResult.rect.width != resultingRect.width
+                if stillMismatch {
                     Logger.log("Final attempt to adjust across displays.")
                     DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(25)) { [weak self] in
                         guard let self else { return }


### PR DESCRIPTION
## Problem

When the macOS dock is positioned on the **right side**, moving a window from a smaller display to a larger display using window management shortcuts (e.g., right half) could result in the target width not being applied. The window would only cover a portion of the intended half-screen area.

The issue was reproducible with "repeated command" modes when windows crossed display boundaries — the window would end up narrower than expected on the destination display.

## Root Cause

macOS enforces a constraint that prevents windows from extending beyond the main screen's frame.maxX via the Accessibility API. When targeting a right-half position on a large external display (e.g., an ultrawide monitor positioned to the right of a built-in Retina display), the calculated frame's maxX could exceed the main screen's frame.maxX. The Accessibility API would silently reject or clamp the size change, leaving the window at a width that fits within the main display's bounds (e.g., 744px instead of the intended 1720px).

## Changes

### 1. AccessibilityElement.setFrame — safe-resize strategy

When the target frame's maxX exceeds the main screen's maxX, the method now uses an alternative sequence: move to a safe X position first where the size constraint is not triggered, resize to the target dimensions, then move to the final position. This works around the macOS constraint while preserving the existing size-position-size approach for all other cases.

### 2. WindowManager.execute — width-aware retry logic

The cross-display retry logic previously only checked for **height** mismatches when deciding whether to re-apply the window frame. It now also checks for **width** mismatches, ensuring both dimensions are correctly applied when moving windows between displays.

## Testing

Tested on macOS 26 with a dual-display setup:
- Built-in Retina display (1512×982)
- LG Ultrawide external display (3440×1440) positioned to the right, with the macOS dock on the right side

Reproduction steps:
1. Place dock on the right side of the screen
2. Open a window on the built-in display
3. Press right-half shortcut → window correctly fills right half of built-in display ✓
4. Move cursor to external display
5. Press right-half shortcut → window correctly fills right half of external display ✓
6. Toggle left-half / right-half on both displays and verify consistent behavior ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)