### PR TITLE
Adds a "Skip gap on top screen edge" checkbox in Settings

### DIFF
--- a/Rectangle/Base.lproj/Main.storyboard
+++ b/Rectangle/Base.lproj/Main.storyboard
@@ -2889,7 +2889,7 @@
                                             </stackView>
                                             <button verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="GTP-tg-Gap">
                                                 <rect key="frame" x="0.0" y="308" width="500" height="16"/>
-                                                <buttonCell key="cell" type="check" title="Skip gap on top screen edge" bezelStyle="regularSquare" imagePosition="left" inset="2" id="GTP-tg-Cel">
+                                                <buttonCell key="cell" type="check" title="Remove gap on top screen edge" bezelStyle="regularSquare" imagePosition="left" inset="2" id="GTP-tg-Cel">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>

--- a/Rectangle/Base.lproj/Main.storyboard
+++ b/Rectangle/Base.lproj/Main.storyboard
@@ -2887,6 +2887,16 @@
                                                     <real value="3.4028234663852886e+38"/>
                                                 </customSpacing>
                                             </stackView>
+                                            <button verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="GTP-tg-Gap">
+                                                <rect key="frame" x="0.0" y="308" width="500" height="16"/>
+                                                <buttonCell key="cell" type="check" title="Skip gap on top screen edge" bezelStyle="regularSquare" imagePosition="left" inset="2" id="GTP-tg-Cel">
+                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="toggleSkipGapTopEdge:" target="yhc-gS-h02" id="GTP-tg-Act"/>
+                                                </connections>
+                                            </button>
                                             <button verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="UY7-Nt-G3K">
                                                 <rect key="frame" x="0.0" y="308" width="500" height="16"/>
                                                 <buttonCell key="cell" type="check" title="Remove keyboard shortcut restrictions" bezelStyle="regularSquare" imagePosition="left" inset="2" id="n4U-FC-L9s">
@@ -3415,6 +3425,7 @@
                         <outlet property="extraSettingsButton" destination="Ext-Set-Btn" id="Ext-Set-Out"/>
                         <outlet property="gapLabel" destination="jd8-SJ-lza" id="pqG-fr-nwW"/>
                         <outlet property="gapSlider" destination="O9H-ZD-bqL" id="H7T-4Y-g8e"/>
+                        <outlet property="skipGapTopEdgeCheckbox" destination="GTP-tg-Gap" id="GTP-tg-Out"/>
                         <outlet property="hideMenuBarIconCheckbox" destination="wBT-R4-q9s" id="bkO-zn-yAZ"/>
                         <outlet property="launchOnLoginCheckbox" destination="eQJ-O3-a8H" id="iF3-bq-l1j"/>
                         <outlet property="reflowTodoShortcutView" destination="QTZ-pv-mwo" id="VYl-Tv-gFy"/>

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -15,6 +15,7 @@ class Defaults {
     static let almostMaximizeHeight = FloatDefault(key: "almostMaximizeHeight")
     static let almostMaximizeWidth = FloatDefault(key: "almostMaximizeWidth")
     static let gapSize = FloatDefault(key: "gapSize")
+    static let skipGapTopEdge = BoolDefault(key: "skipGapTopEdge")
     static let snapEdgeMarginTop = FloatDefault(key: "snapEdgeMarginTop", defaultValue: 5)
     static let snapEdgeMarginBottom = FloatDefault(key: "snapEdgeMarginBottom", defaultValue: 5)
     static let snapEdgeMarginLeft = FloatDefault(key: "snapEdgeMarginLeft", defaultValue: 5)
@@ -111,6 +112,7 @@ class Defaults {
         almostMaximizeHeight,
         almostMaximizeWidth,
         gapSize,
+        skipGapTopEdge,
         snapEdgeMarginTop,
         snapEdgeMarginBottom,
         snapEdgeMarginLeft,

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -16,6 +16,7 @@ class SettingsViewController: NSViewController {
     @IBOutlet weak var checkForUpdatesButton: NSButton!
     @IBOutlet weak var gapSlider: NSSlider!
     @IBOutlet weak var gapLabel: NSTextField!
+    @IBOutlet weak var skipGapTopEdgeCheckbox: NSButton!
     @IBOutlet weak var cursorAcrossCheckbox: NSButton!
     @IBOutlet weak var useCursorScreenDetectionCheckbox: NSButton!
     @IBOutlet weak var doubleClickTitleBarCheckbox: NSButton!
@@ -76,6 +77,10 @@ class SettingsViewController: NSViewController {
         initializeCycleSizesView(animated: true)
     }
     
+    @IBAction func toggleSkipGapTopEdge(_ sender: NSButton) {
+        Defaults.skipGapTopEdge.enabled = sender.state == .on
+    }
+
     @IBAction func gapSliderChanged(_ sender: NSSlider) {
         gapLabel.stringValue = "\(sender.intValue) px"
         if let event = NSApp.currentEvent {
@@ -1037,6 +1042,7 @@ class SettingsViewController: NSViewController {
         gapSlider.intValue = Int32(Defaults.gapSize.value)
         gapLabel.stringValue = "\(gapSlider.intValue) px"
         gapSlider.isContinuous = true
+        skipGapTopEdgeCheckbox.state = Defaults.skipGapTopEdge.enabled ? .on : .off
         
         cursorAcrossCheckbox.state = Defaults.moveCursorAcrossDisplays.userEnabled ? .on : .off
 

--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -387,7 +387,7 @@ class SnappingManager {
             if Defaults.gapSize.value > 0, gapsApplicable != .none {
                 let gapSharedEdges = rectResult.subAction?.gapSharedEdge ?? hotSpot.action.gapSharedEdge
 
-                return GapCalculation.applyGaps(rectResult.rect, dimension: gapsApplicable, sharedEdges: gapSharedEdges, gapSize: Defaults.gapSize.value)
+                return GapCalculation.applyGaps(rectResult.rect, dimension: gapsApplicable, sharedEdges: gapSharedEdges, gapSize: Defaults.gapSize.value, skipTopGap: Defaults.skipGapTopEdge.enabled)
             }
             
             return rectResult.rect

--- a/Rectangle/WindowCalculation/GapCalculation.swift
+++ b/Rectangle/WindowCalculation/GapCalculation.swift
@@ -4,8 +4,7 @@ import Foundation
 
 class GapCalculation {
     
-    static func applyGaps(_ rect: CGRect, dimension: Dimension = .both, sharedEdges: Edge = .none, gapSize: Float) -> CGRect {
-        
+    static func applyGaps(_ rect: CGRect, dimension: Dimension = .both, sharedEdges: Edge = .none, gapSize: Float, skipTopGap: Bool = false) -> CGRect {
         let cgGapSize = CGFloat(gapSize)
         let halfGapSize = cgGapSize / 2
         
@@ -34,6 +33,9 @@ class GapCalculation {
             
             if sharedEdges.contains(.top) {
                 withGaps.size.height += halfGapSize
+            }
+            if skipTopGap && !sharedEdges.contains(.top) {
+                withGaps.size.height += cgGapSize
             }
         }
         

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -115,7 +115,7 @@ class WindowManager {
         if Defaults.gapSize.value > 0, gapsApplicable != .none {
             let gapSharedEdges = calcResult.resultingSubAction?.gapSharedEdge ?? calcResult.resultingAction.gapSharedEdge
             
-            calcResult.rect = GapCalculation.applyGaps(calcResult.rect, dimension: gapsApplicable, sharedEdges: gapSharedEdges, gapSize: Defaults.gapSize.value)
+            calcResult.rect = GapCalculation.applyGaps(calcResult.rect, dimension: gapsApplicable, sharedEdges: gapSharedEdges, gapSize: Defaults.gapSize.value, skipTopGap: Defaults.skipGapTopEdge.enabled)
         }
 
         if Defaults.cyclingOverlapOffset.userEnabled, action.positionCycles {

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -20356,13 +20356,13 @@
       }
     },
     "GTP-tg-Cel.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Skip gap on top screen edge\"; ObjectID = \"GTP-tg-Cel\";",
+      "comment" : "Class = \"NSButtonCell\"; title = \"Remove gap on top screen edge\"; ObjectID = \"GTP-tg-Cel\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Skip gap on top screen edge"
+            "value" : "Remove gap on top screen edge"
           }
         }
       }

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -20355,6 +20355,18 @@
         }
       }
     },
+    "GTP-tg-Cel.title" : {
+      "comment" : "Class = \"NSButtonCell\"; title = \"Skip gap on top screen edge\"; ObjectID = \"GTP-tg-Cel\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Skip gap on top screen edge"
+          }
+        }
+      }
+    },
     "GUa-eO-cwY.title" : {
       "comment" : "Class = \"NSMenuItem\"; title = \"Use Default\"; ObjectID = \"GUa-eO-cwY\";",
       "extractionState" : "manual",


### PR DESCRIPTION
**Change Description:**
Currently, window gaps apply underneath the MacOS menu bar. On displays without a notch, this can create a larger perceived top margin relative to the other screen edges.

This PR adds an optional setting to exclude the top screen edge while preserving the gaps for the other sides and between windows.

Default behavior stays the same. 

**Original behavior, applying padding under menu bar:**
<img width="1920" height="1080" alt="CleanShot 2026-06-03 at 13 45 53" src="https://github.com/user-attachments/assets/7fca9389-b6f3-45a6-baf7-01721962dadc" />

**Behavior with top edge gap disabled:**
<img width="1920" height="1080" alt="CleanShot 2026-06-03 at 13 47 44" src="https://github.com/user-attachments/assets/d051f262-ae20-41fe-b6af-3122edc58d03" />
<img width="1920" height="1080" alt="CleanShot 2026-06-03 at 13 50 00" src="https://github.com/user-attachments/assets/023e5d25-fc89-4a71-a072-68424507121d" />

**Settings Menu:**
<img width="2096" height="1686" alt="CleanShot 2026-06-03 at 13 59 31@2x" src="https://github.com/user-attachments/assets/4f26beb5-c479-4abf-9676-e418f01a5438" />



