### PR TITLE
Apply Half-Split ratio to corner actions and snap areas

### DIFF
--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -117,6 +117,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Defaults.installVersion.value = currentVersion
             Defaults.allowAnyShortcut.enabled = true
         }
+        MASShortcutMigration.migrateRenamedSideShortcutKeys()
         
         Defaults.lastVersion.value = currentVersion
     }

--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -117,7 +117,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Defaults.installVersion.value = currentVersion
             Defaults.allowAnyShortcut.enabled = true
         }
-        MASShortcutMigration.migrateRenamedSideShortcutKeys()
+        MASShortcutMigration.syncRenamedSideShortcutAliases()
         
         Defaults.lastVersion.value = currentVersion
     }

--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -669,7 +669,12 @@ extension AppDelegate {
                 let name = (components.queryItems?.first { $0.name == "name" })?.value
                 switch (components.host, name) {
                 case ("execute-action", _):
-                    let action = (WindowAction.active.first { getUrlName($0.name) == name })
+                    let action = (WindowAction.active.first { windowAction in
+                        if let aliasName = windowAction.aliasName, getUrlName(aliasName) == name {
+                            return true
+                        }
+                        return getUrlName(windowAction.name) == name
+                    })
                     action?.postUrl()
                 case ("execute-task", "ignore-app"):
                     let bundleId = extractBundleIdParameter(fromComponents: components)

--- a/Rectangle/Base.lproj/Main.storyboard
+++ b/Rectangle/Base.lproj/Main.storyboard
@@ -343,7 +343,7 @@
                                                                         <subviews>
                                                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oac-MY-1n1">
                                                                                 <rect key="frame" x="-2" y="0.0" width="56" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Left Half" id="Xc8-Sm-pig">
+                                                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Left Side" id="Xc8-Sm-pig">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -392,7 +392,7 @@
                                                                         <subviews>
                                                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="daG-bl-Dca">
                                                                                 <rect key="frame" x="-2" y="0.0" width="64" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Right Half" id="F8S-GI-LiB">
+                                                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Right Side" id="F8S-GI-LiB">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -441,7 +441,7 @@
                                                                         <subviews>
                                                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3T8-Nh-bKb">
                                                                                 <rect key="frame" x="-2" y="0.0" width="73" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Center Half" id="bRX-dV-iAR">
+                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Center Section" id="bRX-dV-iAR">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -490,7 +490,7 @@
                                                                         <subviews>
                                                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="j1Z-dN-QdR">
                                                                                 <rect key="frame" x="-2" y="0.0" width="55" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Top Half" id="d7y-s8-7GE">
+                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Top Side" id="d7y-s8-7GE">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -542,7 +542,7 @@
                                                                         <subviews>
                                                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xwW-KA-j8t">
                                                                                 <rect key="frame" x="-2" y="0.0" width="77" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Bottom Half" id="ec4-FB-fMa">
+                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Bottom Side" id="ec4-FB-fMa">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -2804,17 +2804,17 @@
                                                     </textField>
                                                     <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="pVH-s3-FHn">
                                                         <rect key="frame" x="138" y="0.0" width="362" height="24"/>
-                                                        <popUpButtonCell key="cell" type="push" title="move to adjacent on left/right, or cycle size on half" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="3" imageScaling="proportionallyDown" inset="2" selectedItem="3GE-la-fAZ" id="ccx-Gx-MGO">
+                                                        <popUpButtonCell key="cell" type="push" title="move to adjacent on left/right, or cycle size on side" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="3" imageScaling="proportionallyDown" inset="2" selectedItem="3GE-la-fAZ" id="ccx-Gx-MGO">
                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" size="12" name="HelveticaNeue"/>
                                                             <menu key="menu" id="TkU-PT-5p8">
                                                                 <items>
                                                                     <menuItem title="do nothing" tag="2" id="jww-Ju-S3d"/>
                                                                     <menuItem title="cycle through displays" tag="4" id="XlM-ch-cLG"/>
-                                                                    <menuItem title="cycle sizes on half actions" id="gHH-BV-5kP"/>
+                                                                    <menuItem title="cycle sizes on side actions" id="gHH-BV-5kP"/>
                                                                     <menuItem title="move to adjacent display on left or right" tag="1" id="Z9d-Rl-RVq"/>
-                                                                    <menuItem title="move to adjacent on left/right, or cycle size on half" state="on" tag="3" id="3GE-la-fAZ"/>
-                                                                    <menuItem title="cycle positions on quadrants, cycle sizes on half" tag="5" id="qCy-Kx-9mR"/>
+                                                                    <menuItem title="move to adjacent on left/right, or cycle size on side" state="on" tag="3" id="3GE-la-fAZ"/>
+                                                                    <menuItem title="cycle positions on quadrants, cycle sizes on side" tag="5" id="qCy-Kx-9mR"/>
                                                                 </items>
                                                             </menu>
                                                         </popUpButtonCell>

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -40,7 +40,7 @@ enum CycleSize: Int, CaseIterable {
     }()
 }
 
-enum RepeatedCommandCycleAxis: Int {
+enum CornerCycleExpansionAxis: Int {
     case horizontal = 0
     case vertical = 1
 }

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -41,6 +41,11 @@ enum CycleSize: Int, CaseIterable {
 }
 
 extension CycleSize {
+    static let matchingTolerance: Float = 0.001
+    
+    static func matching(percentValue: Float) -> CycleSize? {
+        sortedSizes.first { $0.matches(percentValue: percentValue) }
+    }
     
     var title: String {
         switch self {
@@ -70,6 +75,14 @@ extension CycleSize {
         case .threeQuarters:
             3 / 4
         }
+    }
+    
+    var percentValue: Float {
+        fraction * 100
+    }
+    
+    func matches(percentValue: Float, tolerance: Float = Self.matchingTolerance) -> Bool {
+        abs(self.percentValue - percentValue) <= tolerance
     }
     
     var isAlwaysEnabled: Bool {

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -90,14 +90,6 @@ extension CycleSize {
         abs(self.percentValue - percentValue) <= tolerance
     }
     
-    var isAlwaysEnabled: Bool {
-        if self == .firstSize {
-            return true
-        }
-        
-        return false
-    }
-    
 }
 
 extension Set where Element == CycleSize {

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -40,6 +40,11 @@ enum CycleSize: Int, CaseIterable {
     }()
 }
 
+enum RepeatedCommandCycleAxis: Int {
+    case horizontal = 0
+    case vertical = 1
+}
+
 extension CycleSize {
     static let matchingTolerance: Float = 0.001
     

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -10,7 +10,7 @@ class Defaults {
     static let subsequentExecutionMode = SubsequentExecutionDefault()
     static let selectedCycleSizes = CycleSizesDefault()
     static let cycleSizesIsChanged = BoolDefault(key: "cycleSizesIsChanged")
-    static let repeatedCommandCycleAxis = IntEnumDefault<RepeatedCommandCycleAxis>(key: "repeatedCommandCycleAxis", defaultValue: .horizontal)
+    static let cornerCycleExpansionAxis = IntEnumDefault<CornerCycleExpansionAxis>(key: "cornerCycleExpansionAxis", defaultValue: .horizontal)
     static let allowAnyShortcut = BoolDefault(key: "allowAnyShortcut")
     static let windowSnapping = OptionalBoolDefault(key: "windowSnapping")
     static let almostMaximizeHeight = FloatDefault(key: "almostMaximizeHeight")
@@ -108,7 +108,7 @@ class Defaults {
         subsequentExecutionMode,
         selectedCycleSizes,
         cycleSizesIsChanged,
-        repeatedCommandCycleAxis,
+        cornerCycleExpansionAxis,
         allowAnyShortcut,
         windowSnapping,
         almostMaximizeHeight,

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -10,6 +10,7 @@ class Defaults {
     static let subsequentExecutionMode = SubsequentExecutionDefault()
     static let selectedCycleSizes = CycleSizesDefault()
     static let cycleSizesIsChanged = BoolDefault(key: "cycleSizesIsChanged")
+    static let repeatedCommandCycleAxis = IntEnumDefault<RepeatedCommandCycleAxis>(key: "repeatedCommandCycleAxis", defaultValue: .horizontal)
     static let allowAnyShortcut = BoolDefault(key: "allowAnyShortcut")
     static let windowSnapping = OptionalBoolDefault(key: "windowSnapping")
     static let almostMaximizeHeight = FloatDefault(key: "almostMaximizeHeight")
@@ -107,6 +108,7 @@ class Defaults {
         subsequentExecutionMode,
         selectedCycleSizes,
         cycleSizesIsChanged,
+        repeatedCommandCycleAxis,
         allowAnyShortcut,
         windowSnapping,
         almostMaximizeHeight,

--- a/Rectangle/PrefsWindow/Config.swift
+++ b/Rectangle/PrefsWindow/Config.swift
@@ -73,7 +73,8 @@ extension Defaults {
         }
         
         for action in WindowAction.active {
-            if let shortcut = config.shortcuts[action.name]?.toMASSHortcut() {
+            let importedShortcut = config.shortcuts[action.name] ?? action.legacyName.flatMap { config.shortcuts[$0] }
+            if let shortcut = importedShortcut?.toMASSHortcut() {
                 let dictValue = dictTransformer.reverseTransformedValue(shortcut)
                 UserDefaults.standard.setValue(dictValue, forKey: action.name)
             }

--- a/Rectangle/PrefsWindow/Config.swift
+++ b/Rectangle/PrefsWindow/Config.swift
@@ -73,7 +73,7 @@ extension Defaults {
         }
         
         for action in WindowAction.active {
-            let importedShortcut = config.shortcuts[action.name] ?? action.legacyName.flatMap { config.shortcuts[$0] }
+            let importedShortcut = config.shortcuts[action.name] ?? action.aliasName.flatMap { config.shortcuts[$0] }
             if let shortcut = importedShortcut?.toMASSHortcut() {
                 let dictValue = dictTransformer.reverseTransformedValue(shortcut)
                 UserDefaults.standard.setValue(dictValue, forKey: action.name)

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -44,7 +44,7 @@ class SettingsViewController: NSViewController {
     private let shortcutRecordingObserver = ShortcutRecordingObserver()
     
     private var cycleSizeCheckboxes = [NSButton]()
-    private var repeatedCommandCycleAxisCheckboxes = [NSButton]()
+    private var cornerCycleExpansionAxisButtons = [NSButton]()
     private var combinedDisplayModeCheckbox: NSButton?
     
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
@@ -119,14 +119,14 @@ class SettingsViewController: NSViewController {
         Defaults.cyclingOverlapOffset.enabled = sender.state == .on
     }
 
-    @objc func toggleRepeatedCommandCycleAxis(_ sender: NSButton) {
-        guard let axis = RepeatedCommandCycleAxis(rawValue: sender.tag) else {
-            Logger.log("Expected tag of repeated-command axis lock checkbox to match a value of RepeatedCommandCycleAxis. Got: \(String(describing: sender.tag))")
+    @objc func setCornerCycleExpansionAxis(_ sender: NSButton) {
+        guard let axis = CornerCycleExpansionAxis(rawValue: sender.tag) else {
+            Logger.log("Expected tag of cyclic corner expansion axis radio button to match a value of CornerCycleExpansionAxis. Got: \(String(describing: sender.tag))")
             return
         }
 
-        Defaults.repeatedCommandCycleAxis.value = axis
-        setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
+        Defaults.cornerCycleExpansionAxis.value = axis
+        setToggleStatesForCornerCycleExpansionAxisButtons()
     }
     
     @IBAction func checkForUpdates(_ sender: Any) {
@@ -1024,24 +1024,20 @@ class SettingsViewController: NSViewController {
         initializeTodoModeSettings()
         shortcutRecordingObserver.observe([toggleTodoShortcutView, reflowTodoShortcutView])
         
-        self.cycleSizeCheckboxes.forEach {
-            $0.removeFromSuperview()
-        }
-        self.repeatedCommandCycleAxisCheckboxes.forEach {
-            $0.removeFromSuperview()
+        cycleSizesView.arrangedSubviews.forEach { view in
+            cycleSizesView.removeArrangedSubview(view)
+            view.removeFromSuperview()
         }
         
         let cycleSizeCheckboxes = makeCycleSizeCheckboxes()
-        cycleSizeCheckboxes.forEach { checkbox in
-            cycleSizesView.addArrangedSubview(checkbox)
-        }
         self.cycleSizeCheckboxes = cycleSizeCheckboxes
 
-        let repeatedCommandCycleAxisCheckboxes = makeRepeatedCommandCycleAxisCheckboxes()
-        repeatedCommandCycleAxisCheckboxes.forEach { checkbox in
-            cycleSizesView.addArrangedSubview(checkbox)
-        }
-        self.repeatedCommandCycleAxisCheckboxes = repeatedCommandCycleAxisCheckboxes
+        let cornerCycleExpansionAxisRow = makeCornerCycleExpansionAxisRow()
+        cycleSizesView.orientation = .vertical
+        cycleSizesView.alignment = .leading
+        cycleSizesView.spacing = 4
+        cycleSizesView.addArrangedSubview(makeCycleSizesRow(cycleSizeCheckboxes))
+        cycleSizesView.addArrangedSubview(cornerCycleExpansionAxisRow)
         
         initializeCycleSizesView(animated: false)
 
@@ -1122,7 +1118,7 @@ class SettingsViewController: NSViewController {
             stageView.isHidden = true
         }
         setToggleStatesForCycleSizeCheckboxes()
-        setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
+        setToggleStatesForCornerCycleExpansionAxisButtons()
     }
     
     private func initializeCycleSizesView(animated: Bool = false) {
@@ -1130,7 +1126,7 @@ class SettingsViewController: NSViewController {
         
         if showOptionsView {
             setToggleStatesForCycleSizeCheckboxes()
-            setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
+            setToggleStatesForCornerCycleExpansionAxisButtons()
         }
         
         setVisibility(shown: showOptionsView, ofView: cycleSizesView, withConstraint: cycleSizesViewHeightConstraint, animated: animated)
@@ -1214,15 +1210,35 @@ class SettingsViewController: NSViewController {
         }
     }
 
-    private func makeRepeatedCommandCycleAxisCheckboxes() -> [NSButton] {
-        [
-            makeRepeatedCommandCycleAxisCheckbox(title: NSLocalizedString("Lock horizontal axis", tableName: "Main", value: "", comment: ""), axis: .horizontal),
-            makeRepeatedCommandCycleAxisCheckbox(title: NSLocalizedString("Lock vertical axis", tableName: "Main", value: "", comment: ""), axis: .vertical)
-        ]
+    private func makeCycleSizesRow(_ checkboxes: [NSButton]) -> NSStackView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = 8
+        checkboxes.forEach { row.addArrangedSubview($0) }
+        return row
     }
 
-    private func makeRepeatedCommandCycleAxisCheckbox(title: String, axis: RepeatedCommandCycleAxis) -> NSButton {
-        let button = NSButton(checkboxWithTitle: title, target: self, action: #selector(toggleRepeatedCommandCycleAxis(_:)))
+    private func makeCornerCycleExpansionAxisRow() -> NSStackView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = 8
+
+        let label = NSTextField(labelWithString: NSLocalizedString("Cyclic corner shortcuts expand:", tableName: "Main", value: "", comment: ""))
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        row.addArrangedSubview(label)
+
+        let horizontalButton = makeCornerCycleExpansionAxisButton(title: NSLocalizedString("horizontally", tableName: "Main", value: "", comment: ""), axis: .horizontal)
+        let verticalButton = makeCornerCycleExpansionAxisButton(title: NSLocalizedString("vertically", tableName: "Main", value: "", comment: ""), axis: .vertical)
+        cornerCycleExpansionAxisButtons = [horizontalButton, verticalButton]
+        cornerCycleExpansionAxisButtons.forEach { row.addArrangedSubview($0) }
+
+        return row
+    }
+
+    private func makeCornerCycleExpansionAxisButton(title: String, axis: CornerCycleExpansionAxis) -> NSButton {
+        let button = NSButton(radioButtonWithTitle: title, target: self, action: #selector(setCornerCycleExpansionAxis(_:)))
         button.tag = axis.rawValue
         button.setContentCompressionResistancePriority(.required, for: .vertical)
         return button
@@ -1310,9 +1326,9 @@ class SettingsViewController: NSViewController {
         }
     }
 
-    private func setToggleStatesForRepeatedCommandCycleAxisCheckboxes() {
-        repeatedCommandCycleAxisCheckboxes.forEach { checkbox in
-            checkbox.state = checkbox.tag == Defaults.repeatedCommandCycleAxis.value.rawValue ? .on : .off
+    private func setToggleStatesForCornerCycleExpansionAxisButtons() {
+        cornerCycleExpansionAxisButtons.forEach { button in
+            button.state = button.tag == Defaults.cornerCycleExpansionAxis.value.rawValue ? .on : .off
         }
     }
 

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -1205,6 +1205,7 @@ class SettingsViewController: NSViewController {
         CycleSize.sortedSizes.map { division in
             let button = NSButton(checkboxWithTitle: division.title, target: self, action: #selector(didCheckCycleSizeCheckbox(sender:)))
             button.tag = division.rawValue
+            button.refusesFirstResponder = true
             button.setContentCompressionResistancePriority(.required, for: .vertical)
             return button
         }
@@ -1240,6 +1241,7 @@ class SettingsViewController: NSViewController {
     private func makeCornerCycleExpansionAxisButton(title: String, axis: CornerCycleExpansionAxis) -> NSButton {
         let button = NSButton(radioButtonWithTitle: title, target: self, action: #selector(setCornerCycleExpansionAxis(_:)))
         button.tag = axis.rawValue
+        button.refusesFirstResponder = true
         button.setContentCompressionResistancePriority(.required, for: .vertical)
         return button
     }
@@ -1315,14 +1317,9 @@ class SettingsViewController: NSViewController {
                 return
             }
             
-            let isAlwaysEnabled = cycleSizeForCheckbox.isAlwaysEnabled
-            let isChecked = isAlwaysEnabled || cycleSizes.contains(cycleSizeForCheckbox)
+            let isChecked = cycleSizes.contains(cycleSizeForCheckbox)
             checkbox.state = isChecked ? .on : .off
-            
-            // Show that the box cannot be unchecked.
-            if isAlwaysEnabled {
-                checkbox.isEnabled = false
-            }
+            checkbox.isEnabled = true
         }
     }
 

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -1033,7 +1033,7 @@ class SettingsViewController: NSViewController {
         let cornerCycleExpansionAxisRow = makeCornerCycleExpansionAxisRow()
         cycleSizesView.orientation = .vertical
         cycleSizesView.alignment = .leading
-        cycleSizesView.spacing = 4
+        cycleSizesView.spacing = 8
         cycleSizesView.addArrangedSubview(makeCycleSizesRow(cycleSizeCheckboxes))
         cycleSizesView.addArrangedSubview(cornerCycleExpansionAxisRow)
         

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -374,7 +374,7 @@ class SettingsViewController: NSViewController {
             integerFormatter.minimum = 1
             widthStepField.formatter = integerFormatter
 
-            let splitRatioHeaderLabel = NSTextField(labelWithString: NSLocalizedString("Half Split Ratios", tableName: "Main", value: "", comment: ""))
+            let splitRatioHeaderLabel = NSTextField(labelWithString: NSLocalizedString("Side Split Ratio", tableName: "Main", value: "", comment: ""))
             splitRatioHeaderLabel.font = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize)
             splitRatioHeaderLabel.alignment = .center
             splitRatioHeaderLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -965,8 +965,6 @@ class SettingsViewController: NSViewController {
                 twelfthsCyclingShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 sixteenthsCyclingShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 widthStepField.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor),
-                hSplitField.widthAnchor.constraint(equalToConstant: 160),
-                vSplitField.widthAnchor.constraint(equalToConstant: 160),
                 showAdditionalSizesCheckbox.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 overlapOffsetCheckbox.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 smallerWidthShortcutView.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -44,6 +44,7 @@ class SettingsViewController: NSViewController {
     private let shortcutRecordingObserver = ShortcutRecordingObserver()
     
     private var cycleSizeCheckboxes = [NSButton]()
+    private var repeatedCommandCycleAxisCheckboxes = [NSButton]()
     private var combinedDisplayModeCheckbox: NSButton?
     
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
@@ -116,6 +117,16 @@ class SettingsViewController: NSViewController {
 
     @objc func toggleCyclingOverlapOffset(_ sender: NSButton) {
         Defaults.cyclingOverlapOffset.enabled = sender.state == .on
+    }
+
+    @objc func toggleRepeatedCommandCycleAxis(_ sender: NSButton) {
+        guard let axis = RepeatedCommandCycleAxis(rawValue: sender.tag) else {
+            Logger.log("Expected tag of repeated-command axis lock checkbox to match a value of RepeatedCommandCycleAxis. Got: \(String(describing: sender.tag))")
+            return
+        }
+
+        Defaults.repeatedCommandCycleAxis.value = axis
+        setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
     }
     
     @IBAction func checkForUpdates(_ sender: Any) {
@@ -1016,12 +1027,21 @@ class SettingsViewController: NSViewController {
         self.cycleSizeCheckboxes.forEach {
             $0.removeFromSuperview()
         }
+        self.repeatedCommandCycleAxisCheckboxes.forEach {
+            $0.removeFromSuperview()
+        }
         
         let cycleSizeCheckboxes = makeCycleSizeCheckboxes()
         cycleSizeCheckboxes.forEach { checkbox in
             cycleSizesView.addArrangedSubview(checkbox)
         }
         self.cycleSizeCheckboxes = cycleSizeCheckboxes
+
+        let repeatedCommandCycleAxisCheckboxes = makeRepeatedCommandCycleAxisCheckboxes()
+        repeatedCommandCycleAxisCheckboxes.forEach { checkbox in
+            cycleSizesView.addArrangedSubview(checkbox)
+        }
+        self.repeatedCommandCycleAxisCheckboxes = repeatedCommandCycleAxisCheckboxes
         
         initializeCycleSizesView(animated: false)
 
@@ -1101,9 +1121,8 @@ class SettingsViewController: NSViewController {
         } else {
             stageView.isHidden = true
         }
-        
-        
         setToggleStatesForCycleSizeCheckboxes()
+        setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
     }
     
     private func initializeCycleSizesView(animated: Bool = false) {
@@ -1111,6 +1130,7 @@ class SettingsViewController: NSViewController {
         
         if showOptionsView {
             setToggleStatesForCycleSizeCheckboxes()
+            setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
         }
         
         setVisibility(shown: showOptionsView, ofView: cycleSizesView, withConstraint: cycleSizesViewHeightConstraint, animated: animated)
@@ -1193,6 +1213,20 @@ class SettingsViewController: NSViewController {
             return button
         }
     }
+
+    private func makeRepeatedCommandCycleAxisCheckboxes() -> [NSButton] {
+        [
+            makeRepeatedCommandCycleAxisCheckbox(title: NSLocalizedString("Lock horizontal axis", tableName: "Main", value: "", comment: ""), axis: .horizontal),
+            makeRepeatedCommandCycleAxisCheckbox(title: NSLocalizedString("Lock vertical axis", tableName: "Main", value: "", comment: ""), axis: .vertical)
+        ]
+    }
+
+    private func makeRepeatedCommandCycleAxisCheckbox(title: String, axis: RepeatedCommandCycleAxis) -> NSButton {
+        let button = NSButton(checkboxWithTitle: title, target: self, action: #selector(toggleRepeatedCommandCycleAxis(_:)))
+        button.tag = axis.rawValue
+        button.setContentCompressionResistancePriority(.required, for: .vertical)
+        return button
+    }
     
     private func configureHalfSplitRatioPopUpButton(_ popUpButton: HalfSplitRatioPopUpButton) {
         popUpButton.removeAllItems()
@@ -1273,6 +1307,12 @@ class SettingsViewController: NSViewController {
             if isAlwaysEnabled {
                 checkbox.isEnabled = false
             }
+        }
+    }
+
+    private func setToggleStatesForRepeatedCommandCycleAxisCheckboxes() {
+        repeatedCommandCycleAxisCheckboxes.forEach { checkbox in
+            checkbox.state = checkbox.tag == Defaults.repeatedCommandCycleAxis.value.rawValue ? .on : .off
         }
     }
 

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -391,6 +391,14 @@ class SettingsViewController: NSViewController {
             hSplitField.alignment = .right
             hSplitField.formatter = percentFormatter
 
+            let hSplitPopUpButton = HalfSplitRatioPopUpButton()
+            hSplitPopUpButton.translatesAutoresizingMaskIntoConstraints = false
+            hSplitPopUpButton.target = self
+            hSplitPopUpButton.action = #selector(didSelectHalfSplitRatioPreset(sender:))
+            hSplitPopUpButton.defaults = Defaults.horizontalSplitRatio
+            hSplitPopUpButton.customField = hSplitField
+            configureHalfSplitRatioPopUpButton(hSplitPopUpButton)
+
             let vSplitField = AutoSaveFloatField(frame: NSRect(x: 0, y: 0, width: 160, height: 19))
             vSplitField.stringValue = String(Int(Defaults.verticalSplitRatio.value))
             vSplitField.delegate = self
@@ -400,6 +408,21 @@ class SettingsViewController: NSViewController {
             vSplitField.refusesFirstResponder = true
             vSplitField.alignment = .right
             vSplitField.formatter = percentFormatter
+
+            let vSplitPopUpButton = HalfSplitRatioPopUpButton()
+            vSplitPopUpButton.translatesAutoresizingMaskIntoConstraints = false
+            vSplitPopUpButton.target = self
+            vSplitPopUpButton.action = #selector(didSelectHalfSplitRatioPreset(sender:))
+            vSplitPopUpButton.defaults = Defaults.verticalSplitRatio
+            vSplitPopUpButton.customField = vSplitField
+            configureHalfSplitRatioPopUpButton(vSplitPopUpButton)
+
+            hSplitField.defaultsSetAction = { [weak hSplitPopUpButton] in
+                hSplitPopUpButton?.selectCurrentValue()
+            }
+            vSplitField.defaultsSetAction = { [weak vSplitPopUpButton] in
+                vSplitPopUpButton?.selectCurrentValue()
+            }
 
             largerWidthShortcutView.setAssociatedUserDefaultsKey(WindowAction.largerWidth.name, withTransformerName: MASDictionaryTransformerName)
             smallerWidthShortcutView.setAssociatedUserDefaultsKey(WindowAction.smallerWidth.name, withTransformerName: MASDictionaryTransformerName)
@@ -629,14 +652,26 @@ class SettingsViewController: NSViewController {
             hSplitRow.alignment = .centerY
             hSplitRow.spacing = 18
             hSplitRow.addArrangedSubview(hSplitLabel)
-            hSplitRow.addArrangedSubview(hSplitField)
+            let hSplitControlsStack = NSStackView()
+            hSplitControlsStack.orientation = .horizontal
+            hSplitControlsStack.alignment = .centerY
+            hSplitControlsStack.spacing = 8
+            hSplitControlsStack.addArrangedSubview(hSplitPopUpButton)
+            hSplitControlsStack.addArrangedSubview(hSplitField)
+            hSplitRow.addArrangedSubview(hSplitControlsStack)
 
             let vSplitRow = NSStackView()
             vSplitRow.orientation = .horizontal
             vSplitRow.alignment = .centerY
             vSplitRow.spacing = 18
             vSplitRow.addArrangedSubview(vSplitLabel)
-            vSplitRow.addArrangedSubview(vSplitField)
+            let vSplitControlsStack = NSStackView()
+            vSplitControlsStack.orientation = .horizontal
+            vSplitControlsStack.alignment = .centerY
+            vSplitControlsStack.spacing = 8
+            vSplitControlsStack.addArrangedSubview(vSplitPopUpButton)
+            vSplitControlsStack.addArrangedSubview(vSplitField)
+            vSplitRow.addArrangedSubview(vSplitControlsStack)
             
             let topVerticalThirdRow = NSStackView()
             topVerticalThirdRow.orientation = .horizontal
@@ -896,6 +931,12 @@ class SettingsViewController: NSViewController {
                 largerWidthShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 smallerWidthShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 widthStepField.widthAnchor.constraint(equalToConstant: 160),
+                hSplitControlsStack.widthAnchor.constraint(equalToConstant: 160),
+                vSplitControlsStack.widthAnchor.constraint(equalToConstant: 160),
+                hSplitPopUpButton.widthAnchor.constraint(equalToConstant: 100),
+                vSplitPopUpButton.widthAnchor.constraint(equalToConstant: 100),
+                hSplitField.widthAnchor.constraint(equalToConstant: 52),
+                vSplitField.widthAnchor.constraint(equalToConstant: 52),
                 topVerticalThirdShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 middleVerticalThirdShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 bottomVerticalThirdShortcutView.widthAnchor.constraint(equalToConstant: 160),
@@ -936,8 +977,8 @@ class SettingsViewController: NSViewController {
                 sixteenthsCyclingShortcutView.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 gridHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
                 cyclingHintLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor, constant: -20),
-                hSplitField.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor),
-                vSplitField.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor)
+                hSplitControlsStack.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor),
+                vSplitControlsStack.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor)
             ])
 
             let containerView = NSView()
@@ -1153,6 +1194,41 @@ class SettingsViewController: NSViewController {
         }
     }
     
+    private func configureHalfSplitRatioPopUpButton(_ popUpButton: HalfSplitRatioPopUpButton) {
+        popUpButton.removeAllItems()
+        
+        CycleSize.sortedSizes.forEach { cycleSize in
+            popUpButton.addItem(withTitle: cycleSize.title)
+            popUpButton.lastItem?.tag = cycleSize.rawValue
+        }
+        
+        popUpButton.addItem(withTitle: NSLocalizedString("Other", tableName: "Main", value: "", comment: ""))
+        popUpButton.lastItem?.tag = HalfSplitRatioPopUpButton.otherTag
+        popUpButton.selectCurrentValue()
+    }
+    
+    @objc private func didSelectHalfSplitRatioPreset(sender: Any?) {
+        guard let popUpButton = sender as? HalfSplitRatioPopUpButton,
+              let defaults = popUpButton.defaults else {
+            Logger.log("Expected action to be sent from HalfSplitRatioPopUpButton. Instead, sender is: \(String(describing: sender))")
+            return
+        }
+        
+        guard popUpButton.selectedTag() != HalfSplitRatioPopUpButton.otherTag else {
+            popUpButton.customField?.isHidden = false
+            return
+        }
+        
+        guard let cycleSize = CycleSize(rawValue: popUpButton.selectedTag()) else {
+            Logger.log("Expected tag of half split ratio popup to match a value of CycleSize. Got: \(String(describing: popUpButton.selectedTag()))")
+            return
+        }
+        
+        defaults.value = cycleSize.percentValue
+        popUpButton.customField?.stringValue = "\(Int(round(cycleSize.percentValue)))"
+        popUpButton.customField?.isHidden = true
+    }
+    
     @objc private func didCheckCycleSizeCheckbox(sender: Any?) {
         guard let checkbox = sender as? NSButton else {
             Logger.log("Expected action to be sent from NSButton. Instead, sender is: \(String(describing: sender))")
@@ -1241,4 +1317,27 @@ class AutoSaveFloatField: NSTextField {
     var defaults: FloatDefault?
     var defaultsSetAction: (() -> Void)?
     var fallbackValue: Float = 30
+}
+
+class HalfSplitRatioPopUpButton: NSPopUpButton {
+    static let otherTag = -1
+    
+    var defaults: FloatDefault?
+    weak var customField: AutoSaveFloatField?
+    
+    func selectCurrentValue() {
+        guard let value = defaults?.value else {
+            selectItem(withTag: Self.otherTag)
+            customField?.isHidden = false
+            return
+        }
+        
+        if let cycleSize = CycleSize.matching(percentValue: value) {
+            selectItem(withTag: cycleSize.rawValue)
+            customField?.isHidden = true
+        } else {
+            selectItem(withTag: Self.otherTag)
+            customField?.isHidden = false
+        }
+    }
 }

--- a/Rectangle/ShortcutManager.swift
+++ b/Rectangle/ShortcutManager.swift
@@ -163,6 +163,7 @@ class ShortcutManager {
     private func reloadShortcutBindingsIfNeeded() {
         guard !isUpdatingShortcutBindings && !shortcutsSuspendedForRecording else { return }
 
+        MASShortcutMigration.syncRenamedSideShortcutAliases()
         let currentShortcuts = ShortcutCycle.shortcutsByAction()
         let currentIdentities = ShortcutCycle.shortcutIdentities(shortcutsByAction: currentShortcuts)
         guard currentIdentities != shortcutIdentities else { return }

--- a/Rectangle/Snapping/CompoundSnapArea/CompoundSnapArea.swift
+++ b/Rectangle/Snapping/CompoundSnapArea/CompoundSnapArea.swift
@@ -23,15 +23,15 @@ enum CompoundSnapArea: Int, Codable {
     var displayName: String {
         switch self {
         case .leftTopBottomHalf:
-            return NSLocalizedString("Left half, top/bottom half near corners", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Left side, top/bottom side near corners", tableName: "Main", value: "", comment: "")
         case .rightTopBottomHalf:
-            return NSLocalizedString("Right half, top/bottom half near corners", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Right side, top/bottom side near corners", tableName: "Main", value: "", comment: "")
         case .thirds:
             return NSLocalizedString("Thirds, drag toward center for two thirds", tableName: "Main", value: "", comment: "")
         case .portraitThirdsSide:
-            return NSLocalizedString("Thirds, top/bottom half near corners", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Thirds, top/bottom side near corners", tableName: "Main", value: "", comment: "")
         case .halves:
-            return NSLocalizedString("Left or right half", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Left or right side", tableName: "Main", value: "", comment: "")
         case .topSixths:
             return NSLocalizedString("Top sixths from corners; maximize", tableName: "Main", value: "", comment: "")
         case .bottomSixths:
@@ -39,7 +39,7 @@ enum CompoundSnapArea: Int, Codable {
         case .fourths:
             return NSLocalizedString("Fourths columns", tableName: "Main", value: "", comment: "")
         case .portraitTopBottomHalves:
-            return NSLocalizedString("Top/bottom halves", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Top/bottom sides", tableName: "Main", value: "", comment: "")
         case .topEighths:
             return NSLocalizedString("Top eighths from corners; maximize", tableName: "Main", value: "", comment: "")
         case .bottomEighths:

--- a/Rectangle/Utilities/MASShortcutMigration.swift
+++ b/Rectangle/Utilities/MASShortcutMigration.swift
@@ -24,5 +24,18 @@ class MASShortcutMigration {
         }
         
     }
+
+    static func migrateRenamedSideShortcutKeys(userDefaults: UserDefaults = .standard) {
+        for action in WindowAction.active {
+            guard let legacyName = action.legacyName,
+                  let legacyValue = userDefaults.object(forKey: legacyName)
+            else { continue }
+
+            if userDefaults.object(forKey: action.name) == nil {
+                userDefaults.set(legacyValue, forKey: action.name)
+            }
+            userDefaults.removeObject(forKey: legacyName)
+        }
+    }
     
 }

--- a/Rectangle/Utilities/MASShortcutMigration.swift
+++ b/Rectangle/Utilities/MASShortcutMigration.swift
@@ -25,16 +25,21 @@ class MASShortcutMigration {
         
     }
 
-    static func migrateRenamedSideShortcutKeys(userDefaults: UserDefaults = .standard) {
+    static func syncRenamedSideShortcutAliases(userDefaults: UserDefaults = .standard) {
         for action in WindowAction.active {
-            guard let legacyName = action.legacyName,
-                  let legacyValue = userDefaults.object(forKey: legacyName)
+            guard let aliasName = action.aliasName,
+                  let aliasValue = userDefaults.object(forKey: aliasName)
             else { continue }
 
-            if userDefaults.object(forKey: action.name) == nil {
-                userDefaults.set(legacyValue, forKey: action.name)
+            if let currentValue = userDefaults.object(forKey: action.name) as? NSObject,
+               let aliasObject = aliasValue as? NSObject,
+               currentValue.isEqual(aliasObject) {
+                userDefaults.removeObject(forKey: aliasName)
+                continue
             }
-            userDefaults.removeObject(forKey: legacyName)
+
+            userDefaults.set(aliasValue, forKey: action.name)
+            userDefaults.removeObject(forKey: aliasName)
         }
     }
     

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -203,16 +203,16 @@ enum WindowAction: Int, Codable {
 
     var name: String {
         switch self {
-        case .leftHalf: return "leftHalf"
-        case .rightHalf: return "rightHalf"
+        case .leftHalf: return "leftSide"
+        case .rightHalf: return "rightSide"
         case .maximize: return "maximize"
         case .maximizeHeight: return "maximizeHeight"
         case .previousDisplay: return "previousDisplay"
         case .nextDisplay: return "nextDisplay"
         case .larger: return "larger"
         case .smaller: return "smaller"
-        case .bottomHalf: return "bottomHalf"
-        case .topHalf: return "topHalf"
+        case .bottomHalf: return "bottomSide"
+        case .topHalf: return "topSide"
         case .center: return "center"
         case .bottomLeft: return "bottomLeft"
         case .bottomRight: return "bottomRight"
@@ -230,7 +230,7 @@ enum WindowAction: Int, Codable {
         case .moveUp: return "moveUp"
         case .moveDown: return "moveDown"
         case .almostMaximize: return "almostMaximize"
-        case .centerHalf: return "centerHalf"
+        case .centerHalf: return "centerSection"
         case .firstFourth: return "firstFourth"
         case .secondFourth: return "secondFourth"
         case .thirdFourth: return "thirdFourth"
@@ -331,6 +331,17 @@ enum WindowAction: Int, Codable {
         }
     }
 
+    var legacyName: String? {
+        switch self {
+        case .leftHalf: return "leftHalf"
+        case .rightHalf: return "rightHalf"
+        case .bottomHalf: return "bottomHalf"
+        case .topHalf: return "topHalf"
+        case .centerHalf: return "centerHalf"
+        default: return nil
+        }
+    }
+
     var displayIndex: Int? {
         switch self {
         case .displayOne: return 0
@@ -353,10 +364,10 @@ enum WindowAction: Int, Codable {
         switch self {
         case .leftHalf:
             key = "Xc8-Sm-pig.title"
-            value = "Left Half"
+            value = "Left Side"
         case .rightHalf:
             key = "F8S-GI-LiB.title"
-            value = "Right Half"
+            value = "Right Side"
         case .maximize:
             key = "8oe-J2-oUU.title"
             value = "Maximize"
@@ -377,10 +388,10 @@ enum WindowAction: Int, Codable {
             value = "Smaller"
         case .bottomHalf:
             key = "ec4-FB-fMa.title"
-            value = "Bottom Half"
+            value = "Bottom Side"
         case .topHalf:
             key = "d7y-s8-7GE.title"
-            value = "Top Half"
+            value = "Top Side"
         case .center:
             key = "8Bg-SZ-hDO.title"
             value = "Center"
@@ -434,7 +445,7 @@ enum WindowAction: Int, Codable {
             value = "Almost Maximize"
         case .centerHalf:
             key = "bRX-dV-iAR.title"
-            value = "Center Half"
+            value = "Center Section"
         case .firstFourth:
             key = "Q6Q-6J-okH.title"
             value = "First Fourth"

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -203,16 +203,16 @@ enum WindowAction: Int, Codable {
 
     var name: String {
         switch self {
-        case .leftHalf: return "leftSide"
-        case .rightHalf: return "rightSide"
+        case .leftHalf: return "leftHalf"
+        case .rightHalf: return "rightHalf"
         case .maximize: return "maximize"
         case .maximizeHeight: return "maximizeHeight"
         case .previousDisplay: return "previousDisplay"
         case .nextDisplay: return "nextDisplay"
         case .larger: return "larger"
         case .smaller: return "smaller"
-        case .bottomHalf: return "bottomSide"
-        case .topHalf: return "topSide"
+        case .bottomHalf: return "bottomHalf"
+        case .topHalf: return "topHalf"
         case .center: return "center"
         case .bottomLeft: return "bottomLeft"
         case .bottomRight: return "bottomRight"
@@ -230,7 +230,7 @@ enum WindowAction: Int, Codable {
         case .moveUp: return "moveUp"
         case .moveDown: return "moveDown"
         case .almostMaximize: return "almostMaximize"
-        case .centerHalf: return "centerSection"
+        case .centerHalf: return "centerHalf"
         case .firstFourth: return "firstFourth"
         case .secondFourth: return "secondFourth"
         case .thirdFourth: return "thirdFourth"
@@ -331,13 +331,13 @@ enum WindowAction: Int, Codable {
         }
     }
 
-    var legacyName: String? {
+    var aliasName: String? {
         switch self {
-        case .leftHalf: return "leftHalf"
-        case .rightHalf: return "rightHalf"
-        case .bottomHalf: return "bottomHalf"
-        case .topHalf: return "topHalf"
-        case .centerHalf: return "centerHalf"
+        case .leftHalf: return "leftSide"
+        case .rightHalf: return "rightSide"
+        case .bottomHalf: return "bottomSide"
+        case .topHalf: return "topSide"
+        case .centerHalf: return "centerSection"
         default: return nil
         }
     }

--- a/Rectangle/WindowActionCategory.swift
+++ b/Rectangle/WindowActionCategory.swift
@@ -24,7 +24,7 @@ enum WindowActionCategory {
     var displayName: String {
         switch self {
         case .halves:
-            return NSLocalizedString("Halves", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Sides", tableName: "Main", value: "", comment: "")
         case .corners:
             return NSLocalizedString("Corners", tableName: "Main", value: "", comment: "")
         case .thirds:

--- a/Rectangle/WindowCalculation/BottomHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomHalfCalculation.swift
@@ -14,15 +14,11 @@ class BottomHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
     }
     
     func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return calculateFractionalRect(params, fraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0)
+        return RectResult(HalfSplitFrameCalculation.verticalRect(in: params.visibleFrameOfScreen, side: .trailing, fraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var rect = visibleFrameOfScreen
-        rect.size.height = floor(visibleFrameOfScreen.height * CGFloat(fraction))
-        return RectResult(rect)
+        return RectResult(HalfSplitFrameCalculation.verticalRect(in: params.visibleFrameOfScreen, side: .trailing, fraction: fraction))
     }
     
 }

--- a/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
@@ -29,21 +29,14 @@ class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCal
     
     func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
         let ratio = Defaults.horizontalSplitRatio.value / 100.0
-        let fraction = params.action == .rightHalf ? 1.0 - ratio : ratio
-        return calculateFractionalRect(params, fraction: fraction)
+        let side: HalfSplitSide = params.action == .rightHalf ? .trailing : .leading
+        let fraction = side == .trailing ? 1.0 - ratio : ratio
+        return RectResult(HalfSplitFrameCalculation.horizontalRect(in: params.visibleFrameOfScreen, side: side, fraction: fraction))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var rect = visibleFrameOfScreen
-
-        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
-        if params.action == .rightHalf {
-            rect.origin.x = visibleFrameOfScreen.maxX - rect.width
-        }
-
-        return RectResult(rect)
+        let side: HalfSplitSide = params.action == .rightHalf ? .trailing : .leading
+        return RectResult(HalfSplitFrameCalculation.horizontalRect(in: params.visibleFrameOfScreen, side: side, fraction: fraction))
     }
 
     func calculateResize(_ params: WindowCalculationParameters) -> WindowCalculationResult? {
@@ -96,15 +89,6 @@ class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCal
 
     // Used to draw box for snapping
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
-        let ratio = CGFloat(Defaults.horizontalSplitRatio.value / 100.0)
-        var rect = params.visibleFrameOfScreen
-        let leftWidth = floor(rect.width * ratio)
-        if params.action == .leftHalf {
-            rect.size.width = leftWidth
-        } else {
-            rect.size.width = rect.width - leftWidth
-            rect.origin.x += leftWidth
-        }
-        return RectResult(rect)
+        calculateFirstRect(params)
     }
 }

--- a/Rectangle/WindowCalculation/LowerLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerLeftCalculation.swift
@@ -2,7 +2,12 @@
 
 import Foundation
 
-class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation, QuartersRepeated {
+class LowerLeftCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+    
+    let horizontalSide: HalfSplitSide = .leading
+    let verticalSide: HalfSplitSide = .trailing
+    var horizontalSplitFraction: Float { Defaults.horizontalSplitRatio.value / 100.0 }
+    var verticalSplitFraction: Float { 1.0 - Defaults.verticalSplitRatio.value / 100.0 }
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -26,27 +31,15 @@ class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcula
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         return RectResult(cornerRect(visibleFrameOfScreen,
-                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0),
+                                     horizontalFraction: horizontalSplitFraction,
+                                     verticalFraction: verticalSplitFraction),
                           subAction: .bottomLeftQuarter)
-    }
-
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0))
-    }
-
-    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: fraction,
-                                     verticalFraction: fraction))
     }
 
     private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
         HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
-                                             horizontalSide: .leading,
-                                             verticalSide: .trailing,
+                                             horizontalSide: horizontalSide,
+                                             verticalSide: verticalSide,
                                              horizontalFraction: horizontalFraction,
                                              verticalFraction: verticalFraction)
     }

--- a/Rectangle/WindowCalculation/LowerLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerLeftCalculation.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-class LowerLeftCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+class LowerLeftCalculation: WindowCalculation, CornerCycleExpansionCalculation, QuartersRepeated {
     
     let horizontalSide: HalfSplitSide = .leading
     let verticalSide: HalfSplitSide = .trailing

--- a/Rectangle/WindowCalculation/LowerLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerLeftCalculation.swift
@@ -25,18 +25,29 @@ class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcula
     }
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(rect, subAction: .bottomLeftQuarter)
+        return RectResult(cornerRect(visibleFrameOfScreen,
+                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0),
+                          subAction: .bottomLeftQuarter)
+    }
+
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: fraction,
+                                     verticalFraction: fraction))
+    }
 
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(rect)
+    private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
+        HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
+                                             horizontalSide: .leading,
+                                             verticalSide: .trailing,
+                                             horizontalFraction: horizontalFraction,
+                                             verticalFraction: verticalFraction)
     }
 }

--- a/Rectangle/WindowCalculation/LowerRightCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerRightCalculation.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-class LowerRightCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+class LowerRightCalculation: WindowCalculation, CornerCycleExpansionCalculation, QuartersRepeated {
     
     let horizontalSide: HalfSplitSide = .trailing
     let verticalSide: HalfSplitSide = .trailing

--- a/Rectangle/WindowCalculation/LowerRightCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerRightCalculation.swift
@@ -25,20 +25,29 @@ class LowerRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
     }
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(rect, subAction: .bottomRightQuarter)
+        return RectResult(cornerRect(visibleFrameOfScreen,
+                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0),
+                          subAction: .bottomRightQuarter)
+    }
+
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: fraction,
+                                     verticalFraction: fraction))
+    }
 
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
-        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(rect)
+    private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
+        HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
+                                             horizontalSide: .trailing,
+                                             verticalSide: .trailing,
+                                             horizontalFraction: horizontalFraction,
+                                             verticalFraction: verticalFraction)
     }
 }

--- a/Rectangle/WindowCalculation/LowerRightCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerRightCalculation.swift
@@ -2,7 +2,12 @@
 
 import Foundation
 
-class LowerRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation, QuartersRepeated {
+class LowerRightCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+    
+    let horizontalSide: HalfSplitSide = .trailing
+    let verticalSide: HalfSplitSide = .trailing
+    var horizontalSplitFraction: Float { 1.0 - Defaults.horizontalSplitRatio.value / 100.0 }
+    var verticalSplitFraction: Float { 1.0 - Defaults.verticalSplitRatio.value / 100.0 }
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -26,27 +31,15 @@ class LowerRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         return RectResult(cornerRect(visibleFrameOfScreen,
-                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0),
+                                     horizontalFraction: horizontalSplitFraction,
+                                     verticalFraction: verticalSplitFraction),
                           subAction: .bottomRightQuarter)
-    }
-
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0))
-    }
-
-    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: fraction,
-                                     verticalFraction: fraction))
     }
 
     private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
         HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
-                                             horizontalSide: .trailing,
-                                             verticalSide: .trailing,
+                                             horizontalSide: horizontalSide,
+                                             verticalSide: verticalSide,
                                              horizontalFraction: horizontalFraction,
                                              verticalFraction: verticalFraction)
     }

--- a/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
@@ -12,6 +12,14 @@ protocol RepeatedExecutionsCalculation {
 
 extension RepeatedExecutionsCalculation {
     
+    func sortedCycleSizes() -> [CycleSize] {
+        let useDefaultPositions = !Defaults.cycleSizesIsChanged.enabled
+        let positions = useDefaultPositions ? CycleSize.defaultSizes : Defaults.selectedCycleSizes.value
+        
+        return CycleSize.sortedSizes
+            .filter { positions.contains($0) }
+    }
+    
     func calculateRepeatedRect(_ params: RectCalculationParameters) -> RectResult {
         
         guard let count = params.lastAction?.count,
@@ -20,15 +28,84 @@ extension RepeatedExecutionsCalculation {
             return calculateFirstRect(params)
         }
         
-        let useDefaultPositions = !Defaults.cycleSizesIsChanged.enabled
-        let positions = useDefaultPositions ? CycleSize.defaultSizes : Defaults.selectedCycleSizes.value
-        
-        let sortedPositions = CycleSize.sortedSizes
-            .filter { positions.contains($0) }
+        let sortedPositions = sortedCycleSizes()
                 
         let position = count % sortedPositions.count
         
         return calculateRect(for: sortedPositions[position], params: params)
     }
     
+}
+
+protocol AxisLockedCornerRepeatedCalculation: RepeatedExecutionsCalculation {
+    var horizontalSide: HalfSplitSide { get }
+    var verticalSide: HalfSplitSide { get }
+    var horizontalSplitFraction: Float { get }
+    var verticalSplitFraction: Float { get }
+}
+
+extension AxisLockedCornerRepeatedCalculation {
+    
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        RectResult(cornerRect(params.visibleFrameOfScreen,
+                              horizontalFraction: horizontalSplitFraction,
+                              verticalFraction: verticalSplitFraction))
+    }
+    
+    func calculateRect(for cycleDivision: CycleSize, params: RectCalculationParameters) -> RectResult {
+        calculateFractionalRect(params, fraction: cycleDivision.fraction)
+    }
+    
+    func calculateRepeatedRect(_ params: RectCalculationParameters) -> RectResult {
+        guard params.lastAction?.action == params.action else {
+            return calculateFirstRect(params)
+        }
+
+        let sortedPositions = sortedCycleSizes()
+        let currentIndex = sortedPositions.firstIndex { cycleSize in
+            calculateRect(for: cycleSize, params: params).rect.equalTo(params.window.rect)
+        }
+
+        if let currentIndex {
+            let nextIndex = (currentIndex + 1) % sortedPositions.count
+            return calculateRect(for: sortedPositions[nextIndex], params: params)
+        }
+
+        guard let count = params.lastAction?.count else {
+            return calculateFirstRect(params)
+        }
+
+        return calculateRect(for: sortedPositions[count % sortedPositions.count], params: params)
+    }
+    
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
+        let normalRect = calculateFirstRect(params).rect
+
+        switch Defaults.repeatedCommandCycleAxis.value {
+        case .horizontal:
+            let cycledRect = cornerRect(params.visibleFrameOfScreen,
+                                        horizontalFraction: fraction,
+                                        verticalFraction: verticalSplitFraction)
+            return RectResult(CGRect(x: cycledRect.origin.x,
+                                     y: normalRect.origin.y,
+                                     width: cycledRect.width,
+                                     height: normalRect.height))
+        case .vertical:
+            let cycledRect = cornerRect(params.visibleFrameOfScreen,
+                                        horizontalFraction: horizontalSplitFraction,
+                                        verticalFraction: fraction)
+            return RectResult(CGRect(x: normalRect.origin.x,
+                                     y: cycledRect.origin.y,
+                                     width: normalRect.width,
+                                     height: cycledRect.height))
+        }
+    }
+    
+    private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
+        HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
+                                             horizontalSide: horizontalSide,
+                                             verticalSide: verticalSide,
+                                             horizontalFraction: horizontalFraction,
+                                             verticalFraction: verticalFraction)
+    }
 }

--- a/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
@@ -37,14 +37,14 @@ extension RepeatedExecutionsCalculation {
     
 }
 
-protocol AxisLockedCornerRepeatedCalculation: RepeatedExecutionsCalculation {
+protocol CornerCycleExpansionCalculation: RepeatedExecutionsCalculation {
     var horizontalSide: HalfSplitSide { get }
     var verticalSide: HalfSplitSide { get }
     var horizontalSplitFraction: Float { get }
     var verticalSplitFraction: Float { get }
 }
 
-extension AxisLockedCornerRepeatedCalculation {
+extension CornerCycleExpansionCalculation {
     
     func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
         RectResult(cornerRect(params.visibleFrameOfScreen,
@@ -81,7 +81,7 @@ extension AxisLockedCornerRepeatedCalculation {
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
         let normalRect = calculateFirstRect(params).rect
 
-        switch Defaults.repeatedCommandCycleAxis.value {
+        switch Defaults.cornerCycleExpansionAxis.value {
         case .horizontal:
             let cycledRect = cornerRect(params.visibleFrameOfScreen,
                                         horizontalFraction: fraction,

--- a/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
@@ -29,10 +29,21 @@ extension RepeatedExecutionsCalculation {
         }
         
         let sortedPositions = sortedCycleSizes()
+        guard !sortedPositions.isEmpty else {
+            return calculateFirstRect(params)
+        }
                 
-        let position = count % sortedPositions.count
+        let position = cycleIndex(forExecutionCount: count, in: sortedPositions)
         
         return calculateRect(for: sortedPositions[position], params: params)
+    }
+
+    func cycleIndex(forExecutionCount count: Int, in sortedPositions: [CycleSize]) -> Int {
+        if sortedPositions.contains(.firstSize) {
+            return count % sortedPositions.count
+        }
+
+        return max(0, count - 1) % sortedPositions.count
     }
     
 }
@@ -62,6 +73,10 @@ extension CornerCycleExpansionCalculation {
         }
 
         let sortedPositions = sortedCycleSizes()
+        guard !sortedPositions.isEmpty else {
+            return calculateFirstRect(params)
+        }
+
         let currentIndex = sortedPositions.firstIndex { cycleSize in
             calculateRect(for: cycleSize, params: params).rect.equalTo(params.window.rect)
         }
@@ -75,7 +90,7 @@ extension CornerCycleExpansionCalculation {
             return calculateFirstRect(params)
         }
 
-        return calculateRect(for: sortedPositions[count % sortedPositions.count], params: params)
+        return calculateRect(for: sortedPositions[cycleIndex(forExecutionCount: count, in: sortedPositions)], params: params)
     }
     
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {

--- a/Rectangle/WindowCalculation/TopHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/TopHalfCalculation.swift
@@ -14,16 +14,11 @@ class TopHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculati
     }
     
     func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return calculateFractionalRect(params, fraction: Defaults.verticalSplitRatio.value / 100.0)
+        return RectResult(HalfSplitFrameCalculation.verticalRect(in: params.visibleFrameOfScreen, side: .leading, fraction: Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var rect = visibleFrameOfScreen
-        rect.size.height = floor(visibleFrameOfScreen.height * CGFloat(fraction))
-        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
-        return RectResult(rect)
+        return RectResult(HalfSplitFrameCalculation.verticalRect(in: params.visibleFrameOfScreen, side: .leading, fraction: fraction))
     }
     
 }

--- a/Rectangle/WindowCalculation/UpperLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperLeftCalculation.swift
@@ -2,7 +2,12 @@
 
 import Foundation
 
-class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation, QuartersRepeated {
+class UpperLeftCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+    
+    let horizontalSide: HalfSplitSide = .leading
+    let verticalSide: HalfSplitSide = .leading
+    var horizontalSplitFraction: Float { Defaults.horizontalSplitRatio.value / 100.0 }
+    var verticalSplitFraction: Float { Defaults.verticalSplitRatio.value / 100.0 }
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -26,27 +31,15 @@ class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcula
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         return RectResult(cornerRect(visibleFrameOfScreen,
-                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0),
+                                     horizontalFraction: horizontalSplitFraction,
+                                     verticalFraction: verticalSplitFraction),
                           subAction: .topLeftQuarter)
-    }
-
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0))
-    }
-
-    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: fraction,
-                                     verticalFraction: fraction))
     }
 
     private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
         HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
-                                             horizontalSide: .leading,
-                                             verticalSide: .leading,
+                                             horizontalSide: horizontalSide,
+                                             verticalSide: verticalSide,
                                              horizontalFraction: horizontalFraction,
                                              verticalFraction: verticalFraction)
     }

--- a/Rectangle/WindowCalculation/UpperLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperLeftCalculation.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-class UpperLeftCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+class UpperLeftCalculation: WindowCalculation, CornerCycleExpansionCalculation, QuartersRepeated {
     
     let horizontalSide: HalfSplitSide = .leading
     let verticalSide: HalfSplitSide = .leading

--- a/Rectangle/WindowCalculation/UpperLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperLeftCalculation.swift
@@ -25,20 +25,29 @@ class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcula
     }
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
-        return RectResult(rect, subAction: .topLeftQuarter)
+        return RectResult(cornerRect(visibleFrameOfScreen,
+                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0),
+                          subAction: .topLeftQuarter)
+    }
+
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: fraction,
+                                     verticalFraction: fraction))
+    }
 
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
-        return RectResult(rect)
+    private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
+        HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
+                                             horizontalSide: .leading,
+                                             verticalSide: .leading,
+                                             horizontalFraction: horizontalFraction,
+                                             verticalFraction: verticalFraction)
     }
 }

--- a/Rectangle/WindowCalculation/UpperRightCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperRightCalculation.swift
@@ -2,7 +2,12 @@
 
 import Foundation
 
-class UpperRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation, QuartersRepeated {
+class UpperRightCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+    
+    let horizontalSide: HalfSplitSide = .trailing
+    let verticalSide: HalfSplitSide = .leading
+    var horizontalSplitFraction: Float { 1.0 - Defaults.horizontalSplitRatio.value / 100.0 }
+    var verticalSplitFraction: Float { Defaults.verticalSplitRatio.value / 100.0 }
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -26,27 +31,15 @@ class UpperRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         return RectResult(cornerRect(visibleFrameOfScreen,
-                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0),
+                                     horizontalFraction: horizontalSplitFraction,
+                                     verticalFraction: verticalSplitFraction),
                           subAction: .topRightQuarter)
-    }
-
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0))
-    }
-
-    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: fraction,
-                                     verticalFraction: fraction))
     }
 
     private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
         HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
-                                             horizontalSide: .trailing,
-                                             verticalSide: .leading,
+                                             horizontalSide: horizontalSide,
+                                             verticalSide: verticalSide,
                                              horizontalFraction: horizontalFraction,
                                              verticalFraction: verticalFraction)
     }

--- a/Rectangle/WindowCalculation/UpperRightCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperRightCalculation.swift
@@ -25,22 +25,29 @@ class UpperRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
     }
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
-        return RectResult(rect, subAction: .topRightQuarter)
+        return RectResult(cornerRect(visibleFrameOfScreen,
+                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0),
+                          subAction: .topRightQuarter)
+    }
+
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: fraction,
+                                     verticalFraction: fraction))
+    }
 
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
-        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
-        return RectResult(rect)
+    private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
+        HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
+                                             horizontalSide: .trailing,
+                                             verticalSide: .leading,
+                                             horizontalFraction: horizontalFraction,
+                                             verticalFraction: verticalFraction)
     }
 }

--- a/Rectangle/WindowCalculation/UpperRightCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperRightCalculation.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-class UpperRightCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+class UpperRightCalculation: WindowCalculation, CornerCycleExpansionCalculation, QuartersRepeated {
     
     let horizontalSide: HalfSplitSide = .trailing
     let verticalSide: HalfSplitSide = .leading

--- a/Rectangle/WindowCalculation/WindowCalculation.swift
+++ b/Rectangle/WindowCalculation/WindowCalculation.swift
@@ -116,6 +116,57 @@ struct WindowCalculationResult {
     }
 }
 
+enum HalfSplitSide {
+    case leading
+    case trailing
+}
+
+struct HalfSplitFrameCalculation {
+    private static let floorTolerance: CGFloat = 0.0001
+    
+    static func horizontalRect(in visibleFrameOfScreen: CGRect, side: HalfSplitSide, fraction: Float) -> CGRect {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floorDimension(visibleFrameOfScreen.width * CGFloat(fraction))
+        
+        if side == .trailing {
+            rect.origin.x = visibleFrameOfScreen.maxX - rect.width
+        }
+        
+        return rect
+    }
+    
+    static func verticalRect(in visibleFrameOfScreen: CGRect, side: HalfSplitSide, fraction: Float) -> CGRect {
+        var rect = visibleFrameOfScreen
+        rect.size.height = floorDimension(visibleFrameOfScreen.height * CGFloat(fraction))
+        
+        if side == .leading {
+            rect.origin.y = visibleFrameOfScreen.maxY - rect.height
+        }
+        
+        return rect
+    }
+    
+    static func cornerRect(in visibleFrameOfScreen: CGRect,
+                           horizontalSide: HalfSplitSide,
+                           verticalSide: HalfSplitSide,
+                           horizontalFraction: Float,
+                           verticalFraction: Float) -> CGRect {
+        let horizontalRect = horizontalRect(in: visibleFrameOfScreen, side: horizontalSide, fraction: horizontalFraction)
+        let verticalRect = verticalRect(in: visibleFrameOfScreen, side: verticalSide, fraction: verticalFraction)
+        
+        var rect = visibleFrameOfScreen
+        rect.origin.x = horizontalRect.origin.x
+        rect.size.width = horizontalRect.width
+        rect.origin.y = verticalRect.origin.y
+        rect.size.height = verticalRect.height
+        return rect
+    }
+    
+    private static func floorDimension(_ value: CGFloat) -> CGFloat {
+        floor(value + floorTolerance)
+    }
+}
+
 class WindowCalculationFactory {
     
     static let leftHalfCalculation = LeftRightHalfCalculation()

--- a/Rectangle/WindowMover/StandardWindowMover.swift
+++ b/Rectangle/WindowMover/StandardWindowMover.swift
@@ -11,7 +11,7 @@ class StandardWindowMover: WindowMover {
     }
     
     private func shouldAdjustSizeFirst(_ action: WindowAction) -> Bool {
-        switch (action, Defaults.repeatedCommandCycleAxis.value) {
+        switch (action, Defaults.cornerCycleExpansionAxis.value) {
         case (.topRight, .horizontal),
              (.bottomRight, .horizontal),
              (.bottomLeft, .vertical),

--- a/Rectangle/WindowMover/StandardWindowMover.swift
+++ b/Rectangle/WindowMover/StandardWindowMover.swift
@@ -6,6 +6,19 @@ class StandardWindowMover: WindowMover {
     func moveWindow(toRect rect: CGRect, resultParameters: ResultParameters) {
         let windowElement = resultParameters.windowElement
         if windowElement.frame.isNull { return }
-        windowElement.setFrame(rect.screenFlipped)
+        windowElement.setFrame(rect.screenFlipped,
+                               adjustSizeFirst: shouldAdjustSizeFirst(resultParameters.action))
+    }
+    
+    private func shouldAdjustSizeFirst(_ action: WindowAction) -> Bool {
+        switch (action, Defaults.repeatedCommandCycleAxis.value) {
+        case (.topRight, .horizontal),
+             (.bottomRight, .horizontal),
+             (.bottomLeft, .vertical),
+             (.bottomRight, .vertical):
+            return false
+        default:
+            return true
+        }
     }
 }

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -28480,10 +28480,13 @@
         }
       }
     },
-    "Lock horizontal axis" : {
+    "Cyclic corner shortcuts expand:" : {
 
     },
-    "Lock vertical axis" : {
+    "horizontally" : {
+
+    },
+    "vertically" : {
 
     },
     "LqQ-pM-jRN.title" : {

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -1394,7 +1394,7 @@
       }
     },
     "01Z-t3-cBm.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"If you repeat move or half actions, the window will move to the next display instead of 1/2, 2/3, and 1/3 size.\"; ObjectID = \"01Z-t3-cBm\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"If you repeat move or side actions, the window will move to the next display instead of 1/2, 2/3, and 1/3 size.\"; ObjectID = \"01Z-t3-cBm\";",
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -1424,7 +1424,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "If you repeat move or half actions, the window will move to the next display instead of 1/2, 2/3, and 1/3 size."
+            "value" : "If you repeat move or side actions, the window will move to the next display instead of 1/2, 2/3, and 1/3 size."
           }
         },
         "es" : {
@@ -2438,7 +2438,7 @@
       }
     },
     "3GE-la-fAZ.title" : {
-      "comment" : "Class = \"NSMenuItem\"; title = \"move to adjacent on left/right, or cycle size on half\"; ObjectID = \"3GE-la-fAZ\";",
+      "comment" : "Class = \"NSMenuItem\"; title = \"move to adjacent on left/right, or cycle size on side\"; ObjectID = \"3GE-la-fAZ\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -2474,7 +2474,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "move to adjacent on left/right, or cycle size on half"
+            "value" : "move to adjacent on left/right, or cycle size on side"
           }
         },
         "es" : {
@@ -2534,7 +2534,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "move to adjacent on left/right, or cycle size on half"
+            "value" : "move to adjacent on left/right, or cycle size on side"
           }
         },
         "nn" : {
@@ -2546,19 +2546,19 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "move to adjacent on left/right, or cycle size on half"
+            "value" : "move to adjacent on left/right, or cycle size on side"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "move to adjacent on left/right, or cycle size on half"
+            "value" : "move to adjacent on left/right, or cycle size on side"
           }
         },
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "move to adjacent on left/right, or cycle size on half"
+            "value" : "move to adjacent on left/right, or cycle size on side"
           }
         },
         "ro" : {
@@ -10654,7 +10654,7 @@
       }
     },
     "bRX-dV-iAR.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Center Half\"; ObjectID = \"bRX-dV-iAR\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Center Section\"; ObjectID = \"bRX-dV-iAR\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -10690,13 +10690,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Center Half"
+            "value" : "Center Section"
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Centre Half"
+            "value" : "Centre Section"
           }
         },
         "es" : {
@@ -13021,7 +13021,7 @@
       }
     },
     "d7y-s8-7GE.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Top Half\"; ObjectID = \"d7y-s8-7GE\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Top Side\"; ObjectID = \"d7y-s8-7GE\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -13057,7 +13057,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Top Half"
+            "value" : "Top Side"
           }
         },
         "es" : {
@@ -15983,7 +15983,7 @@
       }
     },
     "ec4-FB-fMa.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Bottom Half\"; ObjectID = \"ec4-FB-fMa\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Bottom Side\"; ObjectID = \"ec4-FB-fMa\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -16019,7 +16019,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Bottom Half"
+            "value" : "Bottom Side"
           }
         },
         "es" : {
@@ -16776,7 +16776,7 @@
       }
     },
     "F8S-GI-LiB.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Right Half\"; ObjectID = \"F8S-GI-LiB\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Right Side\"; ObjectID = \"F8S-GI-LiB\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -16812,7 +16812,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Right Half"
+            "value" : "Right Side"
           }
         },
         "es" : {
@@ -19682,7 +19682,7 @@
       }
     },
     "gHH-BV-5kP.title" : {
-      "comment" : "Class = \"NSMenuItem\"; title = \"cycle sizes on half actions\"; ObjectID = \"gHH-BV-5kP\";",
+      "comment" : "Class = \"NSMenuItem\"; title = \"cycle sizes on side actions\"; ObjectID = \"gHH-BV-5kP\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -19718,7 +19718,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "cycle sizes on half actions"
+            "value" : "cycle sizes on side actions"
           }
         },
         "es" : {
@@ -21201,7 +21201,7 @@
         }
       }
     },
-    "Half Split Ratios" : {
+    "Side Split Ratio" : {
       "localizations" : {
         "ko" : {
           "stringUnit" : {
@@ -21217,7 +21217,7 @@
         }
       }
     },
-    "Halves" : {
+    "Sides" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -21306,7 +21306,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Halves"
+            "value" : "Sides"
           }
         },
         "nn" : {
@@ -27938,7 +27938,7 @@
         }
       }
     },
-    "Left half, top/bottom half near corners" : {
+    "Left side, top/bottom side near corners" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -27949,13 +27949,13 @@
         "ca" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "ca-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "cs" : {
@@ -27991,7 +27991,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "it" : {
@@ -28027,7 +28027,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "nn" : {
@@ -28039,7 +28039,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "pt-BR" : {
@@ -28051,13 +28051,13 @@
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "ro" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "ru" : {
@@ -28075,7 +28075,7 @@
         "sv-SE" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "tr" : {
@@ -28116,7 +28116,7 @@
         }
       }
     },
-    "Left or right half" : {
+    "Left or right side" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -28127,13 +28127,13 @@
         "ca" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "ca-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "cs" : {
@@ -28169,7 +28169,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "it" : {
@@ -28205,7 +28205,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "nn" : {
@@ -28217,7 +28217,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "pt-BR" : {
@@ -28229,13 +28229,13 @@
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "ro" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "ru" : {
@@ -28253,7 +28253,7 @@
         "sv-SE" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "tr" : {
@@ -36144,13 +36144,13 @@
       }
     },
     "qCy-Kx-9mR.title" : {
-      "comment" : "Class = \"NSMenuItem\"; title = \"cycle positions on quadrants, cycle sizes on half\"; ObjectID = \"qCy-Kx-9mR\";",
+      "comment" : "Class = \"NSMenuItem\"; title = \"cycle positions on quadrants, cycle sizes on side\"; ObjectID = \"qCy-Kx-9mR\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "cycle positions on quadrants, cycle sizes on half"
+            "value" : "cycle positions on quadrants, cycle sizes on side"
           }
         },
         "ko" : {
@@ -37995,7 +37995,7 @@
         }
       }
     },
-    "Right half, top/bottom half near corners" : {
+    "Right side, top/bottom side near corners" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -38006,13 +38006,13 @@
         "ca" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "ca-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "cs" : {
@@ -38048,7 +38048,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "it" : {
@@ -38084,7 +38084,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "nn" : {
@@ -38096,7 +38096,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "pt-BR" : {
@@ -38108,13 +38108,13 @@
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "ro" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "ru" : {
@@ -38132,7 +38132,7 @@
         "sv-SE" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "tr" : {
@@ -40852,7 +40852,7 @@
         }
       }
     },
-    "Thirds, top/bottom half near corners" : {
+    "Thirds, top/bottom side near corners" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -40863,13 +40863,13 @@
         "ca" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "ca-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "cs" : {
@@ -40905,7 +40905,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "it" : {
@@ -40941,7 +40941,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "nn" : {
@@ -40953,25 +40953,25 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "ro" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "ru" : {
@@ -40989,7 +40989,7 @@
         "sv-SE" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "tr" : {
@@ -41772,7 +41772,7 @@
         }
       }
     },
-    "Top/bottom halves" : {
+    "Top/bottom sides" : {
       "extractionState" : "manual",
       "localizations" : {
         "ko" : {
@@ -47243,7 +47243,7 @@
       }
     },
     "Xc8-Sm-pig.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Left Half\"; ObjectID = \"Xc8-Sm-pig\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Left Side\"; ObjectID = \"Xc8-Sm-pig\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -47279,7 +47279,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Left Half"
+            "value" : "Left Side"
           }
         },
         "es" : {

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -28480,6 +28480,12 @@
         }
       }
     },
+    "Lock horizontal axis" : {
+
+    },
+    "Lock vertical axis" : {
+
+    },
     "LqQ-pM-jRN.title" : {
       "comment" : "Class = \"NSTextFieldCell\"; title = \"Bottom Left Sixth\"; ObjectID = \"LqQ-pM-jRN\";",
       "extractionState" : "extracted_with_value",

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -303,6 +303,53 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         assertRect(WindowCalculationFactory.bottomHalfCalculation.calculateRect(repeatedParams(for: .bottomHalf)).rect,
                    equals: CGRect(x: 10, y: 20, width: 1200, height: 600))
     }
+
+    func testRepeatedHalfActionStartsAtFirstSelectedCycleSizeWhenOneHalfIsDeselected() {
+        setSplitRatio(50)
+        Defaults.cycleSizesIsChanged.enabled = true
+        Defaults.selectedCycleSizes.value = [.oneThird, .twoThirds]
+
+        let firstRepeatedRect = WindowCalculationFactory.bottomHalfCalculation.calculateRepeatedRect(repeatedParams(for: .bottomHalf)).rect
+        let secondRepeatedRect = WindowCalculationFactory.bottomHalfCalculation.calculateRepeatedRect(repeatedParams(for: .bottomHalf, currentRect: firstRepeatedRect, count: 2)).rect
+
+        assertRect(firstRepeatedRect, equals: CGRect(x: 10, y: 20, width: 1200, height: 600))
+        assertRect(secondRepeatedRect, equals: CGRect(x: 10, y: 20, width: 1200, height: 300))
+    }
+
+    func testRepeatedBottomCornerStartsAtFirstSelectedCycleSizeWhenOneHalfIsDeselected() {
+        setSplitRatio(50)
+        Defaults.cornerCycleExpansionAxis.value = .vertical
+        Defaults.cycleSizesIsChanged.enabled = true
+        Defaults.selectedCycleSizes.value = [.oneThird, .twoThirds]
+
+        let firstRect = WindowCalculationFactory.lowerLeftCalculation.calculateRect(params(for: .bottomLeft)).rect
+        let firstRepeatedRect = WindowCalculationFactory.lowerLeftCalculation.calculateRect(repeatedParams(for: .bottomLeft, currentRect: firstRect)).rect
+        let secondRepeatedRect = WindowCalculationFactory.lowerLeftCalculation.calculateRect(repeatedParams(for: .bottomLeft, currentRect: firstRepeatedRect, count: 2)).rect
+
+        assertRect(firstRect, equals: CGRect(x: 10, y: 20, width: 600, height: 450))
+        assertRect(firstRepeatedRect, equals: CGRect(x: 10, y: 20, width: 600, height: 600))
+        assertRect(secondRepeatedRect, equals: CGRect(x: 10, y: 20, width: 600, height: 300))
+    }
+
+    func testRepeatedHalfActionWithNoCycleSizesSelectedUsesFirstRect() {
+        setSplitRatio(60)
+        Defaults.cycleSizesIsChanged.enabled = true
+        Defaults.selectedCycleSizes.value = []
+
+        assertRect(WindowCalculationFactory.leftHalfCalculation.calculateRepeatedRect(repeatedParams(for: .leftHalf)).rect,
+                   equals: CGRect(x: 10, y: 20, width: 720, height: 900))
+    }
+
+    func testRepeatedCornerActionWithNoCycleSizesSelectedUsesFirstRect() {
+        setSplitRatio(60)
+        Defaults.cycleSizesIsChanged.enabled = true
+        Defaults.selectedCycleSizes.value = []
+
+        let firstRect = WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect
+        let repeatedRect = WindowCalculationFactory.upperLeftCalculation.calculateRect(repeatedParams(for: .topLeft, currentRect: firstRect)).rect
+
+        assertRect(repeatedRect, equals: firstRect)
+    }
     
     private func setSplitRatio(_ percent: Float) {
         Defaults.horizontalSplitRatio.value = percent

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -153,7 +153,7 @@ class HalfSplitCornerCalculationTests: XCTestCase {
     private var savedHorizontalSplitRatio: Float = 50
     private var savedVerticalSplitRatio: Float = 50
     private var savedSubsequentExecutionMode: SubsequentExecutionMode = .resize
-    private var savedRepeatedCommandCycleAxis: RepeatedCommandCycleAxis = .horizontal
+    private var savedCornerCycleExpansionAxis: CornerCycleExpansionAxis = .horizontal
     private var savedCycleSizesIsChanged = false
     private var savedSelectedCycleSizes = Set<CycleSize>()
     private let visibleFrame = CGRect(x: 10, y: 20, width: 1200, height: 900)
@@ -163,7 +163,7 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         savedHorizontalSplitRatio = Defaults.horizontalSplitRatio.value
         savedVerticalSplitRatio = Defaults.verticalSplitRatio.value
         savedSubsequentExecutionMode = Defaults.subsequentExecutionMode.value
-        savedRepeatedCommandCycleAxis = Defaults.repeatedCommandCycleAxis.value
+        savedCornerCycleExpansionAxis = Defaults.cornerCycleExpansionAxis.value
         savedCycleSizesIsChanged = Defaults.cycleSizesIsChanged.enabled
         savedSelectedCycleSizes = Defaults.selectedCycleSizes.value
         Defaults.subsequentExecutionMode.value = .resize
@@ -174,7 +174,7 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         Defaults.horizontalSplitRatio.value = savedHorizontalSplitRatio
         Defaults.verticalSplitRatio.value = savedVerticalSplitRatio
         Defaults.subsequentExecutionMode.value = savedSubsequentExecutionMode
-        Defaults.repeatedCommandCycleAxis.value = savedRepeatedCommandCycleAxis
+        Defaults.cornerCycleExpansionAxis.value = savedCornerCycleExpansionAxis
         Defaults.cycleSizesIsChanged.enabled = savedCycleSizesIsChanged
         Defaults.selectedCycleSizes.value = savedSelectedCycleSizes
         super.tearDown()
@@ -237,9 +237,9 @@ class HalfSplitCornerCalculationTests: XCTestCase {
                    equals: CGRect(x: 10, y: 20, width: 1200, height: 360))
     }
 
-    func testRepeatedCornersWithHorizontalAxisLockCycleWidthOnly() {
+    func testRepeatedCornersWithHorizontalExpansionCycleWidthOnly() {
         setSplitRatio(60)
-        Defaults.repeatedCommandCycleAxis.value = .horizontal
+        Defaults.cornerCycleExpansionAxis.value = .horizontal
 
         assertRepeatedCornerRects(
             topLeft: CGRect(x: 10, y: 380, width: 800, height: 540),
@@ -251,7 +251,7 @@ class HalfSplitCornerCalculationTests: XCTestCase {
 
     func testSecondRepeatedCornerShortcutBeginsCyclingImmediately() {
         setSplitRatio(CycleSize.twoThirds.percentValue)
-        Defaults.repeatedCommandCycleAxis.value = .horizontal
+        Defaults.cornerCycleExpansionAxis.value = .horizontal
 
         let firstFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect
         let secondFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(repeatedParams(for: .topLeft, currentRect: firstFrame, count: 1)).rect
@@ -264,7 +264,7 @@ class HalfSplitCornerCalculationTests: XCTestCase {
 
     func testRepeatedCornerCyclingDoesNotReturnNoOpFrameWhenBaseMatchesCycleSize() {
         setSplitRatio(CycleSize.twoThirds.percentValue)
-        Defaults.repeatedCommandCycleAxis.value = .vertical
+        Defaults.cornerCycleExpansionAxis.value = .vertical
 
         let firstFrame = WindowCalculationFactory.upperRightCalculation.calculateRect(params(for: .topRight)).rect
         let secondFrame = WindowCalculationFactory.upperRightCalculation.calculateRect(repeatedParams(for: .topRight, currentRect: firstFrame, count: 1)).rect
@@ -275,9 +275,9 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         XCTAssertEqual(firstFrame.width, secondFrame.width, accuracy: 0.001)
     }
 
-    func testRepeatedCornersWithVerticalAxisLockCycleHeightOnly() {
+    func testRepeatedCornersWithVerticalExpansionCycleHeightOnly() {
         setSplitRatio(60)
-        Defaults.repeatedCommandCycleAxis.value = .vertical
+        Defaults.cornerCycleExpansionAxis.value = .vertical
 
         assertRepeatedCornerRects(
             topLeft: CGRect(x: 10, y: 320, width: 720, height: 600),
@@ -289,14 +289,14 @@ class HalfSplitCornerCalculationTests: XCTestCase {
 
     func testRepeatedHalfActionsStillCycleOnTheirNaturalAxis() {
         setSplitRatio(60)
-        Defaults.repeatedCommandCycleAxis.value = .vertical
+        Defaults.cornerCycleExpansionAxis.value = .vertical
 
         assertRect(WindowCalculationFactory.leftHalfCalculation.calculateRepeatedRect(repeatedParams(for: .leftHalf)).rect,
                    equals: CGRect(x: 10, y: 20, width: 800, height: 900))
         assertRect(WindowCalculationFactory.rightHalfCalculation.calculateRepeatedRect(repeatedParams(for: .rightHalf)).rect,
                    equals: CGRect(x: 410, y: 20, width: 800, height: 900))
 
-        Defaults.repeatedCommandCycleAxis.value = .horizontal
+        Defaults.cornerCycleExpansionAxis.value = .horizontal
 
         assertRect(WindowCalculationFactory.topHalfCalculation.calculateRect(repeatedParams(for: .topHalf)).rect,
                    equals: CGRect(x: 10, y: 320, width: 1200, height: 600))

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -702,6 +702,33 @@ class ShortcutCycleTests: XCTestCase {
         MASShortcut(keyCode: keyCode, modifierFlags: flags)
     }
 
+    func testSideShortcutActionsUseRenamedDefaultsKeys() {
+        XCTAssertEqual(WindowAction.leftHalf.name, "leftSide")
+        XCTAssertEqual(WindowAction.rightHalf.name, "rightSide")
+        XCTAssertEqual(WindowAction.centerHalf.name, "centerSection")
+        XCTAssertEqual(WindowAction.topHalf.name, "topSide")
+        XCTAssertEqual(WindowAction.bottomHalf.name, "bottomSide")
+    }
+
+    func testRenamedSideShortcutMigrationMovesLegacyDefaultsKeys() {
+        let suiteName = "ShortcutCycleTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let centerSectionShortcut = shortcut(1, [.option, .command])
+        let dictTransformer = ValueTransformer(forName: NSValueTransformerName(rawValue: MASDictionaryTransformerName))!
+        let shortcutDict = dictTransformer.reverseTransformedValue(centerSectionShortcut)
+        userDefaults.setValue(shortcutDict, forKey: "centerHalf")
+
+        MASShortcutMigration.migrateRenamedSideShortcutKeys(userDefaults: userDefaults)
+
+        XCTAssertNil(userDefaults.object(forKey: "centerHalf"))
+        XCTAssertNotNil(userDefaults.object(forKey: "centerSection"))
+        XCTAssertNotNil(ShortcutCycle.shortcut(for: .centerHalf, userDefaults: userDefaults))
+    }
+
     func testUniqueShortcutsProduceSingletonGroups() {
         let groups = ShortcutCycle.groups(
             actions: [.centerHalf, .centerThird],

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -130,6 +130,24 @@ class DefaultsExportTests: XCTestCase {
     }
 }
 
+class CycleSizeRatioPresetTests: XCTestCase {
+
+    func testPercentValuesMatchCycleSizeFractions() {
+        XCTAssertEqual(CycleSize.oneHalf.percentValue, 50, accuracy: 0.001)
+        XCTAssertEqual(CycleSize.twoThirds.percentValue, 66.666, accuracy: 0.001)
+        XCTAssertEqual(CycleSize.oneThird.percentValue, 33.333, accuracy: 0.001)
+    }
+
+    func testMatchingPercentValueUsesTolerance() {
+        XCTAssertEqual(CycleSize.matching(percentValue: 33.3334), .oneThird)
+        XCTAssertEqual(CycleSize.matching(percentValue: 66.6666), .twoThirds)
+    }
+
+    func testCustomPercentValueDoesNotMatchPreset() {
+        XCTAssertNil(CycleSize.matching(percentValue: 60))
+    }
+}
+
 class OverlapOffsetGuardsTests: XCTestCase {
 
     func testMaxCascadeClampedToMinOne() {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -153,6 +153,9 @@ class HalfSplitCornerCalculationTests: XCTestCase {
     private var savedHorizontalSplitRatio: Float = 50
     private var savedVerticalSplitRatio: Float = 50
     private var savedSubsequentExecutionMode: SubsequentExecutionMode = .resize
+    private var savedRepeatedCommandCycleAxis: RepeatedCommandCycleAxis = .horizontal
+    private var savedCycleSizesIsChanged = false
+    private var savedSelectedCycleSizes = Set<CycleSize>()
     private let visibleFrame = CGRect(x: 10, y: 20, width: 1200, height: 900)
     
     override func setUp() {
@@ -160,13 +163,20 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         savedHorizontalSplitRatio = Defaults.horizontalSplitRatio.value
         savedVerticalSplitRatio = Defaults.verticalSplitRatio.value
         savedSubsequentExecutionMode = Defaults.subsequentExecutionMode.value
+        savedRepeatedCommandCycleAxis = Defaults.repeatedCommandCycleAxis.value
+        savedCycleSizesIsChanged = Defaults.cycleSizesIsChanged.enabled
+        savedSelectedCycleSizes = Defaults.selectedCycleSizes.value
         Defaults.subsequentExecutionMode.value = .resize
+        Defaults.cycleSizesIsChanged.enabled = false
     }
     
     override func tearDown() {
         Defaults.horizontalSplitRatio.value = savedHorizontalSplitRatio
         Defaults.verticalSplitRatio.value = savedVerticalSplitRatio
         Defaults.subsequentExecutionMode.value = savedSubsequentExecutionMode
+        Defaults.repeatedCommandCycleAxis.value = savedRepeatedCommandCycleAxis
+        Defaults.cycleSizesIsChanged.enabled = savedCycleSizesIsChanged
+        Defaults.selectedCycleSizes.value = savedSelectedCycleSizes
         super.tearDown()
     }
     
@@ -226,6 +236,73 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         assertRect(WindowCalculationFactory.bottomHalfCalculation.calculateRect(params(for: .bottomHalf)).rect,
                    equals: CGRect(x: 10, y: 20, width: 1200, height: 360))
     }
+
+    func testRepeatedCornersWithHorizontalAxisLockCycleWidthOnly() {
+        setSplitRatio(60)
+        Defaults.repeatedCommandCycleAxis.value = .horizontal
+
+        assertRepeatedCornerRects(
+            topLeft: CGRect(x: 10, y: 380, width: 800, height: 540),
+            topRight: CGRect(x: 410, y: 380, width: 800, height: 540),
+            bottomLeft: CGRect(x: 10, y: 20, width: 800, height: 360),
+            bottomRight: CGRect(x: 410, y: 20, width: 800, height: 360)
+        )
+    }
+
+    func testSecondRepeatedCornerShortcutBeginsCyclingImmediately() {
+        setSplitRatio(CycleSize.twoThirds.percentValue)
+        Defaults.repeatedCommandCycleAxis.value = .horizontal
+
+        let firstFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect
+        let secondFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(repeatedParams(for: .topLeft, currentRect: firstFrame, count: 1)).rect
+        let thirdFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(repeatedParams(for: .topLeft, currentRect: secondFrame, count: 2)).rect
+
+        assertRect(firstFrame, equals: CGRect(x: 10, y: 320, width: 800, height: 600))
+        assertRect(secondFrame, equals: CGRect(x: 10, y: 320, width: 400, height: 600))
+        assertRect(thirdFrame, equals: CGRect(x: 10, y: 320, width: 600, height: 600))
+    }
+
+    func testRepeatedCornerCyclingDoesNotReturnNoOpFrameWhenBaseMatchesCycleSize() {
+        setSplitRatio(CycleSize.twoThirds.percentValue)
+        Defaults.repeatedCommandCycleAxis.value = .vertical
+
+        let firstFrame = WindowCalculationFactory.upperRightCalculation.calculateRect(params(for: .topRight)).rect
+        let secondFrame = WindowCalculationFactory.upperRightCalculation.calculateRect(repeatedParams(for: .topRight, currentRect: firstFrame, count: 1)).rect
+
+        XCTAssertFalse(firstFrame.equalTo(secondFrame))
+        XCTAssertEqual(firstFrame.maxY, secondFrame.maxY, accuracy: 0.001)
+        XCTAssertEqual(firstFrame.origin.x, secondFrame.origin.x, accuracy: 0.001)
+        XCTAssertEqual(firstFrame.width, secondFrame.width, accuracy: 0.001)
+    }
+
+    func testRepeatedCornersWithVerticalAxisLockCycleHeightOnly() {
+        setSplitRatio(60)
+        Defaults.repeatedCommandCycleAxis.value = .vertical
+
+        assertRepeatedCornerRects(
+            topLeft: CGRect(x: 10, y: 320, width: 720, height: 600),
+            topRight: CGRect(x: 730, y: 320, width: 480, height: 600),
+            bottomLeft: CGRect(x: 10, y: 20, width: 720, height: 600),
+            bottomRight: CGRect(x: 730, y: 20, width: 480, height: 600)
+        )
+    }
+
+    func testRepeatedHalfActionsStillCycleOnTheirNaturalAxis() {
+        setSplitRatio(60)
+        Defaults.repeatedCommandCycleAxis.value = .vertical
+
+        assertRect(WindowCalculationFactory.leftHalfCalculation.calculateRepeatedRect(repeatedParams(for: .leftHalf)).rect,
+                   equals: CGRect(x: 10, y: 20, width: 800, height: 900))
+        assertRect(WindowCalculationFactory.rightHalfCalculation.calculateRepeatedRect(repeatedParams(for: .rightHalf)).rect,
+                   equals: CGRect(x: 410, y: 20, width: 800, height: 900))
+
+        Defaults.repeatedCommandCycleAxis.value = .horizontal
+
+        assertRect(WindowCalculationFactory.topHalfCalculation.calculateRect(repeatedParams(for: .topHalf)).rect,
+                   equals: CGRect(x: 10, y: 320, width: 1200, height: 600))
+        assertRect(WindowCalculationFactory.bottomHalfCalculation.calculateRect(repeatedParams(for: .bottomHalf)).rect,
+                   equals: CGRect(x: 10, y: 20, width: 1200, height: 600))
+    }
     
     private func setSplitRatio(_ percent: Float) {
         Defaults.horizontalSplitRatio.value = percent
@@ -238,12 +315,34 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         assertRect(WindowCalculationFactory.lowerLeftCalculation.calculateRect(params(for: .bottomLeft)).rect, equals: bottomLeft)
         assertRect(WindowCalculationFactory.lowerRightCalculation.calculateRect(params(for: .bottomRight)).rect, equals: bottomRight)
     }
+
+    private func assertRepeatedCornerRects(topLeft: CGRect, topRight: CGRect, bottomLeft: CGRect, bottomRight: CGRect) {
+        let topLeftBase = WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect
+        let topRightBase = WindowCalculationFactory.upperRightCalculation.calculateRect(params(for: .topRight)).rect
+        let bottomLeftBase = WindowCalculationFactory.lowerLeftCalculation.calculateRect(params(for: .bottomLeft)).rect
+        let bottomRightBase = WindowCalculationFactory.lowerRightCalculation.calculateRect(params(for: .bottomRight)).rect
+
+        assertRect(WindowCalculationFactory.upperLeftCalculation.calculateRect(repeatedParams(for: .topLeft, currentRect: topLeftBase)).rect, equals: topLeft)
+        assertRect(WindowCalculationFactory.upperRightCalculation.calculateRect(repeatedParams(for: .topRight, currentRect: topRightBase)).rect, equals: topRight)
+        assertRect(WindowCalculationFactory.lowerLeftCalculation.calculateRect(repeatedParams(for: .bottomLeft, currentRect: bottomLeftBase)).rect, equals: bottomLeft)
+        assertRect(WindowCalculationFactory.lowerRightCalculation.calculateRect(repeatedParams(for: .bottomRight, currentRect: bottomRightBase)).rect, equals: bottomRight)
+    }
     
     private func params(for action: WindowAction) -> RectCalculationParameters {
         RectCalculationParameters(window: Window(id: 1, rect: visibleFrame),
                                   visibleFrameOfScreen: visibleFrame,
                                   action: action,
                                   lastAction: nil)
+    }
+
+    private func repeatedParams(for action: WindowAction, currentRect: CGRect? = nil, count: Int = 1) -> RectCalculationParameters {
+        RectCalculationParameters(window: Window(id: 1, rect: currentRect ?? visibleFrame),
+                                  visibleFrameOfScreen: visibleFrame,
+                                  action: action,
+                                  lastAction: RectangleAction(action: action,
+                                                              subAction: nil,
+                                                              rect: currentRect ?? visibleFrame,
+                                                              count: count))
     }
     
     private func assertRect(_ rect: CGRect, equals expected: CGRect, file: StaticString = #filePath, line: UInt = #line) {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -702,15 +702,15 @@ class ShortcutCycleTests: XCTestCase {
         MASShortcut(keyCode: keyCode, modifierFlags: flags)
     }
 
-    func testSideShortcutActionsUseRenamedDefaultsKeys() {
-        XCTAssertEqual(WindowAction.leftHalf.name, "leftSide")
-        XCTAssertEqual(WindowAction.rightHalf.name, "rightSide")
-        XCTAssertEqual(WindowAction.centerHalf.name, "centerSection")
-        XCTAssertEqual(WindowAction.topHalf.name, "topSide")
-        XCTAssertEqual(WindowAction.bottomHalf.name, "bottomSide")
+    func testSideShortcutActionsKeepLegacyDefaultsKeys() {
+        XCTAssertEqual(WindowAction.leftHalf.name, "leftHalf")
+        XCTAssertEqual(WindowAction.rightHalf.name, "rightHalf")
+        XCTAssertEqual(WindowAction.centerHalf.name, "centerHalf")
+        XCTAssertEqual(WindowAction.topHalf.name, "topHalf")
+        XCTAssertEqual(WindowAction.bottomHalf.name, "bottomHalf")
     }
 
-    func testRenamedSideShortcutMigrationMovesLegacyDefaultsKeys() {
+    func testRenamedSideShortcutAliasSyncWritesLegacyDefaultsKey() {
         let suiteName = "ShortcutCycleTests.\(UUID().uuidString)"
         let userDefaults = UserDefaults(suiteName: suiteName)!
         defer {
@@ -720,13 +720,20 @@ class ShortcutCycleTests: XCTestCase {
         let centerSectionShortcut = shortcut(1, [.option, .command])
         let dictTransformer = ValueTransformer(forName: NSValueTransformerName(rawValue: MASDictionaryTransformerName))!
         let shortcutDict = dictTransformer.reverseTransformedValue(centerSectionShortcut)
-        userDefaults.setValue(shortcutDict, forKey: "centerHalf")
+        userDefaults.setValue(shortcutDict, forKey: "centerSection")
 
-        MASShortcutMigration.migrateRenamedSideShortcutKeys(userDefaults: userDefaults)
+        MASShortcutMigration.syncRenamedSideShortcutAliases(userDefaults: userDefaults)
 
-        XCTAssertNil(userDefaults.object(forKey: "centerHalf"))
-        XCTAssertNotNil(userDefaults.object(forKey: "centerSection"))
+        XCTAssertNil(userDefaults.object(forKey: "centerSection"))
+        XCTAssertNotNil(userDefaults.object(forKey: "centerHalf"))
         XCTAssertNotNil(ShortcutCycle.shortcut(for: .centerHalf, userDefaults: userDefaults))
+
+        let updatedCenterHalfShortcut = shortcut(2, [.option, .command])
+        let updatedShortcutDict = dictTransformer.reverseTransformedValue(updatedCenterHalfShortcut)
+        userDefaults.setValue(updatedShortcutDict, forKey: "centerHalf")
+
+        MASShortcutMigration.syncRenamedSideShortcutAliases(userDefaults: userDefaults)
+        XCTAssertEqual(ShortcutCycle.shortcut(for: .centerHalf, userDefaults: userDefaults)?.keyCode, updatedCenterHalfShortcut.keyCode)
     }
 
     func testUniqueShortcutsProduceSingletonGroups() {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -148,6 +148,112 @@ class CycleSizeRatioPresetTests: XCTestCase {
     }
 }
 
+class HalfSplitCornerCalculationTests: XCTestCase {
+    
+    private var savedHorizontalSplitRatio: Float = 50
+    private var savedVerticalSplitRatio: Float = 50
+    private var savedSubsequentExecutionMode: SubsequentExecutionMode = .resize
+    private let visibleFrame = CGRect(x: 10, y: 20, width: 1200, height: 900)
+    
+    override func setUp() {
+        super.setUp()
+        savedHorizontalSplitRatio = Defaults.horizontalSplitRatio.value
+        savedVerticalSplitRatio = Defaults.verticalSplitRatio.value
+        savedSubsequentExecutionMode = Defaults.subsequentExecutionMode.value
+        Defaults.subsequentExecutionMode.value = .resize
+    }
+    
+    override func tearDown() {
+        Defaults.horizontalSplitRatio.value = savedHorizontalSplitRatio
+        Defaults.verticalSplitRatio.value = savedVerticalSplitRatio
+        Defaults.subsequentExecutionMode.value = savedSubsequentExecutionMode
+        super.tearDown()
+    }
+    
+    func testCornersUseHalfSplitRatioOneHalf() {
+        setSplitRatio(50)
+        
+        assertCornerRects(
+            topLeft: CGRect(x: 10, y: 470, width: 600, height: 450),
+            topRight: CGRect(x: 610, y: 470, width: 600, height: 450),
+            bottomLeft: CGRect(x: 10, y: 20, width: 600, height: 450),
+            bottomRight: CGRect(x: 610, y: 20, width: 600, height: 450)
+        )
+    }
+    
+    func testCornersUseHalfSplitRatioTwoThirds() {
+        setSplitRatio(CycleSize.twoThirds.percentValue)
+        
+        assertCornerRects(
+            topLeft: CGRect(x: 10, y: 320, width: 800, height: 600),
+            topRight: CGRect(x: 810, y: 320, width: 400, height: 600),
+            bottomLeft: CGRect(x: 10, y: 20, width: 800, height: 300),
+            bottomRight: CGRect(x: 810, y: 20, width: 400, height: 300)
+        )
+    }
+    
+    func testCornersUseHalfSplitRatioThreeQuarters() {
+        setSplitRatio(CycleSize.threeQuarters.percentValue)
+        
+        assertCornerRects(
+            topLeft: CGRect(x: 10, y: 245, width: 900, height: 675),
+            topRight: CGRect(x: 910, y: 245, width: 300, height: 675),
+            bottomLeft: CGRect(x: 10, y: 20, width: 900, height: 225),
+            bottomRight: CGRect(x: 910, y: 20, width: 300, height: 225)
+        )
+    }
+    
+    func testCornersUseCustomHalfSplitRatio() {
+        setSplitRatio(60)
+        
+        assertCornerRects(
+            topLeft: CGRect(x: 10, y: 380, width: 720, height: 540),
+            topRight: CGRect(x: 730, y: 380, width: 480, height: 540),
+            bottomLeft: CGRect(x: 10, y: 20, width: 720, height: 360),
+            bottomRight: CGRect(x: 730, y: 20, width: 480, height: 360)
+        )
+    }
+    
+    func testHalfActionsStillUseHalfSplitRatio() {
+        setSplitRatio(60)
+        
+        assertRect(WindowCalculationFactory.leftHalfCalculation.calculateRect(params(for: .leftHalf)).rect,
+                   equals: CGRect(x: 10, y: 20, width: 720, height: 900))
+        assertRect(WindowCalculationFactory.rightHalfCalculation.calculateRect(params(for: .rightHalf)).rect,
+                   equals: CGRect(x: 730, y: 20, width: 480, height: 900))
+        assertRect(WindowCalculationFactory.topHalfCalculation.calculateRect(params(for: .topHalf)).rect,
+                   equals: CGRect(x: 10, y: 380, width: 1200, height: 540))
+        assertRect(WindowCalculationFactory.bottomHalfCalculation.calculateRect(params(for: .bottomHalf)).rect,
+                   equals: CGRect(x: 10, y: 20, width: 1200, height: 360))
+    }
+    
+    private func setSplitRatio(_ percent: Float) {
+        Defaults.horizontalSplitRatio.value = percent
+        Defaults.verticalSplitRatio.value = percent
+    }
+    
+    private func assertCornerRects(topLeft: CGRect, topRight: CGRect, bottomLeft: CGRect, bottomRight: CGRect) {
+        assertRect(WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect, equals: topLeft)
+        assertRect(WindowCalculationFactory.upperRightCalculation.calculateRect(params(for: .topRight)).rect, equals: topRight)
+        assertRect(WindowCalculationFactory.lowerLeftCalculation.calculateRect(params(for: .bottomLeft)).rect, equals: bottomLeft)
+        assertRect(WindowCalculationFactory.lowerRightCalculation.calculateRect(params(for: .bottomRight)).rect, equals: bottomRight)
+    }
+    
+    private func params(for action: WindowAction) -> RectCalculationParameters {
+        RectCalculationParameters(window: Window(id: 1, rect: visibleFrame),
+                                  visibleFrameOfScreen: visibleFrame,
+                                  action: action,
+                                  lastAction: nil)
+    }
+    
+    private func assertRect(_ rect: CGRect, equals expected: CGRect, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(rect.origin.x, expected.origin.x, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(rect.origin.y, expected.origin.y, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(rect.width, expected.width, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(rect.height, expected.height, accuracy: 0.001, file: file, line: line)
+    }
+}
+
 class OverlapOffsetGuardsTests: XCTestCase {
 
     func testMaxCascadeClampedToMinOne() {


### PR DESCRIPTION
<img width="878" height="743" alt="Screenshot 2026-06-10 at 12 04 16 PM" src="https://github.com/user-attachments/assets/b585898e-d23d-492b-a1b1-e24e7e7e2131" />

## Summary

This changes the corner actions and snap areas to use the same Half-Split ratio preference. It also updates the UI to reduce error from whole number percentages.

This might not be a behavior change that everyone would want, but it has been useful for my workflow. It cuts down the number of repeated-command cycles I use between `Left Half` / `Right Half` / `Top Half` / `Bottom Half` and the corner shortcuts when using `Repeated commands: cycle sizes on half actions`

The Half-Split ratio in `General -> ... -> Half-Split ratio` is now also the default ratio for:

* `UpperLeftCalculation`
* `UpperRightCalculation`
* `LowerLeftCalculation`
* `LowerRightCalculation`

That means the corner snap areas, plus the `Top Left`, `Top Right`, `Bottom Left`, and `Bottom Right` shortcuts, now follow the configured Half-Split ratio instead of always behaving like fixed quarters.

With the default `1/2` ratio, behavior stays the same. With something like `2/3`, the corners now compose the same split used by the half actions:

* `Top Left`: `2/3` width x `2/3` height
* `Top Right`: `1/3` width x `2/3` height
* `Bottom Left`: `2/3` width x `1/3` height
* `Bottom Right`: `1/3` width x `1/3` height

This also adds a dropdown for the Half-Split ratio picker so common ratios can be selected directly instead of typed as whole-number percentages. The dropdown reuses the same common values as the repeated-command cycle-size options, so there is not a second hard-coded ratio list. Custom percentages still work through `Other`.

The matching tolerance is there to avoid precision issues with values like `1/3` and `2/3`, and also avoided turning this into a much larger unit test refactor. That may need to change.

## Changes

* Add shared half-split frame helpers for leading/trailing horizontal and vertical components
* Refactor half actions to use the shared split helper
* Update corner actions to compose horizontal and vertical half-split components from the existing ratio preference
* Apply the same ratio to corner snap areas
* Preserve repeated-command sizing behavior
* Add a Half-Split ratio dropdown backed by the existing repeated-command common ratio values
* Keep custom Half-Split percentages working through `Other`
* Keep the existing Half-Split ratio preference keys unchanged
* Add tests for `1/2`, `2/3`, `3/4`, and custom `60%` corner ratios
* Preserve existing half-action behavior with tests

ai disclosure: codex was used for the majority of this work. I've reviewed and tested the changes. But, swift & osx apps are a bit outside my normal wheelhouse. 