### PR TITLE
Anchor clamped windows to the snap edge instead of leaving a gap

### DIFF
--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -11,6 +11,7 @@ class WindowManager {
     init() {
         standardWindowMoverChain = [
             StandardWindowMover(),
+            EdgeAlignmentWindowMover(),
             BestEffortWindowMover()
         ]
         

--- a/Rectangle/WindowMover/FixedSizeWindowMover.swift
+++ b/Rectangle/WindowMover/FixedSizeWindowMover.swift
@@ -2,59 +2,26 @@
 
 import Foundation
 
-/// Handle windows that are a fixed size, default to centering them in the proposed window area
+/// Handle windows that are a fixed size. With `moveFixedSizeToEdge` enabled, anchor them
+/// to the snap zone's screen edges; otherwise center them in the zone (legacy behavior).
 class FixedSizeWindowMover: WindowMover {
-    
+
     func moveWindow(toRect rect: CGRect, resultParameters: ResultParameters) {
         let windowElement = resultParameters.windowElement
         let currentWindowRect: CGRect = windowElement.frame
-        
-        let sharedEdges = resultParameters.calcResult.initialRect.screenFlipped.sharedEdges(withRect: resultParameters.visibleFrameOfScreen.screenFlipped)
-        
-        if Defaults.moveFixedSizeToEdge.userEnabled, sharedEdges.isCorner {
-            matchSharedEdges(rect: rect, currentWindowRect: currentWindowRect, sharedEdges: sharedEdges, windowElement: windowElement)
-        } else {
-            centerWindowRect(rect: rect, currentWindowRect: currentWindowRect, windowElement: windowElement)
-        }
-    }
+        if currentWindowRect.isNull { return }
 
-    func matchSharedEdges(rect: CGRect, currentWindowRect: CGRect, sharedEdges: Edge, windowElement: AccessibilityElement) {
-        var adjustedWindowRect = currentWindowRect
-        let flippedRect = rect.screenFlipped
-        
-        if sharedEdges.contains(.left) {
-            adjustedWindowRect.origin.x = flippedRect.minX
-        }
-        if sharedEdges.contains(.right) {
-            adjustedWindowRect.origin.x = flippedRect.maxX - currentWindowRect.width
-        }
-        if sharedEdges.contains(.top) {
-            adjustedWindowRect.origin.y = flippedRect.maxY - currentWindowRect.height
-        }
-        if sharedEdges.contains(.bottom) {
-            adjustedWindowRect.origin.y = flippedRect.minY
-        }
-        
-        if !adjustedWindowRect.equalTo(currentWindowRect) {
-            windowElement.setFrame(adjustedWindowRect)
-        }
-    }
+        let sharedEdges: Edge = Defaults.moveFixedSizeToEdge.userEnabled
+            ? resultParameters.calcResult.initialRect.screenFlipped
+                .sharedEdges(withRect: resultParameters.visibleFrameOfScreen.screenFlipped)
+            : .none // no shared edges -> aligner centers, matching legacy behavior
 
-    func centerWindowRect(rect: CGRect, currentWindowRect: CGRect, windowElement: AccessibilityElement) {
+        let adjusted = ClampedWindowAligner.aligned(window: currentWindowRect,
+                                                    inZone: rect.screenFlipped,
+                                                    sharedEdges: sharedEdges)
 
-        var adjustedWindowRect: CGRect = currentWindowRect
-        let flippedRect = rect.screenFlipped
-
-        if currentWindowRect.size.width != rect.width {
-            adjustedWindowRect.origin.x = round((rect.width - currentWindowRect.width) / 2.0) + flippedRect.minX
-        }
-        
-        if currentWindowRect.size.height != rect.height {
-            adjustedWindowRect.origin.y = round((rect.height - currentWindowRect.height) / 2.0) + flippedRect.minY
-        }
-        
-        if !adjustedWindowRect.equalTo(currentWindowRect) {
-            windowElement.setFrame(adjustedWindowRect)
+        if !adjusted.equalTo(currentWindowRect) {
+            windowElement.setFrame(adjusted)
         }
     }
 }

--- a/Rectangle/WindowMover/WindowMover.swift
+++ b/Rectangle/WindowMover/WindowMover.swift
@@ -5,3 +5,38 @@ import Foundation
 protocol WindowMover {
     func moveWindow(toRect rect: CGRect, resultParameters: ResultParameters)
 }
+
+/// Repositions a window that may not fill its snap zone. Pure geometry, no side effects.
+///
+/// Per axis: if the zone touches exactly one screen edge on that axis, anchor the window
+/// to that edge; if it spans the full axis (both edges) or floats inside (neither), center.
+/// `window` and `zone` must be in the same (screen-flipped) coordinate space, where the
+/// `.top` edge corresponds to maxY and `.bottom` to minY (matching the rest of Rectangle).
+enum ClampedWindowAligner {
+
+    static func aligned(window: CGRect, inZone zone: CGRect, sharedEdges: Edge) -> CGRect {
+        var result = window
+
+        if window.width != zone.width {
+            if sharedEdges.contains(.left), !sharedEdges.contains(.right) {
+                result.origin.x = zone.minX
+            } else if sharedEdges.contains(.right), !sharedEdges.contains(.left) {
+                result.origin.x = zone.maxX - window.width
+            } else {
+                result.origin.x = round((zone.width - window.width) / 2.0) + zone.minX
+            }
+        }
+
+        if window.height != zone.height {
+            if sharedEdges.contains(.top), !sharedEdges.contains(.bottom) {
+                result.origin.y = zone.maxY - window.height
+            } else if sharedEdges.contains(.bottom), !sharedEdges.contains(.top) {
+                result.origin.y = zone.minY
+            } else {
+                result.origin.y = round((zone.height - window.height) / 2.0) + zone.minY
+            }
+        }
+
+        return result
+    }
+}

--- a/Rectangle/WindowMover/WindowMover.swift
+++ b/Rectangle/WindowMover/WindowMover.swift
@@ -40,3 +40,29 @@ enum ClampedWindowAligner {
         return result
     }
 }
+
+/// For resizable windows that clamp smaller than their snap zone (e.g. FaceTime keeping a
+/// fixed aspect ratio), `StandardWindowMover` leaves them at the zone's leading corner with
+/// a gap on the screen-edge side. When `moveFixedSizeToEdge` is enabled, re-anchor them to
+/// the zone's screen edges. No-op when the flag is off or the window already fills the zone.
+class EdgeAlignmentWindowMover: WindowMover {
+
+    func moveWindow(toRect rect: CGRect, resultParameters: ResultParameters) {
+        guard Defaults.moveFixedSizeToEdge.userEnabled, resultParameters.action.resizes else { return }
+
+        let windowElement = resultParameters.windowElement
+        let currentWindowRect: CGRect = windowElement.frame
+        if currentWindowRect.isNull { return }
+
+        let sharedEdges = resultParameters.calcResult.initialRect.screenFlipped
+            .sharedEdges(withRect: resultParameters.visibleFrameOfScreen.screenFlipped)
+
+        let adjusted = ClampedWindowAligner.aligned(window: currentWindowRect,
+                                                    inZone: rect.screenFlipped,
+                                                    sharedEdges: sharedEdges)
+
+        if !adjusted.equalTo(currentWindowRect) {
+            windowElement.setFrame(adjusted)
+        }
+    }
+}

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -585,3 +585,58 @@ class TodoShortcutValidatorTests: XCTestCase {
         XCTAssertFalse(validator.isShortcutAlreadyTaken(bySystem: existingShortcut, explanation: nil))
     }
 }
+
+class ClampedWindowAlignerTests: XCTestCase {
+
+    // Screen 2000x1200 at origin. Coordinates are already screen-flipped (window space):
+    // the zone's maxY edge is the screen TOP, minY edge is the screen BOTTOM.
+
+    func testRightHalfClampedBothAxesAnchorsRightCentersVertically() {
+        let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let window = CGRect(x: 1000, y: 0, width: 600, height: 800) // narrower + shorter than zone
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        XCTAssertEqual(result.origin.x, 1400, accuracy: 0.001) // zone.maxX - width = 2000 - 600
+        XCTAssertEqual(result.origin.y, 200, accuracy: 0.001)  // centered: (1200 - 800)/2
+        XCTAssertEqual(result.width, 600, accuracy: 0.001)
+        XCTAssertEqual(result.height, 800, accuracy: 0.001)
+    }
+
+    func testRightHalfFullHeightLeavesVerticalUntouched() {
+        let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let window = CGRect(x: 1000, y: 0, width: 600, height: 1200) // fills height
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        XCTAssertEqual(result.origin.x, 1400, accuracy: 0.001)
+        XCTAssertEqual(result.origin.y, 0, accuracy: 0.001)
+    }
+
+    func testLeftHalfClampedAnchorsLeftCentersVertically() {
+        let zone = CGRect(x: 0, y: 0, width: 1000, height: 1200)
+        let window = CGRect(x: 0, y: 0, width: 600, height: 800)
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.left, .top, .bottom])
+        XCTAssertEqual(result.origin.x, 0, accuracy: 0.001)
+        XCTAssertEqual(result.origin.y, 200, accuracy: 0.001)
+    }
+
+    func testTopRightQuarterAnchorsToCorner() {
+        let zone = CGRect(x: 1000, y: 600, width: 1000, height: 600) // top-right; maxY=1200=screen top
+        let window = CGRect(x: 1000, y: 600, width: 600, height: 400)
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top])
+        XCTAssertEqual(result.origin.x, 1400, accuracy: 0.001) // maxX - width
+        XCTAssertEqual(result.origin.y, 800, accuracy: 0.001)  // maxY - height = 1200 - 400
+    }
+
+    func testInteriorZoneCentersBothAxes() {
+        let zone = CGRect(x: 600, y: 400, width: 800, height: 400)
+        let window = CGRect(x: 600, y: 400, width: 400, height: 200)
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [])
+        XCTAssertEqual(result.origin.x, 800, accuracy: 0.001) // (800-400)/2 + 600
+        XCTAssertEqual(result.origin.y, 500, accuracy: 0.001) // (400-200)/2 + 400
+    }
+
+    func testExactFitReturnsUnchanged() {
+        let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let window = zone
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        XCTAssertTrue(result.equalTo(window))
+    }
+}

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -36,6 +36,7 @@ The preferences window is purposefully slim, but there's a lot that can be modif
 - [Change the behavior of double-click window title bar](#change-the-behavior-of-double-click-window-title-bar)
 - [Change the order of displays to order by x coordinate](#change-the-order-of-displays-to-order-by-x-coordinate-for-next-and-prev-displays-commands)
 - [Offset cycling position when overlapping another window](#offset-cycling-position-when-overlapping-another-window)
+- [Move windows that can't fill the snap area to the edge](#move-windows-that-cant-fill-the-snap-area-to-the-edge)
 
 ## Keyboard Shortcuts
 
@@ -537,4 +538,12 @@ By default, only one cascade layer is shown (the original window plus one offset
 
 ```bash
 defaults write com.knollsoft.Rectangle cyclingOverlapMaxCascade -int 3
+```
+
+## Move windows that can't fill the snap area to the edge
+
+Some windows can't be resized to fill a snap area — either because they're a fixed size, or because they're resizable but have a maximum size or a fixed aspect ratio (FaceTime is a common example). By default such a window is centered within the snap area, which can leave a gap against the screen edge (e.g. snapping FaceTime to the right half leaves it floating left of the screen's right edge). Enable this to instead align the window to the snap area's screen edge(s): a right-half snap anchors flush right, a corner snap anchors into the corner, and the window stays centered on any axis it can't fill. Off by default.
+
+```bash
+defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -bool true
 ```


### PR DESCRIPTION
## Summary

When a window can't be resized to fill its snap zone, Rectangle leaves it at the zone's *leading* corner, producing a gap on the screen-edge side. The clearest repro is **FaceTime snapped to a half (when in a vertical video call)**: it keeps a fixed video aspect ratio, so on a wide display it clamps its own width and ends up floating near screen-center instead of flush against the screen edge. This also happens with the System Settings window for example.

This makes a clamped window anchor to the snap zone's screen edge(s), and stay centered on any axis it can't fill. It's all behind the existing `moveFixedSizeToEdge` default, which is **off by default**, so default behavior is unchanged.

## Why it happens today

- FaceTime is *resizable* (`isResizable()` is `true`), so it goes through the **standard** mover chain and never reaches `FixedSizeWindowMover`. `StandardWindowMover` sets the zone position, the app clamps the size, and `BestEffortWindowMover` only rescues windows that overflow *off* the screen — an under-filled window keeps its leading-corner position, leaving the gap.
- The existing `moveFixedSizeToEdge` edge-anchoring in `FixedSizeWindowMover` was gated on `sharedEdges.isCorner`, so it only fired for quarter snaps, never halves (a half shares three screen edges, so `isCorner` is false).

## Changes

- **`ClampedWindowAligner`** — a pure, unit-tested helper that repositions a window per axis: if the zone touches exactly one screen edge on that axis, anchor to it; otherwise (spans the full axis, or floats inside) center. It subsumes the old `matchSharedEdges` / `centerWindowRect` and drops the `isCorner` gate.
- **`FixedSizeWindowMover`** now delegates to it, so half-snaps of fixed-size windows anchor correctly too. (Flag off → `.none` shared edges → centers, exactly as before.)
- **`EdgeAlignmentWindowMover`** added to the standard chain to re-anchor resizable-but-clamped windows like FaceTime after `StandardWindowMover` runs.
- Documented the (now broader) `moveFixedSizeToEdge` flag in `TerminalCommands.md`.

Edge detection and anchoring use the gap-applied rect, so existing gap settings are respected.

## Test plan

- [x] New unit tests for `ClampedWindowAligner` (right half, left half, full-height half, top-right quarter, interior, exact-fit): 6/6 pass.
- [x] Full app builds.
- [x] Manual, with `defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -bool true`:
  - FaceTime snapped to the right/left half now sits flush against the screen edge, vertically centered (previously a gap).
  - Quarters snug into the correct corner.
  - Normal windows that fill a half, and all behavior with the flag off, are unchanged.
