### PR TITLE
add feature override green button

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		AA0ACC2F2864A86D0025E376 /* StageUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0ACC2E2864A86D0025E376 /* StageUtil.swift */; };
 		AA3A9E8B29230A82004EB8E5 /* CFExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3A9E8A29230A82004EB8E5 /* CFExtension.swift */; };
 		AA49DD1129B8C1B100690E13 /* TitleBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA49DD1029B8C1B100690E13 /* TitleBarManager.swift */; };
+		AA49DD2129B8C1B100690E13 /* GreenButtonManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA49DD2029B8C1B100690E13 /* GreenButtonManager.swift */; };
 		AA4DA2FB28FDC94A00355CEB /* DispatchTimeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4DA2FA28FDC94A00355CEB /* DispatchTimeExtension.swift */; };
 		AA536C2729005DD000579AC6 /* TimeoutCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA536C2629005DD000579AC6 /* TimeoutCache.swift */; };
 		AA69F83C29909A95001A81AF /* RightTodoCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA69F83B29909A95001A81AF /* RightTodoCalculation.swift */; };
@@ -366,6 +367,7 @@
 		AA0ACC2E2864A86D0025E376 /* StageUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageUtil.swift; sourceTree = "<group>"; };
 		AA3A9E8A29230A82004EB8E5 /* CFExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CFExtension.swift; sourceTree = "<group>"; };
 		AA49DD1029B8C1B100690E13 /* TitleBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleBarManager.swift; sourceTree = "<group>"; };
+		AA49DD2029B8C1B100690E13 /* GreenButtonManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GreenButtonManager.swift; sourceTree = "<group>"; };
 		AA4DA2FA28FDC94A00355CEB /* DispatchTimeExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchTimeExtension.swift; sourceTree = "<group>"; };
 		AA536C2629005DD000579AC6 /* TimeoutCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeoutCache.swift; sourceTree = "<group>"; };
 		AA69F83B29909A95001A81AF /* RightTodoCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightTodoCalculation.swift; sourceTree = "<group>"; };
@@ -689,6 +691,7 @@
 				98C275662322E2DA009B9292 /* WindowHistory.swift */,
 				9824704022B186D00037B409 /* WindowManager.swift */,
 				AA49DD1029B8C1B100690E13 /* TitleBarManager.swift */,
+				AA49DD2029B8C1B100690E13 /* GreenButtonManager.swift */,
 				98987AA62391890C00BE72C4 /* Logging */,
 				98910B3C2311304D0066EC23 /* PrefsWindow */,
 				989DA30C243FC0C3008C7AA4 /* WelcomeWindow */,
@@ -1072,6 +1075,7 @@
 				B4780A322BD4C75900732B9E /* HalfOrDoubleDimensionCalculation.swift in Sources */,
 				AA69F83C29909A95001A81AF /* RightTodoCalculation.swift in Sources */,
 				AA49DD1129B8C1B100690E13 /* TitleBarManager.swift in Sources */,
+				AA49DD2129B8C1B100690E13 /* GreenButtonManager.swift in Sources */,
 				9824700D22AF9B7D0037B409 /* AppDelegate.swift in Sources */,
 				98A009BF251253AB00CFBF0C /* BottomRightSixthCalculation.swift in Sources */,
 				6490B39527BF96880056C220 /* TopLeftEighthCalculation.swift in Sources */,
@@ -1405,11 +1409,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Rectangle/RectangleRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 102;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = XSYZ3E4B7D;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Rectangle/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Rectangle/AccessibilityElement.swift
+++ b/Rectangle/AccessibilityElement.swift
@@ -82,6 +82,11 @@ class AccessibilityElement {
         guard let subrole = subrole else { return nil }
         return subrole == .systemDialog
     }
+
+    var isFullScreenButton: Bool? {
+        guard let subrole = subrole else { return nil }
+        return subrole == .fullScreenButton
+    }
     
     private var position: CGPoint? {
         get {

--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -26,6 +26,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var windowCalculationFactory: WindowCalculationFactory!
     private var snappingManager: SnappingManager!
     private var titleBarManager: TitleBarManager!
+    private var greenButtonManager: GreenButtonManager!
     
     private var prefsWindowController: NSWindowController?
     
@@ -152,6 +153,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.applicationToggle = ApplicationToggle(shortcutManager: shortcutManager)
         self.snappingManager = SnappingManager()
         self.titleBarManager = TitleBarManager()
+        self.greenButtonManager = GreenButtonManager()
         self.initializeTodo()
         checkForProblematicApps()
         MacTilingDefaults.checkForBuiltInTiling(skipIfAlreadyNotified: true)

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -99,6 +99,7 @@ class Defaults {
     static let internalTilingNotified = BoolDefault(key: "internalTilingNotified")
     static let screensOrderedByX = OptionalBoolDefault(key: "screensOrderedByX")
     static let combinedDisplayMode = OptionalBoolDefault(key: "combinedDisplayMode")
+    static let greenButtonOverride = BoolDefault(key: "greenButtonOverride")
     static var array: [Default] = [
         launchOnLogin,
         disabledApps,
@@ -188,7 +189,8 @@ class Defaults {
         cyclingOverlapOffset,
         cyclingOverlapOffsetSize,
         cyclingOverlapMaxCascade,
-        moveFixedSizeToEdge
+        moveFixedSizeToEdge,
+        greenButtonOverride
     ]
 }
 

--- a/Rectangle/GreenButtonManager.swift
+++ b/Rectangle/GreenButtonManager.swift
@@ -1,0 +1,80 @@
+/// GreenButtonManager.swift
+
+import Cocoa
+
+class GreenButtonManager {
+    private var eventMonitor: ActiveEventMonitor!
+    private var windowElement: AccessibilityElement?
+    private var buttonFrame: CGRect?
+
+    init() {
+        eventMonitor = ActiveEventMonitor(mask: [.leftMouseDown, .leftMouseUp], filterer: filter, handler: { _ in })
+        toggleListening()
+        Notification.Name.greenButtonOverride.onPost { notification in
+            self.toggleListening()
+        }
+        Notification.Name.configImported.onPost { notification in
+            self.toggleListening()
+        }
+    }
+
+    private func toggleListening() {
+        if Defaults.greenButtonOverride.enabled {
+            if !eventMonitor.running {
+                eventMonitor.start()
+            }
+        } else {
+            eventMonitor.stop()
+        }
+    }
+
+    /// Runs on the event tap thread. Returning true consumes the event so the
+    /// app never sees the click that would put its window into native full screen.
+    private func filter(_ event: NSEvent) -> Bool {
+        switch event.type {
+        case .leftMouseDown:
+            guard
+                event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty,
+                let location = event.cgEvent?.location,
+                let element = AccessibilityElement(location),
+                element.isFullScreenButton == true,
+                case let buttonFrame = element.frame,
+                buttonFrame != .null,
+                let windowElement = element.windowElement
+            else {
+                return false
+            }
+            self.windowElement = windowElement
+            self.buttonFrame = buttonFrame
+            return true
+        case .leftMouseUp:
+            guard let windowElement = windowElement, let buttonFrame = buttonFrame else {
+                return false
+            }
+            self.windowElement = nil
+            self.buttonFrame = nil
+            // Releasing outside the button cancels the click, matching native button behavior
+            if let location = event.cgEvent?.location, buttonFrame.contains(location) {
+                DispatchQueue.main.async {
+                    GreenButtonManager.executeAction(windowElement)
+                }
+            }
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func executeAction(_ windowElement: AccessibilityElement) {
+        if let windowId = windowElement.getWindowId(),
+           case let windowFrame = windowElement.frame,
+           windowFrame != .null,
+           let historyAction = AppDelegate.windowHistory.lastRectangleActions[windowId],
+           historyAction.action == .maximize,
+           historyAction.rect == windowFrame {
+            WindowAction.restore.postTitleBar(windowElement: windowElement)
+            return
+        }
+        WindowAction.maximize.postTitleBar(windowElement: windowElement)
+    }
+}

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -45,6 +45,7 @@ class SettingsViewController: NSViewController {
     
     private var cycleSizeCheckboxes = [NSButton]()
     private var combinedDisplayModeCheckbox: NSButton?
+    private var greenButtonOverrideCheckbox: NSButton?
     
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
         let newSetting: Bool = sender.state == .on
@@ -152,6 +153,11 @@ class SettingsViewController: NSViewController {
     
     @objc func toggleCombinedDisplayMode(_ sender: NSButton) {
         Defaults.combinedDisplayMode.enabled = sender.state == .on
+    }
+
+    @objc func toggleGreenButtonOverride(_ sender: NSButton) {
+        Defaults.greenButtonOverride.enabled = sender.state == .on
+        Notification.Name.greenButtonOverride.post()
     }
 
     @IBAction func toggleTodoMode(_ sender: NSButton) {
@@ -986,6 +992,8 @@ class SettingsViewController: NSViewController {
 
         initializeCombinedDisplayCheckbox()
 
+        initializeGreenButtonOverrideCheckbox()
+
         Notification.Name.configImported.onPost(using: {_ in
             self.initializeTodoModeSettings()
             self.initializeToggles()
@@ -1053,6 +1061,8 @@ class SettingsViewController: NSViewController {
 
         combinedDisplayModeCheckbox?.state = Defaults.combinedDisplayMode.userEnabled ? .on : .off
 
+        greenButtonOverrideCheckbox?.state = Defaults.greenButtonOverride.enabled ? .on : .off
+
         if StageUtil.stageCapable {
             stageSlider.intValue = Int32(Defaults.stageSize.value)
             stageSlider.isContinuous = true
@@ -1107,6 +1117,33 @@ class SettingsViewController: NSViewController {
             separator.widthAnchor.constraint(equalTo: doubleClickTitleBarCheckbox.widthAnchor).isActive = true
             separator.heightAnchor.constraint(equalToConstant: 20).isActive = true
             combinedDisplayModeCheckbox = checkbox
+        }
+    }
+
+    private func initializeGreenButtonOverrideCheckbox() {
+        if greenButtonOverrideCheckbox == nil,
+           let parentStack = doubleClickTitleBarCheckbox.superview as? NSStackView,
+           let insertIdx = parentStack.arrangedSubviews.firstIndex(of: doubleClickTitleBarCheckbox) {
+
+            let checkbox = NSButton(checkboxWithTitle: NSLocalizedString("Click green button to fill screen instead of full screen", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleGreenButtonOverride(_:)))
+            checkbox.state = Defaults.greenButtonOverride.enabled ? .on : .off
+            // Match storyboard checkbox content priorities to prevent vertical compression
+            checkbox.setContentCompressionResistancePriority(.required, for: .vertical)
+            checkbox.setContentHuggingPriority(.defaultHigh, for: .vertical)
+
+            // Must be set before inserting: NSStackView queries intrinsicContentSize once on
+            // insertion, so preferredMaxLayoutWidth=0 would give zero height permanently.
+            let descLabel = NSTextField(wrappingLabelWithString: NSLocalizedString("Clicking a window's green button maximizes it to fill the screen instead of entering macOS full screen. Hold any modifier key or use the button's menu for the default macOS behavior.", tableName: "Main", value: "", comment: ""))
+            descLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+            descLabel.textColor = .secondaryLabelColor
+            descLabel.translatesAutoresizingMaskIntoConstraints = false
+            descLabel.preferredMaxLayoutWidth = 500
+            descLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+            descLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
+
+            parentStack.insertArrangedSubview(checkbox, at: insertIdx + 1)
+            parentStack.insertArrangedSubview(descLabel, at: insertIdx + 2)
+            greenButtonOverrideCheckbox = checkbox
         }
     }
 

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -1125,7 +1125,7 @@ class SettingsViewController: NSViewController {
            let parentStack = doubleClickTitleBarCheckbox.superview as? NSStackView,
            let insertIdx = parentStack.arrangedSubviews.firstIndex(of: doubleClickTitleBarCheckbox) {
 
-            let checkbox = NSButton(checkboxWithTitle: NSLocalizedString("Click green button to fill screen instead of full screen", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleGreenButtonOverride(_:)))
+            let checkbox = NSButton(checkboxWithTitle: NSLocalizedString("Green stoplight button maximizes instead of Full Screen", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleGreenButtonOverride(_:)))
             checkbox.state = Defaults.greenButtonOverride.enabled ? .on : .off
             // Match storyboard checkbox content priorities to prevent vertical compression
             checkbox.setContentCompressionResistancePriority(.required, for: .vertical)
@@ -1133,7 +1133,7 @@ class SettingsViewController: NSViewController {
 
             // Must be set before inserting: NSStackView queries intrinsicContentSize once on
             // insertion, so preferredMaxLayoutWidth=0 would give zero height permanently.
-            let descLabel = NSTextField(wrappingLabelWithString: NSLocalizedString("Clicking a window's green button maximizes it to fill the screen instead of entering macOS full screen. Hold any modifier key or use the button's menu for the default macOS behavior.", tableName: "Main", value: "", comment: ""))
+            let descLabel = NSTextField(wrappingLabelWithString: NSLocalizedString("Hold any modifier key or use the window menu for default macOS behavior", tableName: "Main", value: "", comment: ""))
             descLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
             descLabel.textColor = .secondaryLabelColor
             descLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/Rectangle/Utilities/NotificationExtension.swift
+++ b/Rectangle/Utilities/NotificationExtension.swift
@@ -14,6 +14,7 @@ extension Notification.Name {
     static let missionControlDragging = Notification.Name("missionControlDragging")
     static let menuBarIconHidden = Notification.Name("menuBarIconHidden")
     static let windowTitleBar = Notification.Name("windowTitleBar")
+    static let greenButtonOverride = Notification.Name("greenButtonOverride")
     static let defaultSnapAreas = Notification.Name("defaultSnapAreas")
     static let updateAvailability = Notification.Name("updateAvailability")
     static let showAdditionalSizesInMenuChanged = Notification.Name("showAdditionalSizesInMenuChanged")

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -11983,12 +11983,6 @@
         }
       }
     },
-    "Click green button to fill screen instead of full screen" : {
-
-    },
-    "Clicking a window's green button maximizes it to fill the screen instead of entering macOS full screen. Hold any modifier key or use the button's menu for the default macOS behavior." : {
-
-    },
     "Conflict with macOS tiling" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -20159,6 +20153,9 @@
         }
       }
     },
+    "Green stoplight button maximizes instead of Full Screen" : {
+
+    },
     "Grid Positions" : {
       "localizations" : {
         "ko" : {
@@ -22048,6 +22045,9 @@
           }
         }
       }
+    },
+    "Hold any modifier key or use the window menu for default macOS behavior" : {
+
     },
     "HOm-BV-2jc.title" : {
       "comment" : "Class = \"NSTextFieldCell\"; title = \"Move Up\"; ObjectID = \"HOm-BV-2jc\";",

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -11983,6 +11983,12 @@
         }
       }
     },
+    "Click green button to fill screen instead of full screen" : {
+
+    },
+    "Clicking a window's green button maximizes it to fill the screen instead of entering macOS full screen. Hold any modifier key or use the button's menu for the default macOS behavior." : {
+
+    },
     "Conflict with macOS tiling" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
<img width="849" height="701" alt="image" src="https://github.com/user-attachments/assets/90fc62c8-7d9d-4734-a621-2fd28c59625b" />

Added a new setting that overrides the macOS green button behavior. When enabled, clicking a window's green button maximizes it to fill the screen instead of entering native macOS full screen. Holding any modifier key or using the button's menu restores the default macOS behavior.

Core manager responsible for intercepting and handling green button clicks.

- Registers a low-level `ActiveEventMonitor` for `leftMouseDown` and `leftMouseUp` events
- On `mouseDown`: detects clicks on the full-screen button (with no modifier keys held), captures the window element and button frame, and consumes the event to prevent native full screen
- On `mouseUp`: if the cursor is still within the button bounds, dispatches a **maximize** or **restore** action based on the window's last recorded Rectangle action
- Listens to `greenButtonOverride` and `configImported` notifications to start or stop the monitor dynamically

## Modified Files

### `Rectangle/AccessibilityElement.swift`

- Added `isFullScreenButton` computed property that returns `true` when the element's subrole is `.fullScreenButton`

### `Rectangle/AppDelegate.swift`

- Declared a `greenButtonManager: GreenButtonManager` property
- Instantiated `GreenButtonManager()` during app startup alongside other managers

### `Rectangle/Defaults.swift`

- Added `greenButtonOverride` as a new `BoolDefault` with key `"greenButtonOverride"`
- Registered `greenButtonOverride` in the `array` of all defaults

### `Rectangle/PrefsWindow/SettingsViewController.swift`

- Added `greenButtonOverrideCheckbox` outlet
- Added `toggleGreenButtonOverride(_:)` action that saves the setting and posts the `greenButtonOverride` notification
- Added `initializeGreenButtonOverrideCheckbox()` that programmatically inserts the checkbox and a description label into the settings stack view after `doubleClickTitleBarCheckbox`
- Updated `initializeToggles()` to sync the checkbox state on load

### `Rectangle/Utilities/NotificationExtension.swift`

- Added `Notification.Name.greenButtonOverride` for broadcasting setting changes to `GreenButtonManager`

### `Rectangle/mul.lproj/Main.xcstrings`

- Added localization entries for:
  - Checkbox label: *"Click green button to fill screen instead of full screen"*
  - Description label: *"Clicking a window's green button maximizes it to fill the screen instead of entering macOS full screen. Hold any modifier key or use the button's menu for the default macOS behavior."*