### PR TITLE
Cooperative Window Resizer

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		729E0A982AFF76B1006E2F48 /* CenterProminentlyCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729E0A972AFF76B1006E2F48 /* CenterProminentlyCalculation.swift */; };
 		74804F0B2E25521C009F1F7D /* CenterTwoThirdsCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74804F0A2E25521C009F1F7D /* CenterTwoThirdsCalculation.swift */; };
 		7BE578EF2C5BF4EE0083DAE3 /* CycleSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE578EE2C5BF4ED0083DAE3 /* CycleSize.swift */; };
+		7BE578F12EFA00010083DAE3 /* CooperativeCornerResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE578F02EFA00010083DAE3 /* CooperativeCornerResize.swift */; };
 		7EC9E3BAD5BC57E49A7BCEE5 /* TwelfthsRepeated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3592F8E85CE82B8FA662A31 /* TwelfthsRepeated.swift */; };
 		866661F2257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */; };
 		88763FEFFA3AECF8502604D6 /* LowerMiddleCenterLeftSixteenthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378C96D832D4CC6BCCF9D604 /* LowerMiddleCenterLeftSixteenthCalculation.swift */; };
@@ -240,6 +241,7 @@
 		729E0A972AFF76B1006E2F48 /* CenterProminentlyCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterProminentlyCalculation.swift; sourceTree = "<group>"; };
 		74804F0A2E25521C009F1F7D /* CenterTwoThirdsCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterTwoThirdsCalculation.swift; sourceTree = "<group>"; };
 		7BE578EE2C5BF4ED0083DAE3 /* CycleSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleSize.swift; sourceTree = "<group>"; };
+		7BE578F02EFA00010083DAE3 /* CooperativeCornerResize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CooperativeCornerResize.swift; sourceTree = "<group>"; };
 		7E8357E928530D10A806F3CD /* TopRightTwelfthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopRightTwelfthCalculation.swift; sourceTree = "<group>"; };
 		84E2DBE0733F31BC159BC99C /* UpperMiddleLeftSixteenthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpperMiddleLeftSixteenthCalculation.swift; sourceTree = "<group>"; };
 		866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatedExecutionsInThirdsCalculation.swift; sourceTree = "<group>"; };
@@ -679,6 +681,7 @@
 				984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */,
 				98C1008B2305F1FA006E5344 /* SubsequentExecutionMode.swift */,
 				7BE578EE2C5BF4ED0083DAE3 /* CycleSize.swift */,
+				7BE578F02EFA00010083DAE3 /* CooperativeCornerResize.swift */,
 				985B9BF422B93EEC00A2E8F0 /* ApplicationToggle.swift */,
 				9824703022AFA8470037B409 /* RectangleStatusItem.swift */,
 				9824703622B0F3200037B409 /* WindowAction.swift */,
@@ -1050,6 +1053,7 @@
 				98C97FFD25893B040061F01F /* Config.swift in Sources */,
 				989DA30E243FC0DF008C7AA4 /* WelcomeViewController.swift in Sources */,
 				9818E01228B59B64004AA524 /* ThirdsCompoundCalculation.swift in Sources */,
+				7BE578F12EFA00010083DAE3 /* CooperativeCornerResize.swift in Sources */,
 				98C27561231FFA5F009B9292 /* SnappingManager.swift in Sources */,
 				9824703722B0F3200037B409 /* WindowAction.swift in Sources */,
 				B4521F932BD7CEFB00FD43CC /* ChangeWindowDimensionCalculation.swift in Sources */,

--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		9824702F22AFA2E50037B409 /* AccessibilityAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9824702E22AFA2E50037B409 /* AccessibilityAuthorization.swift */; };
 		9824703122AFA8470037B409 /* RectangleStatusItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9824703022AFA8470037B409 /* RectangleStatusItem.swift */; };
 		9824703722B0F3200037B409 /* WindowAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9824703622B0F3200037B409 /* WindowAction.swift */; };
+		982470382EFA00010037B409 /* WindowActionCooperativeResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982470372EFA00010037B409 /* WindowActionCooperativeResize.swift */; };
 		9824703922B0F37C0037B409 /* ShortcutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9824703822B0F37C0037B409 /* ShortcutManager.swift */; };
 		9824703B22B139780037B409 /* CUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9824703A22B139780037B409 /* CUtil.swift */; };
 		9824703D22B13C7E0037B409 /* AccessibilityElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9824703C22B13C7E0037B409 /* AccessibilityElement.swift */; };
@@ -299,6 +300,7 @@
 		9824702E22AFA2E50037B409 /* AccessibilityAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityAuthorization.swift; sourceTree = "<group>"; };
 		9824703022AFA8470037B409 /* RectangleStatusItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleStatusItem.swift; sourceTree = "<group>"; };
 		9824703622B0F3200037B409 /* WindowAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAction.swift; sourceTree = "<group>"; };
+		982470372EFA00010037B409 /* WindowActionCooperativeResize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowActionCooperativeResize.swift; sourceTree = "<group>"; };
 		9824703822B0F37C0037B409 /* ShortcutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutManager.swift; sourceTree = "<group>"; };
 		9824703A22B139780037B409 /* CUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CUtil.swift; sourceTree = "<group>"; };
 		9824703C22B13C7E0037B409 /* AccessibilityElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityElement.swift; sourceTree = "<group>"; };
@@ -685,6 +687,7 @@
 				985B9BF422B93EEC00A2E8F0 /* ApplicationToggle.swift */,
 				9824703022AFA8470037B409 /* RectangleStatusItem.swift */,
 				9824703622B0F3200037B409 /* WindowAction.swift */,
+				982470372EFA00010037B409 /* WindowActionCooperativeResize.swift */,
 				98A6EDEB2528FFC100F74B10 /* WindowActionCategory.swift */,
 				9824703822B0F37C0037B409 /* ShortcutManager.swift */,
 				9824703C22B13C7E0037B409 /* AccessibilityElement.swift */,
@@ -1056,6 +1059,7 @@
 				7BE578F12EFA00010083DAE3 /* CooperativeCornerResize.swift in Sources */,
 				98C27561231FFA5F009B9292 /* SnappingManager.swift in Sources */,
 				9824703722B0F3200037B409 /* WindowAction.swift in Sources */,
+				982470382EFA00010037B409 /* WindowActionCooperativeResize.swift in Sources */,
 				B4521F932BD7CEFB00FD43CC /* ChangeWindowDimensionCalculation.swift in Sources */,
 				9821402922B3889100ABFB3F /* LowerLeftCalculation.swift in Sources */,
 				7BE578EF2C5BF4EE0083DAE3 /* CycleSize.swift in Sources */,

--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -117,6 +117,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Defaults.installVersion.value = currentVersion
             Defaults.allowAnyShortcut.enabled = true
         }
+        MASShortcutMigration.migrateRenamedSideShortcutKeys()
         
         Defaults.lastVersion.value = currentVersion
     }

--- a/Rectangle/Base.lproj/Main.storyboard
+++ b/Rectangle/Base.lproj/Main.storyboard
@@ -343,7 +343,7 @@
                                                                         <subviews>
                                                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oac-MY-1n1">
                                                                                 <rect key="frame" x="-2" y="0.0" width="56" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Left Half" id="Xc8-Sm-pig">
+                                                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Left Side" id="Xc8-Sm-pig">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -392,7 +392,7 @@
                                                                         <subviews>
                                                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="daG-bl-Dca">
                                                                                 <rect key="frame" x="-2" y="0.0" width="64" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Right Half" id="F8S-GI-LiB">
+                                                                                <textFieldCell key="cell" lineBreakMode="clipping" title="Right Side" id="F8S-GI-LiB">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -441,7 +441,7 @@
                                                                         <subviews>
                                                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3T8-Nh-bKb">
                                                                                 <rect key="frame" x="-2" y="0.0" width="73" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Center Half" id="bRX-dV-iAR">
+                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Center Section" id="bRX-dV-iAR">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -490,7 +490,7 @@
                                                                         <subviews>
                                                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="j1Z-dN-QdR">
                                                                                 <rect key="frame" x="-2" y="0.0" width="55" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Top Half" id="d7y-s8-7GE">
+                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Top Side" id="d7y-s8-7GE">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -542,7 +542,7 @@
                                                                         <subviews>
                                                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xwW-KA-j8t">
                                                                                 <rect key="frame" x="-2" y="0.0" width="77" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Bottom Half" id="ec4-FB-fMa">
+                                                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Bottom Side" id="ec4-FB-fMa">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -2804,17 +2804,17 @@
                                                     </textField>
                                                     <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="pVH-s3-FHn">
                                                         <rect key="frame" x="138" y="0.0" width="362" height="24"/>
-                                                        <popUpButtonCell key="cell" type="push" title="move to adjacent on left/right, or cycle size on half" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="3" imageScaling="proportionallyDown" inset="2" selectedItem="3GE-la-fAZ" id="ccx-Gx-MGO">
+                                                        <popUpButtonCell key="cell" type="push" title="move to adjacent on left/right, or cycle size on side" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="3" imageScaling="proportionallyDown" inset="2" selectedItem="3GE-la-fAZ" id="ccx-Gx-MGO">
                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" size="12" name="HelveticaNeue"/>
                                                             <menu key="menu" id="TkU-PT-5p8">
                                                                 <items>
                                                                     <menuItem title="do nothing" tag="2" id="jww-Ju-S3d"/>
                                                                     <menuItem title="cycle through displays" tag="4" id="XlM-ch-cLG"/>
-                                                                    <menuItem title="cycle sizes on half actions" id="gHH-BV-5kP"/>
+                                                                    <menuItem title="cycle sizes on side actions" id="gHH-BV-5kP"/>
                                                                     <menuItem title="move to adjacent display on left or right" tag="1" id="Z9d-Rl-RVq"/>
-                                                                    <menuItem title="move to adjacent on left/right, or cycle size on half" state="on" tag="3" id="3GE-la-fAZ"/>
-                                                                    <menuItem title="cycle positions on quadrants, cycle sizes on half" tag="5" id="qCy-Kx-9mR"/>
+                                                                    <menuItem title="move to adjacent on left/right, or cycle size on side" state="on" tag="3" id="3GE-la-fAZ"/>
+                                                                    <menuItem title="cycle positions on quadrants, cycle sizes on side" tag="5" id="qCy-Kx-9mR"/>
                                                                 </items>
                                                             </menu>
                                                         </popUpButtonCell>

--- a/Rectangle/CooperativeCornerResize.swift
+++ b/Rectangle/CooperativeCornerResize.swift
@@ -1,0 +1,122 @@
+/// CooperativeCornerResize.swift
+
+import Cocoa
+
+struct CooperativeCornerResize {
+    struct Candidate {
+        let id: CGWindowID
+        let frame: CGRect
+    }
+
+    struct Adjustment {
+        let id: CGWindowID
+        let oldFrame: CGRect
+        let newFrame: CGRect
+    }
+
+    enum MovedEdge {
+        case left, right, top, bottom
+    }
+
+    static func movedEdge(from oldFocusedFrame: CGRect,
+                          to newFocusedFrame: CGRect,
+                          axis: CornerCycleExpansionAxis,
+                          tolerance: CGFloat) -> MovedEdge? {
+        switch axis {
+        case .horizontal:
+            let leftMoved = abs(oldFocusedFrame.minX - newFocusedFrame.minX) > tolerance
+            let rightMoved = abs(oldFocusedFrame.maxX - newFocusedFrame.maxX) > tolerance
+            guard leftMoved != rightMoved else { return nil }
+            return leftMoved ? .left : .right
+        case .vertical:
+            let bottomMoved = abs(oldFocusedFrame.minY - newFocusedFrame.minY) > tolerance
+            let topMoved = abs(oldFocusedFrame.maxY - newFocusedFrame.maxY) > tolerance
+            guard bottomMoved != topMoved else { return nil }
+            return bottomMoved ? .bottom : .top
+        }
+    }
+
+    static func adjustments(oldFocusedFrame: CGRect,
+                            newFocusedFrame: CGRect,
+                            screenFrame: CGRect,
+                            candidates: [Candidate],
+                            axis: CornerCycleExpansionAxis,
+                            tolerance: CGFloat,
+                            minimumSize: CGSize) -> [Adjustment] {
+        guard let movedEdge = movedEdge(from: oldFocusedFrame, to: newFocusedFrame, axis: axis, tolerance: tolerance) else {
+            return []
+        }
+
+        return candidates.compactMap { candidate in
+            guard !candidate.frame.isNull,
+                  screenFrame.intersects(candidate.frame),
+                  approximatelyMatchesPerpendicularSpan(candidate.frame, oldFocusedFrame, movedEdge: movedEdge, tolerance: tolerance),
+                  touchesOldMovingEdge(candidate.frame, oldFocusedFrame, movedEdge: movedEdge, tolerance: tolerance)
+            else {
+                return nil
+            }
+
+            var newFrame = candidate.frame
+            switch movedEdge {
+            case .left:
+                newFrame.size.width = newFocusedFrame.minX - candidate.frame.minX
+            case .right:
+                newFrame.origin.x = newFocusedFrame.maxX
+                newFrame.size.width = candidate.frame.maxX - newFocusedFrame.maxX
+            case .bottom:
+                newFrame.size.height = newFocusedFrame.minY - candidate.frame.minY
+            case .top:
+                newFrame.origin.y = newFocusedFrame.maxY
+                newFrame.size.height = candidate.frame.maxY - newFocusedFrame.maxY
+            }
+
+            guard newFrame.width >= minimumSize.width,
+                  newFrame.height >= minimumSize.height,
+                  screenFrame.intersects(newFrame)
+            else {
+                return nil
+            }
+
+            return Adjustment(id: candidate.id, oldFrame: candidate.frame, newFrame: newFrame)
+        }
+    }
+
+    static func focusedWindowIsExpanding(oldFrame: CGRect, newFrame: CGRect, axis: CornerCycleExpansionAxis) -> Bool {
+        switch axis {
+        case .horizontal:
+            return newFrame.width > oldFrame.width
+        case .vertical:
+            return newFrame.height > oldFrame.height
+        }
+    }
+
+    private static func touchesOldMovingEdge(_ candidate: CGRect,
+                                             _ focused: CGRect,
+                                             movedEdge: MovedEdge,
+                                             tolerance: CGFloat) -> Bool {
+        switch movedEdge {
+        case .left:
+            return abs(candidate.maxX - focused.minX) <= tolerance
+        case .right:
+            return abs(candidate.minX - focused.maxX) <= tolerance
+        case .bottom:
+            return abs(candidate.maxY - focused.minY) <= tolerance
+        case .top:
+            return abs(candidate.minY - focused.maxY) <= tolerance
+        }
+    }
+
+    private static func approximatelyMatchesPerpendicularSpan(_ candidate: CGRect,
+                                                              _ focused: CGRect,
+                                                              movedEdge: MovedEdge,
+                                                              tolerance: CGFloat) -> Bool {
+        switch movedEdge {
+        case .left, .right:
+            return abs(candidate.minY - focused.minY) <= tolerance
+                && abs(candidate.maxY - focused.maxY) <= tolerance
+        case .top, .bottom:
+            return abs(candidate.minX - focused.minX) <= tolerance
+                && abs(candidate.maxX - focused.maxX) <= tolerance
+        }
+    }
+}

--- a/Rectangle/CooperativeCornerResize.swift
+++ b/Rectangle/CooperativeCornerResize.swift
@@ -72,8 +72,44 @@ struct CooperativeCornerResize {
 
         let matchingFocusedFrameIds = Set(matchingFocusedFrameAdjustments.map(\.id))
 
+        let matchingMovingSpanAdjustments = candidates.compactMap { candidate -> Adjustment? in
+            guard !matchingFocusedFrameIds.contains(candidate.id),
+                  !candidate.frame.isNull,
+                  screenFrame.intersects(candidate.frame),
+                  matchesMovingSpan(candidate.frame, oldFocusedFrame, movedEdge: movedEdge, tolerance: tolerance),
+                  isSupportedPerpendicularSpan(candidate.frame, oldFocusedFrame, movedEdge: movedEdge, tolerance: tolerance)
+            else {
+                return nil
+            }
+
+            var newFrame = candidate.frame
+            switch movedEdge {
+            case .left, .right:
+                newFrame.origin.x = newFocusedFrame.minX
+                newFrame.size.width = newFocusedFrame.width
+            case .top, .bottom:
+                newFrame.origin.y = newFocusedFrame.minY
+                newFrame.size.height = newFocusedFrame.height
+            }
+
+            guard newFrame.width >= minimumSize.width,
+                  newFrame.height >= minimumSize.height,
+                  screenFrame.intersects(newFrame)
+            else {
+                return nil
+            }
+
+            return Adjustment(id: candidate.id,
+                              oldFrame: candidate.frame,
+                              newFrame: newFrame,
+                              kind: .matchingFocusedFrame)
+        }
+
+        let matchingMovingSpanIds = Set(matchingMovingSpanAdjustments.map(\.id))
+
         let adjacentAdjustments = candidates.compactMap { candidate -> Adjustment? in
             guard !matchingFocusedFrameIds.contains(candidate.id),
+                  !matchingMovingSpanIds.contains(candidate.id),
                   !candidate.frame.isNull,
                   screenFrame.intersects(candidate.frame),
                   isSupportedPerpendicularSpan(candidate.frame, oldFocusedFrame, movedEdge: movedEdge, tolerance: tolerance),
@@ -110,7 +146,7 @@ struct CooperativeCornerResize {
                               kind: .adjacent)
         }
 
-        return matchingFocusedFrameAdjustments + adjacentAdjustments
+        return matchingFocusedFrameAdjustments + matchingMovingSpanAdjustments + adjacentAdjustments
     }
 
     static func focusedWindowIsExpanding(oldFrame: CGRect, newFrame: CGRect, axis: CornerCycleExpansionAxis) -> Bool {
@@ -155,6 +191,20 @@ struct CooperativeCornerResize {
                                             focusedMin: focused.minX,
                                             focusedMax: focused.maxX,
                                             tolerance: tolerance)
+        }
+    }
+
+    private static func matchesMovingSpan(_ candidate: CGRect,
+                                          _ focused: CGRect,
+                                          movedEdge: MovedEdge,
+                                          tolerance: CGFloat) -> Bool {
+        switch movedEdge {
+        case .left, .right:
+            return abs(candidate.minX - focused.minX) <= tolerance
+                && abs(candidate.maxX - focused.maxX) <= tolerance
+        case .top, .bottom:
+            return abs(candidate.minY - focused.minY) <= tolerance
+                && abs(candidate.maxY - focused.maxY) <= tolerance
         }
     }
 

--- a/Rectangle/CooperativeCornerResize.swift
+++ b/Rectangle/CooperativeCornerResize.swift
@@ -12,6 +12,12 @@ struct CooperativeCornerResize {
         let id: CGWindowID
         let oldFrame: CGRect
         let newFrame: CGRect
+        let kind: Kind
+
+        enum Kind {
+            case matchingFocusedFrame
+            case adjacent
+        }
     }
 
     enum MovedEdge {
@@ -47,8 +53,28 @@ struct CooperativeCornerResize {
             return []
         }
 
-        return candidates.compactMap { candidate in
+        let matchingFocusedFrameAdjustments = candidates.compactMap { candidate -> Adjustment? in
             guard !candidate.frame.isNull,
+                  screenFrame.intersects(candidate.frame),
+                  approximatelyMatchesFrame(candidate.frame, oldFocusedFrame, tolerance: tolerance),
+                  newFocusedFrame.width >= minimumSize.width,
+                  newFocusedFrame.height >= minimumSize.height,
+                  screenFrame.intersects(newFocusedFrame)
+            else {
+                return nil
+            }
+
+            return Adjustment(id: candidate.id,
+                              oldFrame: candidate.frame,
+                              newFrame: newFocusedFrame,
+                              kind: .matchingFocusedFrame)
+        }
+
+        let matchingFocusedFrameIds = Set(matchingFocusedFrameAdjustments.map(\.id))
+
+        let adjacentAdjustments = candidates.compactMap { candidate -> Adjustment? in
+            guard !matchingFocusedFrameIds.contains(candidate.id),
+                  !candidate.frame.isNull,
                   screenFrame.intersects(candidate.frame),
                   approximatelyMatchesPerpendicularSpan(candidate.frame, oldFocusedFrame, movedEdge: movedEdge, tolerance: tolerance),
                   touchesOldMovingEdge(candidate.frame, oldFocusedFrame, movedEdge: movedEdge, tolerance: tolerance)
@@ -70,15 +96,21 @@ struct CooperativeCornerResize {
                 newFrame.size.height = candidate.frame.maxY - newFocusedFrame.maxY
             }
 
-            guard newFrame.width >= minimumSize.width,
+            guard !candidate.frame.isNull,
+                  newFrame.width >= minimumSize.width,
                   newFrame.height >= minimumSize.height,
                   screenFrame.intersects(newFrame)
             else {
                 return nil
             }
 
-            return Adjustment(id: candidate.id, oldFrame: candidate.frame, newFrame: newFrame)
+            return Adjustment(id: candidate.id,
+                              oldFrame: candidate.frame,
+                              newFrame: newFrame,
+                              kind: .adjacent)
         }
+
+        return matchingFocusedFrameAdjustments + adjacentAdjustments
     }
 
     static func focusedWindowIsExpanding(oldFrame: CGRect, newFrame: CGRect, axis: CornerCycleExpansionAxis) -> Bool {
@@ -118,5 +150,14 @@ struct CooperativeCornerResize {
             return abs(candidate.minX - focused.minX) <= tolerance
                 && abs(candidate.maxX - focused.maxX) <= tolerance
         }
+    }
+
+    private static func approximatelyMatchesFrame(_ candidate: CGRect,
+                                                  _ focused: CGRect,
+                                                  tolerance: CGFloat) -> Bool {
+        abs(candidate.minX - focused.minX) <= tolerance
+            && abs(candidate.maxX - focused.maxX) <= tolerance
+            && abs(candidate.minY - focused.minY) <= tolerance
+            && abs(candidate.maxY - focused.maxY) <= tolerance
     }
 }

--- a/Rectangle/CooperativeCornerResize.swift
+++ b/Rectangle/CooperativeCornerResize.swift
@@ -76,7 +76,7 @@ struct CooperativeCornerResize {
             guard !matchingFocusedFrameIds.contains(candidate.id),
                   !candidate.frame.isNull,
                   screenFrame.intersects(candidate.frame),
-                  approximatelyMatchesPerpendicularSpan(candidate.frame, oldFocusedFrame, movedEdge: movedEdge, tolerance: tolerance),
+                  isSupportedPerpendicularSpan(candidate.frame, oldFocusedFrame, movedEdge: movedEdge, tolerance: tolerance),
                   touchesOldMovingEdge(candidate.frame, oldFocusedFrame, movedEdge: movedEdge, tolerance: tolerance)
             else {
                 return nil
@@ -138,18 +138,44 @@ struct CooperativeCornerResize {
         }
     }
 
-    private static func approximatelyMatchesPerpendicularSpan(_ candidate: CGRect,
-                                                              _ focused: CGRect,
-                                                              movedEdge: MovedEdge,
-                                                              tolerance: CGFloat) -> Bool {
+    private static func isSupportedPerpendicularSpan(_ candidate: CGRect,
+                                                     _ focused: CGRect,
+                                                     movedEdge: MovedEdge,
+                                                     tolerance: CGFloat) -> Bool {
         switch movedEdge {
         case .left, .right:
-            return abs(candidate.minY - focused.minY) <= tolerance
-                && abs(candidate.maxY - focused.maxY) <= tolerance
+            return approximatelyMatchesSpan(candidateMin: candidate.minY,
+                                            candidateMax: candidate.maxY,
+                                            focusedMin: focused.minY,
+                                            focusedMax: focused.maxY,
+                                            tolerance: tolerance)
         case .top, .bottom:
-            return abs(candidate.minX - focused.minX) <= tolerance
-                && abs(candidate.maxX - focused.maxX) <= tolerance
+            return approximatelyMatchesSpan(candidateMin: candidate.minX,
+                                            candidateMax: candidate.maxX,
+                                            focusedMin: focused.minX,
+                                            focusedMax: focused.maxX,
+                                            tolerance: tolerance)
         }
+    }
+
+    private static func approximatelyMatchesSpan(candidateMin: CGFloat,
+                                                 candidateMax: CGFloat,
+                                                 focusedMin: CGFloat,
+                                                 focusedMax: CGFloat,
+                                                 tolerance: CGFloat) -> Bool {
+        let fullMatch = abs(candidateMin - focusedMin) <= tolerance
+            && abs(candidateMax - focusedMax) <= tolerance
+        if fullMatch {
+            return true
+        }
+
+        let candidateIsWithinFocused = candidateMin >= focusedMin - tolerance
+            && candidateMax <= focusedMax + tolerance
+        let sharesFocusedBoundary = abs(candidateMin - focusedMin) <= tolerance
+            || abs(candidateMax - focusedMax) <= tolerance
+        let meaningfulSpan = candidateMax - candidateMin > tolerance
+
+        return candidateIsWithinFocused && sharesFocusedBoundary && meaningfulSpan
     }
 
     private static func approximatelyMatchesFrame(_ candidate: CGRect,

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -40,7 +40,7 @@ enum CycleSize: Int, CaseIterable {
     }()
 }
 
-enum RepeatedCommandCycleAxis: Int {
+enum CornerCycleExpansionAxis: Int {
     case horizontal = 0
     case vertical = 1
 }

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -41,6 +41,11 @@ enum CycleSize: Int, CaseIterable {
 }
 
 extension CycleSize {
+    static let matchingTolerance: Float = 0.001
+    
+    static func matching(percentValue: Float) -> CycleSize? {
+        sortedSizes.first { $0.matches(percentValue: percentValue) }
+    }
     
     var title: String {
         switch self {
@@ -70,6 +75,14 @@ extension CycleSize {
         case .threeQuarters:
             3 / 4
         }
+    }
+    
+    var percentValue: Float {
+        fraction * 100
+    }
+    
+    func matches(percentValue: Float, tolerance: Float = Self.matchingTolerance) -> Bool {
+        abs(self.percentValue - percentValue) <= tolerance
     }
     
     var isAlwaysEnabled: Bool {

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -90,14 +90,6 @@ extension CycleSize {
         abs(self.percentValue - percentValue) <= tolerance
     }
     
-    var isAlwaysEnabled: Bool {
-        if self == .firstSize {
-            return true
-        }
-        
-        return false
-    }
-    
 }
 
 extension Set where Element == CycleSize {

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -40,6 +40,11 @@ enum CycleSize: Int, CaseIterable {
     }()
 }
 
+enum RepeatedCommandCycleAxis: Int {
+    case horizontal = 0
+    case vertical = 1
+}
+
 extension CycleSize {
     static let matchingTolerance: Float = 0.001
     

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -10,7 +10,7 @@ class Defaults {
     static let subsequentExecutionMode = SubsequentExecutionDefault()
     static let selectedCycleSizes = CycleSizesDefault()
     static let cycleSizesIsChanged = BoolDefault(key: "cycleSizesIsChanged")
-    static let repeatedCommandCycleAxis = IntEnumDefault<RepeatedCommandCycleAxis>(key: "repeatedCommandCycleAxis", defaultValue: .horizontal)
+    static let cornerCycleExpansionAxis = IntEnumDefault<CornerCycleExpansionAxis>(key: "cornerCycleExpansionAxis", defaultValue: .horizontal)
     static let allowAnyShortcut = BoolDefault(key: "allowAnyShortcut")
     static let windowSnapping = OptionalBoolDefault(key: "windowSnapping")
     static let almostMaximizeHeight = FloatDefault(key: "almostMaximizeHeight")
@@ -108,7 +108,7 @@ class Defaults {
         subsequentExecutionMode,
         selectedCycleSizes,
         cycleSizesIsChanged,
-        repeatedCommandCycleAxis,
+        cornerCycleExpansionAxis,
         allowAnyShortcut,
         windowSnapping,
         almostMaximizeHeight,

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -10,6 +10,7 @@ class Defaults {
     static let subsequentExecutionMode = SubsequentExecutionDefault()
     static let selectedCycleSizes = CycleSizesDefault()
     static let cycleSizesIsChanged = BoolDefault(key: "cycleSizesIsChanged")
+    static let repeatedCommandCycleAxis = IntEnumDefault<RepeatedCommandCycleAxis>(key: "repeatedCommandCycleAxis", defaultValue: .horizontal)
     static let allowAnyShortcut = BoolDefault(key: "allowAnyShortcut")
     static let windowSnapping = OptionalBoolDefault(key: "windowSnapping")
     static let almostMaximizeHeight = FloatDefault(key: "almostMaximizeHeight")
@@ -107,6 +108,7 @@ class Defaults {
         subsequentExecutionMode,
         selectedCycleSizes,
         cycleSizesIsChanged,
+        repeatedCommandCycleAxis,
         allowAnyShortcut,
         windowSnapping,
         almostMaximizeHeight,

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -11,6 +11,7 @@ class Defaults {
     static let selectedCycleSizes = CycleSizesDefault()
     static let cycleSizesIsChanged = BoolDefault(key: "cycleSizesIsChanged")
     static let cornerCycleExpansionAxis = IntEnumDefault<CornerCycleExpansionAxis>(key: "cornerCycleExpansionAxis", defaultValue: .horizontal)
+    static let cooperativeCornerResize = BoolDefault(key: "cooperativeCornerResize")
     static let allowAnyShortcut = BoolDefault(key: "allowAnyShortcut")
     static let windowSnapping = OptionalBoolDefault(key: "windowSnapping")
     static let almostMaximizeHeight = FloatDefault(key: "almostMaximizeHeight")
@@ -109,6 +110,7 @@ class Defaults {
         selectedCycleSizes,
         cycleSizesIsChanged,
         cornerCycleExpansionAxis,
+        cooperativeCornerResize,
         allowAnyShortcut,
         windowSnapping,
         almostMaximizeHeight,

--- a/Rectangle/PrefsWindow/Config.swift
+++ b/Rectangle/PrefsWindow/Config.swift
@@ -73,7 +73,8 @@ extension Defaults {
         }
         
         for action in WindowAction.active {
-            if let shortcut = config.shortcuts[action.name]?.toMASSHortcut() {
+            let importedShortcut = config.shortcuts[action.name] ?? action.legacyName.flatMap { config.shortcuts[$0] }
+            if let shortcut = importedShortcut?.toMASSHortcut() {
                 let dictValue = dictTransformer.reverseTransformedValue(shortcut)
                 UserDefaults.standard.setValue(dictValue, forKey: action.name)
             }

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -44,7 +44,7 @@ class SettingsViewController: NSViewController {
     private let shortcutRecordingObserver = ShortcutRecordingObserver()
     
     private var cycleSizeCheckboxes = [NSButton]()
-    private var repeatedCommandCycleAxisCheckboxes = [NSButton]()
+    private var cornerCycleExpansionAxisButtons = [NSButton]()
     private var combinedDisplayModeCheckbox: NSButton?
     
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
@@ -119,14 +119,14 @@ class SettingsViewController: NSViewController {
         Defaults.cyclingOverlapOffset.enabled = sender.state == .on
     }
 
-    @objc func toggleRepeatedCommandCycleAxis(_ sender: NSButton) {
-        guard let axis = RepeatedCommandCycleAxis(rawValue: sender.tag) else {
-            Logger.log("Expected tag of repeated-command axis lock checkbox to match a value of RepeatedCommandCycleAxis. Got: \(String(describing: sender.tag))")
+    @objc func setCornerCycleExpansionAxis(_ sender: NSButton) {
+        guard let axis = CornerCycleExpansionAxis(rawValue: sender.tag) else {
+            Logger.log("Expected tag of cyclic corner expansion axis radio button to match a value of CornerCycleExpansionAxis. Got: \(String(describing: sender.tag))")
             return
         }
 
-        Defaults.repeatedCommandCycleAxis.value = axis
-        setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
+        Defaults.cornerCycleExpansionAxis.value = axis
+        setToggleStatesForCornerCycleExpansionAxisButtons()
     }
     
     @IBAction func checkForUpdates(_ sender: Any) {
@@ -1024,24 +1024,20 @@ class SettingsViewController: NSViewController {
         initializeTodoModeSettings()
         shortcutRecordingObserver.observe([toggleTodoShortcutView, reflowTodoShortcutView])
         
-        self.cycleSizeCheckboxes.forEach {
-            $0.removeFromSuperview()
-        }
-        self.repeatedCommandCycleAxisCheckboxes.forEach {
-            $0.removeFromSuperview()
+        cycleSizesView.arrangedSubviews.forEach { view in
+            cycleSizesView.removeArrangedSubview(view)
+            view.removeFromSuperview()
         }
         
         let cycleSizeCheckboxes = makeCycleSizeCheckboxes()
-        cycleSizeCheckboxes.forEach { checkbox in
-            cycleSizesView.addArrangedSubview(checkbox)
-        }
         self.cycleSizeCheckboxes = cycleSizeCheckboxes
 
-        let repeatedCommandCycleAxisCheckboxes = makeRepeatedCommandCycleAxisCheckboxes()
-        repeatedCommandCycleAxisCheckboxes.forEach { checkbox in
-            cycleSizesView.addArrangedSubview(checkbox)
-        }
-        self.repeatedCommandCycleAxisCheckboxes = repeatedCommandCycleAxisCheckboxes
+        let cornerCycleExpansionAxisRow = makeCornerCycleExpansionAxisRow()
+        cycleSizesView.orientation = .vertical
+        cycleSizesView.alignment = .leading
+        cycleSizesView.spacing = 4
+        cycleSizesView.addArrangedSubview(makeCycleSizesRow(cycleSizeCheckboxes))
+        cycleSizesView.addArrangedSubview(cornerCycleExpansionAxisRow)
         
         initializeCycleSizesView(animated: false)
 
@@ -1122,7 +1118,7 @@ class SettingsViewController: NSViewController {
             stageView.isHidden = true
         }
         setToggleStatesForCycleSizeCheckboxes()
-        setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
+        setToggleStatesForCornerCycleExpansionAxisButtons()
     }
     
     private func initializeCycleSizesView(animated: Bool = false) {
@@ -1130,7 +1126,7 @@ class SettingsViewController: NSViewController {
         
         if showOptionsView {
             setToggleStatesForCycleSizeCheckboxes()
-            setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
+            setToggleStatesForCornerCycleExpansionAxisButtons()
         }
         
         setVisibility(shown: showOptionsView, ofView: cycleSizesView, withConstraint: cycleSizesViewHeightConstraint, animated: animated)
@@ -1214,15 +1210,35 @@ class SettingsViewController: NSViewController {
         }
     }
 
-    private func makeRepeatedCommandCycleAxisCheckboxes() -> [NSButton] {
-        [
-            makeRepeatedCommandCycleAxisCheckbox(title: NSLocalizedString("Lock horizontal axis", tableName: "Main", value: "", comment: ""), axis: .horizontal),
-            makeRepeatedCommandCycleAxisCheckbox(title: NSLocalizedString("Lock vertical axis", tableName: "Main", value: "", comment: ""), axis: .vertical)
-        ]
+    private func makeCycleSizesRow(_ checkboxes: [NSButton]) -> NSStackView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = 8
+        checkboxes.forEach { row.addArrangedSubview($0) }
+        return row
     }
 
-    private func makeRepeatedCommandCycleAxisCheckbox(title: String, axis: RepeatedCommandCycleAxis) -> NSButton {
-        let button = NSButton(checkboxWithTitle: title, target: self, action: #selector(toggleRepeatedCommandCycleAxis(_:)))
+    private func makeCornerCycleExpansionAxisRow() -> NSStackView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = 8
+
+        let label = NSTextField(labelWithString: NSLocalizedString("Cyclic corner shortcuts expand:", tableName: "Main", value: "", comment: ""))
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        row.addArrangedSubview(label)
+
+        let horizontalButton = makeCornerCycleExpansionAxisButton(title: NSLocalizedString("horizontally", tableName: "Main", value: "", comment: ""), axis: .horizontal)
+        let verticalButton = makeCornerCycleExpansionAxisButton(title: NSLocalizedString("vertically", tableName: "Main", value: "", comment: ""), axis: .vertical)
+        cornerCycleExpansionAxisButtons = [horizontalButton, verticalButton]
+        cornerCycleExpansionAxisButtons.forEach { row.addArrangedSubview($0) }
+
+        return row
+    }
+
+    private func makeCornerCycleExpansionAxisButton(title: String, axis: CornerCycleExpansionAxis) -> NSButton {
+        let button = NSButton(radioButtonWithTitle: title, target: self, action: #selector(setCornerCycleExpansionAxis(_:)))
         button.tag = axis.rawValue
         button.setContentCompressionResistancePriority(.required, for: .vertical)
         return button
@@ -1310,9 +1326,9 @@ class SettingsViewController: NSViewController {
         }
     }
 
-    private func setToggleStatesForRepeatedCommandCycleAxisCheckboxes() {
-        repeatedCommandCycleAxisCheckboxes.forEach { checkbox in
-            checkbox.state = checkbox.tag == Defaults.repeatedCommandCycleAxis.value.rawValue ? .on : .off
+    private func setToggleStatesForCornerCycleExpansionAxisButtons() {
+        cornerCycleExpansionAxisButtons.forEach { button in
+            button.state = button.tag == Defaults.cornerCycleExpansionAxis.value.rawValue ? .on : .off
         }
     }
 

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -1205,6 +1205,7 @@ class SettingsViewController: NSViewController {
         CycleSize.sortedSizes.map { division in
             let button = NSButton(checkboxWithTitle: division.title, target: self, action: #selector(didCheckCycleSizeCheckbox(sender:)))
             button.tag = division.rawValue
+            button.refusesFirstResponder = true
             button.setContentCompressionResistancePriority(.required, for: .vertical)
             return button
         }
@@ -1240,6 +1241,7 @@ class SettingsViewController: NSViewController {
     private func makeCornerCycleExpansionAxisButton(title: String, axis: CornerCycleExpansionAxis) -> NSButton {
         let button = NSButton(radioButtonWithTitle: title, target: self, action: #selector(setCornerCycleExpansionAxis(_:)))
         button.tag = axis.rawValue
+        button.refusesFirstResponder = true
         button.setContentCompressionResistancePriority(.required, for: .vertical)
         return button
     }
@@ -1315,14 +1317,9 @@ class SettingsViewController: NSViewController {
                 return
             }
             
-            let isAlwaysEnabled = cycleSizeForCheckbox.isAlwaysEnabled
-            let isChecked = isAlwaysEnabled || cycleSizes.contains(cycleSizeForCheckbox)
+            let isChecked = cycleSizes.contains(cycleSizeForCheckbox)
             checkbox.state = isChecked ? .on : .off
-            
-            // Show that the box cannot be unchecked.
-            if isAlwaysEnabled {
-                checkbox.isEnabled = false
-            }
+            checkbox.isEnabled = true
         }
     }
 

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -1257,7 +1257,7 @@ class SettingsViewController: NSViewController {
     }
 
     private func makeCooperativeCornerResizeCheckbox() -> NSButton {
-        let button = NSButton(checkboxWithTitle: NSLocalizedString("Resize adjacent windows when cycling corner shortcuts", tableName: "Main", value: "", comment: ""),
+        let button = NSButton(checkboxWithTitle: NSLocalizedString("Resize adjacent windows when cycling side or corner shortcuts", tableName: "Main", value: "", comment: ""),
                               target: self,
                               action: #selector(toggleCooperativeCornerResize(_:)))
         button.refusesFirstResponder = true

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -374,7 +374,7 @@ class SettingsViewController: NSViewController {
             integerFormatter.minimum = 1
             widthStepField.formatter = integerFormatter
 
-            let splitRatioHeaderLabel = NSTextField(labelWithString: NSLocalizedString("Half Split Ratios", tableName: "Main", value: "", comment: ""))
+            let splitRatioHeaderLabel = NSTextField(labelWithString: NSLocalizedString("Side Split Ratio", tableName: "Main", value: "", comment: ""))
             splitRatioHeaderLabel.font = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize)
             splitRatioHeaderLabel.alignment = .center
             splitRatioHeaderLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -44,6 +44,7 @@ class SettingsViewController: NSViewController {
     private let shortcutRecordingObserver = ShortcutRecordingObserver()
     
     private var cycleSizeCheckboxes = [NSButton]()
+    private var repeatedCommandCycleAxisCheckboxes = [NSButton]()
     private var combinedDisplayModeCheckbox: NSButton?
     
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
@@ -116,6 +117,16 @@ class SettingsViewController: NSViewController {
 
     @objc func toggleCyclingOverlapOffset(_ sender: NSButton) {
         Defaults.cyclingOverlapOffset.enabled = sender.state == .on
+    }
+
+    @objc func toggleRepeatedCommandCycleAxis(_ sender: NSButton) {
+        guard let axis = RepeatedCommandCycleAxis(rawValue: sender.tag) else {
+            Logger.log("Expected tag of repeated-command axis lock checkbox to match a value of RepeatedCommandCycleAxis. Got: \(String(describing: sender.tag))")
+            return
+        }
+
+        Defaults.repeatedCommandCycleAxis.value = axis
+        setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
     }
     
     @IBAction func checkForUpdates(_ sender: Any) {
@@ -1016,12 +1027,21 @@ class SettingsViewController: NSViewController {
         self.cycleSizeCheckboxes.forEach {
             $0.removeFromSuperview()
         }
+        self.repeatedCommandCycleAxisCheckboxes.forEach {
+            $0.removeFromSuperview()
+        }
         
         let cycleSizeCheckboxes = makeCycleSizeCheckboxes()
         cycleSizeCheckboxes.forEach { checkbox in
             cycleSizesView.addArrangedSubview(checkbox)
         }
         self.cycleSizeCheckboxes = cycleSizeCheckboxes
+
+        let repeatedCommandCycleAxisCheckboxes = makeRepeatedCommandCycleAxisCheckboxes()
+        repeatedCommandCycleAxisCheckboxes.forEach { checkbox in
+            cycleSizesView.addArrangedSubview(checkbox)
+        }
+        self.repeatedCommandCycleAxisCheckboxes = repeatedCommandCycleAxisCheckboxes
         
         initializeCycleSizesView(animated: false)
 
@@ -1101,9 +1121,8 @@ class SettingsViewController: NSViewController {
         } else {
             stageView.isHidden = true
         }
-        
-        
         setToggleStatesForCycleSizeCheckboxes()
+        setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
     }
     
     private func initializeCycleSizesView(animated: Bool = false) {
@@ -1111,6 +1130,7 @@ class SettingsViewController: NSViewController {
         
         if showOptionsView {
             setToggleStatesForCycleSizeCheckboxes()
+            setToggleStatesForRepeatedCommandCycleAxisCheckboxes()
         }
         
         setVisibility(shown: showOptionsView, ofView: cycleSizesView, withConstraint: cycleSizesViewHeightConstraint, animated: animated)
@@ -1193,6 +1213,20 @@ class SettingsViewController: NSViewController {
             return button
         }
     }
+
+    private func makeRepeatedCommandCycleAxisCheckboxes() -> [NSButton] {
+        [
+            makeRepeatedCommandCycleAxisCheckbox(title: NSLocalizedString("Lock horizontal axis", tableName: "Main", value: "", comment: ""), axis: .horizontal),
+            makeRepeatedCommandCycleAxisCheckbox(title: NSLocalizedString("Lock vertical axis", tableName: "Main", value: "", comment: ""), axis: .vertical)
+        ]
+    }
+
+    private func makeRepeatedCommandCycleAxisCheckbox(title: String, axis: RepeatedCommandCycleAxis) -> NSButton {
+        let button = NSButton(checkboxWithTitle: title, target: self, action: #selector(toggleRepeatedCommandCycleAxis(_:)))
+        button.tag = axis.rawValue
+        button.setContentCompressionResistancePriority(.required, for: .vertical)
+        return button
+    }
     
     private func configureHalfSplitRatioPopUpButton(_ popUpButton: HalfSplitRatioPopUpButton) {
         popUpButton.removeAllItems()
@@ -1273,6 +1307,12 @@ class SettingsViewController: NSViewController {
             if isAlwaysEnabled {
                 checkbox.isEnabled = false
             }
+        }
+    }
+
+    private func setToggleStatesForRepeatedCommandCycleAxisCheckboxes() {
+        repeatedCommandCycleAxisCheckboxes.forEach { checkbox in
+            checkbox.state = checkbox.tag == Defaults.repeatedCommandCycleAxis.value.rawValue ? .on : .off
         }
     }
 

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -391,6 +391,14 @@ class SettingsViewController: NSViewController {
             hSplitField.alignment = .right
             hSplitField.formatter = percentFormatter
 
+            let hSplitPopUpButton = HalfSplitRatioPopUpButton()
+            hSplitPopUpButton.translatesAutoresizingMaskIntoConstraints = false
+            hSplitPopUpButton.target = self
+            hSplitPopUpButton.action = #selector(didSelectHalfSplitRatioPreset(sender:))
+            hSplitPopUpButton.defaults = Defaults.horizontalSplitRatio
+            hSplitPopUpButton.customField = hSplitField
+            configureHalfSplitRatioPopUpButton(hSplitPopUpButton)
+
             let vSplitField = AutoSaveFloatField(frame: NSRect(x: 0, y: 0, width: 160, height: 19))
             vSplitField.stringValue = String(Int(Defaults.verticalSplitRatio.value))
             vSplitField.delegate = self
@@ -400,6 +408,21 @@ class SettingsViewController: NSViewController {
             vSplitField.refusesFirstResponder = true
             vSplitField.alignment = .right
             vSplitField.formatter = percentFormatter
+
+            let vSplitPopUpButton = HalfSplitRatioPopUpButton()
+            vSplitPopUpButton.translatesAutoresizingMaskIntoConstraints = false
+            vSplitPopUpButton.target = self
+            vSplitPopUpButton.action = #selector(didSelectHalfSplitRatioPreset(sender:))
+            vSplitPopUpButton.defaults = Defaults.verticalSplitRatio
+            vSplitPopUpButton.customField = vSplitField
+            configureHalfSplitRatioPopUpButton(vSplitPopUpButton)
+
+            hSplitField.defaultsSetAction = { [weak hSplitPopUpButton] in
+                hSplitPopUpButton?.selectCurrentValue()
+            }
+            vSplitField.defaultsSetAction = { [weak vSplitPopUpButton] in
+                vSplitPopUpButton?.selectCurrentValue()
+            }
 
             largerWidthShortcutView.setAssociatedUserDefaultsKey(WindowAction.largerWidth.name, withTransformerName: MASDictionaryTransformerName)
             smallerWidthShortcutView.setAssociatedUserDefaultsKey(WindowAction.smallerWidth.name, withTransformerName: MASDictionaryTransformerName)
@@ -629,14 +652,26 @@ class SettingsViewController: NSViewController {
             hSplitRow.alignment = .centerY
             hSplitRow.spacing = 18
             hSplitRow.addArrangedSubview(hSplitLabel)
-            hSplitRow.addArrangedSubview(hSplitField)
+            let hSplitControlsStack = NSStackView()
+            hSplitControlsStack.orientation = .horizontal
+            hSplitControlsStack.alignment = .centerY
+            hSplitControlsStack.spacing = 8
+            hSplitControlsStack.addArrangedSubview(hSplitPopUpButton)
+            hSplitControlsStack.addArrangedSubview(hSplitField)
+            hSplitRow.addArrangedSubview(hSplitControlsStack)
 
             let vSplitRow = NSStackView()
             vSplitRow.orientation = .horizontal
             vSplitRow.alignment = .centerY
             vSplitRow.spacing = 18
             vSplitRow.addArrangedSubview(vSplitLabel)
-            vSplitRow.addArrangedSubview(vSplitField)
+            let vSplitControlsStack = NSStackView()
+            vSplitControlsStack.orientation = .horizontal
+            vSplitControlsStack.alignment = .centerY
+            vSplitControlsStack.spacing = 8
+            vSplitControlsStack.addArrangedSubview(vSplitPopUpButton)
+            vSplitControlsStack.addArrangedSubview(vSplitField)
+            vSplitRow.addArrangedSubview(vSplitControlsStack)
             
             let topVerticalThirdRow = NSStackView()
             topVerticalThirdRow.orientation = .horizontal
@@ -896,6 +931,12 @@ class SettingsViewController: NSViewController {
                 largerWidthShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 smallerWidthShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 widthStepField.widthAnchor.constraint(equalToConstant: 160),
+                hSplitControlsStack.widthAnchor.constraint(equalToConstant: 160),
+                vSplitControlsStack.widthAnchor.constraint(equalToConstant: 160),
+                hSplitPopUpButton.widthAnchor.constraint(equalToConstant: 100),
+                vSplitPopUpButton.widthAnchor.constraint(equalToConstant: 100),
+                hSplitField.widthAnchor.constraint(equalToConstant: 52),
+                vSplitField.widthAnchor.constraint(equalToConstant: 52),
                 topVerticalThirdShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 middleVerticalThirdShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 bottomVerticalThirdShortcutView.widthAnchor.constraint(equalToConstant: 160),
@@ -936,8 +977,8 @@ class SettingsViewController: NSViewController {
                 sixteenthsCyclingShortcutView.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 gridHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
                 cyclingHintLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor, constant: -20),
-                hSplitField.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor),
-                vSplitField.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor)
+                hSplitControlsStack.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor),
+                vSplitControlsStack.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor)
             ])
 
             let containerView = NSView()
@@ -1153,6 +1194,41 @@ class SettingsViewController: NSViewController {
         }
     }
     
+    private func configureHalfSplitRatioPopUpButton(_ popUpButton: HalfSplitRatioPopUpButton) {
+        popUpButton.removeAllItems()
+        
+        CycleSize.sortedSizes.forEach { cycleSize in
+            popUpButton.addItem(withTitle: cycleSize.title)
+            popUpButton.lastItem?.tag = cycleSize.rawValue
+        }
+        
+        popUpButton.addItem(withTitle: NSLocalizedString("Other", tableName: "Main", value: "", comment: ""))
+        popUpButton.lastItem?.tag = HalfSplitRatioPopUpButton.otherTag
+        popUpButton.selectCurrentValue()
+    }
+    
+    @objc private func didSelectHalfSplitRatioPreset(sender: Any?) {
+        guard let popUpButton = sender as? HalfSplitRatioPopUpButton,
+              let defaults = popUpButton.defaults else {
+            Logger.log("Expected action to be sent from HalfSplitRatioPopUpButton. Instead, sender is: \(String(describing: sender))")
+            return
+        }
+        
+        guard popUpButton.selectedTag() != HalfSplitRatioPopUpButton.otherTag else {
+            popUpButton.customField?.isHidden = false
+            return
+        }
+        
+        guard let cycleSize = CycleSize(rawValue: popUpButton.selectedTag()) else {
+            Logger.log("Expected tag of half split ratio popup to match a value of CycleSize. Got: \(String(describing: popUpButton.selectedTag()))")
+            return
+        }
+        
+        defaults.value = cycleSize.percentValue
+        popUpButton.customField?.stringValue = "\(Int(round(cycleSize.percentValue)))"
+        popUpButton.customField?.isHidden = true
+    }
+    
     @objc private func didCheckCycleSizeCheckbox(sender: Any?) {
         guard let checkbox = sender as? NSButton else {
             Logger.log("Expected action to be sent from NSButton. Instead, sender is: \(String(describing: sender))")
@@ -1241,4 +1317,27 @@ class AutoSaveFloatField: NSTextField {
     var defaults: FloatDefault?
     var defaultsSetAction: (() -> Void)?
     var fallbackValue: Float = 30
+}
+
+class HalfSplitRatioPopUpButton: NSPopUpButton {
+    static let otherTag = -1
+    
+    var defaults: FloatDefault?
+    weak var customField: AutoSaveFloatField?
+    
+    func selectCurrentValue() {
+        guard let value = defaults?.value else {
+            selectItem(withTag: Self.otherTag)
+            customField?.isHidden = false
+            return
+        }
+        
+        if let cycleSize = CycleSize.matching(percentValue: value) {
+            selectItem(withTag: cycleSize.rawValue)
+            customField?.isHidden = true
+        } else {
+            selectItem(withTag: Self.otherTag)
+            customField?.isHidden = false
+        }
+    }
 }

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -45,6 +45,7 @@ class SettingsViewController: NSViewController {
     
     private var cycleSizeCheckboxes = [NSButton]()
     private var cornerCycleExpansionAxisButtons = [NSButton]()
+    private var cooperativeCornerResizeCheckbox: NSButton?
     private var combinedDisplayModeCheckbox: NSButton?
     
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
@@ -127,6 +128,10 @@ class SettingsViewController: NSViewController {
 
         Defaults.cornerCycleExpansionAxis.value = axis
         setToggleStatesForCornerCycleExpansionAxisButtons()
+    }
+
+    @objc func toggleCooperativeCornerResize(_ sender: NSButton) {
+        Defaults.cooperativeCornerResize.enabled = sender.state == .on
     }
     
     @IBAction func checkForUpdates(_ sender: Any) {
@@ -1033,11 +1038,14 @@ class SettingsViewController: NSViewController {
         self.cycleSizeCheckboxes = cycleSizeCheckboxes
 
         let cornerCycleExpansionAxisRow = makeCornerCycleExpansionAxisRow()
+        let cooperativeCornerResizeCheckbox = makeCooperativeCornerResizeCheckbox()
+        self.cooperativeCornerResizeCheckbox = cooperativeCornerResizeCheckbox
         cycleSizesView.orientation = .vertical
         cycleSizesView.alignment = .leading
         cycleSizesView.spacing = 4
         cycleSizesView.addArrangedSubview(makeCycleSizesRow(cycleSizeCheckboxes))
         cycleSizesView.addArrangedSubview(cornerCycleExpansionAxisRow)
+        cycleSizesView.addArrangedSubview(cooperativeCornerResizeCheckbox)
         
         initializeCycleSizesView(animated: false)
 
@@ -1119,6 +1127,7 @@ class SettingsViewController: NSViewController {
         }
         setToggleStatesForCycleSizeCheckboxes()
         setToggleStatesForCornerCycleExpansionAxisButtons()
+        setToggleStateForCooperativeCornerResizeCheckbox()
     }
     
     private func initializeCycleSizesView(animated: Bool = false) {
@@ -1127,6 +1136,7 @@ class SettingsViewController: NSViewController {
         if showOptionsView {
             setToggleStatesForCycleSizeCheckboxes()
             setToggleStatesForCornerCycleExpansionAxisButtons()
+            setToggleStateForCooperativeCornerResizeCheckbox()
         }
         
         setVisibility(shown: showOptionsView, ofView: cycleSizesView, withConstraint: cycleSizesViewHeightConstraint, animated: animated)
@@ -1245,6 +1255,15 @@ class SettingsViewController: NSViewController {
         button.setContentCompressionResistancePriority(.required, for: .vertical)
         return button
     }
+
+    private func makeCooperativeCornerResizeCheckbox() -> NSButton {
+        let button = NSButton(checkboxWithTitle: NSLocalizedString("Resize adjacent windows when cycling corner shortcuts", tableName: "Main", value: "", comment: ""),
+                              target: self,
+                              action: #selector(toggleCooperativeCornerResize(_:)))
+        button.refusesFirstResponder = true
+        button.setContentCompressionResistancePriority(.required, for: .vertical)
+        return button
+    }
     
     private func configureHalfSplitRatioPopUpButton(_ popUpButton: HalfSplitRatioPopUpButton) {
         popUpButton.removeAllItems()
@@ -1327,6 +1346,10 @@ class SettingsViewController: NSViewController {
         cornerCycleExpansionAxisButtons.forEach { button in
             button.state = button.tag == Defaults.cornerCycleExpansionAxis.value.rawValue ? .on : .off
         }
+    }
+
+    private func setToggleStateForCooperativeCornerResizeCheckbox() {
+        cooperativeCornerResizeCheckbox?.state = Defaults.cooperativeCornerResize.enabled ? .on : .off
     }
 
 }

--- a/Rectangle/Snapping/CompoundSnapArea/CompoundSnapArea.swift
+++ b/Rectangle/Snapping/CompoundSnapArea/CompoundSnapArea.swift
@@ -23,15 +23,15 @@ enum CompoundSnapArea: Int, Codable {
     var displayName: String {
         switch self {
         case .leftTopBottomHalf:
-            return NSLocalizedString("Left half, top/bottom half near corners", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Left side, top/bottom side near corners", tableName: "Main", value: "", comment: "")
         case .rightTopBottomHalf:
-            return NSLocalizedString("Right half, top/bottom half near corners", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Right side, top/bottom side near corners", tableName: "Main", value: "", comment: "")
         case .thirds:
             return NSLocalizedString("Thirds, drag toward center for two thirds", tableName: "Main", value: "", comment: "")
         case .portraitThirdsSide:
-            return NSLocalizedString("Thirds, top/bottom half near corners", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Thirds, top/bottom side near corners", tableName: "Main", value: "", comment: "")
         case .halves:
-            return NSLocalizedString("Left or right half", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Left or right side", tableName: "Main", value: "", comment: "")
         case .topSixths:
             return NSLocalizedString("Top sixths from corners; maximize", tableName: "Main", value: "", comment: "")
         case .bottomSixths:
@@ -39,7 +39,7 @@ enum CompoundSnapArea: Int, Codable {
         case .fourths:
             return NSLocalizedString("Fourths columns", tableName: "Main", value: "", comment: "")
         case .portraitTopBottomHalves:
-            return NSLocalizedString("Top/bottom halves", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Top/bottom sides", tableName: "Main", value: "", comment: "")
         case .topEighths:
             return NSLocalizedString("Top eighths from corners; maximize", tableName: "Main", value: "", comment: "")
         case .bottomEighths:

--- a/Rectangle/Utilities/MASShortcutMigration.swift
+++ b/Rectangle/Utilities/MASShortcutMigration.swift
@@ -24,5 +24,18 @@ class MASShortcutMigration {
         }
         
     }
+
+    static func migrateRenamedSideShortcutKeys(userDefaults: UserDefaults = .standard) {
+        for action in WindowAction.active {
+            guard let legacyName = action.legacyName,
+                  let legacyValue = userDefaults.object(forKey: legacyName)
+            else { continue }
+
+            if userDefaults.object(forKey: action.name) == nil {
+                userDefaults.set(legacyValue, forKey: action.name)
+            }
+            userDefaults.removeObject(forKey: legacyName)
+        }
+    }
     
 }

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -203,16 +203,16 @@ enum WindowAction: Int, Codable {
 
     var name: String {
         switch self {
-        case .leftHalf: return "leftHalf"
-        case .rightHalf: return "rightHalf"
+        case .leftHalf: return "leftSide"
+        case .rightHalf: return "rightSide"
         case .maximize: return "maximize"
         case .maximizeHeight: return "maximizeHeight"
         case .previousDisplay: return "previousDisplay"
         case .nextDisplay: return "nextDisplay"
         case .larger: return "larger"
         case .smaller: return "smaller"
-        case .bottomHalf: return "bottomHalf"
-        case .topHalf: return "topHalf"
+        case .bottomHalf: return "bottomSide"
+        case .topHalf: return "topSide"
         case .center: return "center"
         case .bottomLeft: return "bottomLeft"
         case .bottomRight: return "bottomRight"
@@ -230,7 +230,7 @@ enum WindowAction: Int, Codable {
         case .moveUp: return "moveUp"
         case .moveDown: return "moveDown"
         case .almostMaximize: return "almostMaximize"
-        case .centerHalf: return "centerHalf"
+        case .centerHalf: return "centerSection"
         case .firstFourth: return "firstFourth"
         case .secondFourth: return "secondFourth"
         case .thirdFourth: return "thirdFourth"
@@ -331,6 +331,17 @@ enum WindowAction: Int, Codable {
         }
     }
 
+    var legacyName: String? {
+        switch self {
+        case .leftHalf: return "leftHalf"
+        case .rightHalf: return "rightHalf"
+        case .bottomHalf: return "bottomHalf"
+        case .topHalf: return "topHalf"
+        case .centerHalf: return "centerHalf"
+        default: return nil
+        }
+    }
+
     var displayIndex: Int? {
         switch self {
         case .displayOne: return 0
@@ -353,10 +364,10 @@ enum WindowAction: Int, Codable {
         switch self {
         case .leftHalf:
             key = "Xc8-Sm-pig.title"
-            value = "Left Half"
+            value = "Left Side"
         case .rightHalf:
             key = "F8S-GI-LiB.title"
-            value = "Right Half"
+            value = "Right Side"
         case .maximize:
             key = "8oe-J2-oUU.title"
             value = "Maximize"
@@ -377,10 +388,10 @@ enum WindowAction: Int, Codable {
             value = "Smaller"
         case .bottomHalf:
             key = "ec4-FB-fMa.title"
-            value = "Bottom Half"
+            value = "Bottom Side"
         case .topHalf:
             key = "d7y-s8-7GE.title"
-            value = "Top Half"
+            value = "Top Side"
         case .center:
             key = "8Bg-SZ-hDO.title"
             value = "Center"
@@ -434,7 +445,7 @@ enum WindowAction: Int, Codable {
             value = "Almost Maximize"
         case .centerHalf:
             key = "bRX-dV-iAR.title"
-            value = "Center Half"
+            value = "Center Section"
         case .firstFourth:
             key = "Q6Q-6J-okH.title"
             value = "First Fourth"

--- a/Rectangle/WindowActionCategory.swift
+++ b/Rectangle/WindowActionCategory.swift
@@ -24,7 +24,7 @@ enum WindowActionCategory {
     var displayName: String {
         switch self {
         case .halves:
-            return NSLocalizedString("Halves", tableName: "Main", value: "", comment: "")
+            return NSLocalizedString("Sides", tableName: "Main", value: "", comment: "")
         case .corners:
             return NSLocalizedString("Corners", tableName: "Main", value: "", comment: "")
         case .thirds:

--- a/Rectangle/WindowActionCooperativeResize.swift
+++ b/Rectangle/WindowActionCooperativeResize.swift
@@ -1,0 +1,51 @@
+/// WindowActionCooperativeResize.swift
+
+import Foundation
+
+extension WindowAction {
+    var cooperativeResizeAxis: CornerCycleExpansionAxis? {
+        switch self {
+        case .topLeft, .topRight, .bottomLeft, .bottomRight:
+            return Defaults.cornerCycleExpansionAxis.value
+        case .leftHalf, .rightHalf:
+            return .horizontal
+        case .topHalf, .bottomHalf:
+            return .vertical
+        default:
+            return nil
+        }
+    }
+
+    func isCompatibleRepeatedResizeAction(with other: WindowAction?) -> Bool {
+        guard let other else { return false }
+        return cooperativeResizeSide == other.cooperativeResizeSide
+            && cooperativeResizeAxis == other.cooperativeResizeAxis
+    }
+
+    private var cooperativeResizeSide: CooperativeResizeSide? {
+        switch self {
+        case .leftHalf:
+            return .left
+        case .rightHalf:
+            return .right
+        case .topHalf:
+            return .top
+        case .bottomHalf:
+            return .bottom
+        case .topLeft:
+            return Defaults.cornerCycleExpansionAxis.value == .horizontal ? .left : .top
+        case .topRight:
+            return Defaults.cornerCycleExpansionAxis.value == .horizontal ? .right : .top
+        case .bottomLeft:
+            return Defaults.cornerCycleExpansionAxis.value == .horizontal ? .left : .bottom
+        case .bottomRight:
+            return Defaults.cornerCycleExpansionAxis.value == .horizontal ? .right : .bottom
+        default:
+            return nil
+        }
+    }
+}
+
+private enum CooperativeResizeSide {
+    case left, right, top, bottom
+}

--- a/Rectangle/WindowActionCooperativeResize.swift
+++ b/Rectangle/WindowActionCooperativeResize.swift
@@ -18,8 +18,20 @@ extension WindowAction {
 
     func isCompatibleRepeatedResizeAction(with other: WindowAction?) -> Bool {
         guard let other else { return false }
+        if isCooperativeCornerAction, other.isCooperativeCornerAction {
+            return self == other
+        }
         return cooperativeResizeSide == other.cooperativeResizeSide
             && cooperativeResizeAxis == other.cooperativeResizeAxis
+    }
+
+    private var isCooperativeCornerAction: Bool {
+        switch self {
+        case .topLeft, .topRight, .bottomLeft, .bottomRight:
+            return true
+        default:
+            return false
+        }
     }
 
     private var cooperativeResizeSide: CooperativeResizeSide? {

--- a/Rectangle/WindowCalculation/BottomHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomHalfCalculation.swift
@@ -14,15 +14,11 @@ class BottomHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
     }
     
     func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return calculateFractionalRect(params, fraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0)
+        return RectResult(HalfSplitFrameCalculation.verticalRect(in: params.visibleFrameOfScreen, side: .trailing, fraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var rect = visibleFrameOfScreen
-        rect.size.height = floor(visibleFrameOfScreen.height * CGFloat(fraction))
-        return RectResult(rect)
+        return RectResult(HalfSplitFrameCalculation.verticalRect(in: params.visibleFrameOfScreen, side: .trailing, fraction: fraction))
     }
     
 }

--- a/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
@@ -29,21 +29,14 @@ class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCal
     
     func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
         let ratio = Defaults.horizontalSplitRatio.value / 100.0
-        let fraction = params.action == .rightHalf ? 1.0 - ratio : ratio
-        return calculateFractionalRect(params, fraction: fraction)
+        let side: HalfSplitSide = params.action == .rightHalf ? .trailing : .leading
+        let fraction = side == .trailing ? 1.0 - ratio : ratio
+        return RectResult(HalfSplitFrameCalculation.horizontalRect(in: params.visibleFrameOfScreen, side: side, fraction: fraction))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var rect = visibleFrameOfScreen
-
-        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
-        if params.action == .rightHalf {
-            rect.origin.x = visibleFrameOfScreen.maxX - rect.width
-        }
-
-        return RectResult(rect)
+        let side: HalfSplitSide = params.action == .rightHalf ? .trailing : .leading
+        return RectResult(HalfSplitFrameCalculation.horizontalRect(in: params.visibleFrameOfScreen, side: side, fraction: fraction))
     }
 
     func calculateResize(_ params: WindowCalculationParameters) -> WindowCalculationResult? {
@@ -96,15 +89,6 @@ class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCal
 
     // Used to draw box for snapping
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
-        let ratio = CGFloat(Defaults.horizontalSplitRatio.value / 100.0)
-        var rect = params.visibleFrameOfScreen
-        let leftWidth = floor(rect.width * ratio)
-        if params.action == .leftHalf {
-            rect.size.width = leftWidth
-        } else {
-            rect.size.width = rect.width - leftWidth
-            rect.origin.x += leftWidth
-        }
-        return RectResult(rect)
+        calculateFirstRect(params)
     }
 }

--- a/Rectangle/WindowCalculation/LowerLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerLeftCalculation.swift
@@ -2,7 +2,12 @@
 
 import Foundation
 
-class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation, QuartersRepeated {
+class LowerLeftCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+    
+    let horizontalSide: HalfSplitSide = .leading
+    let verticalSide: HalfSplitSide = .trailing
+    var horizontalSplitFraction: Float { Defaults.horizontalSplitRatio.value / 100.0 }
+    var verticalSplitFraction: Float { 1.0 - Defaults.verticalSplitRatio.value / 100.0 }
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -26,27 +31,15 @@ class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcula
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         return RectResult(cornerRect(visibleFrameOfScreen,
-                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0),
+                                     horizontalFraction: horizontalSplitFraction,
+                                     verticalFraction: verticalSplitFraction),
                           subAction: .bottomLeftQuarter)
-    }
-
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0))
-    }
-
-    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: fraction,
-                                     verticalFraction: fraction))
     }
 
     private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
         HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
-                                             horizontalSide: .leading,
-                                             verticalSide: .trailing,
+                                             horizontalSide: horizontalSide,
+                                             verticalSide: verticalSide,
                                              horizontalFraction: horizontalFraction,
                                              verticalFraction: verticalFraction)
     }

--- a/Rectangle/WindowCalculation/LowerLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerLeftCalculation.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-class LowerLeftCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+class LowerLeftCalculation: WindowCalculation, CornerCycleExpansionCalculation, QuartersRepeated {
     
     let horizontalSide: HalfSplitSide = .leading
     let verticalSide: HalfSplitSide = .trailing

--- a/Rectangle/WindowCalculation/LowerLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerLeftCalculation.swift
@@ -25,18 +25,29 @@ class LowerLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcula
     }
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(rect, subAction: .bottomLeftQuarter)
+        return RectResult(cornerRect(visibleFrameOfScreen,
+                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0),
+                          subAction: .bottomLeftQuarter)
+    }
+
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: fraction,
+                                     verticalFraction: fraction))
+    }
 
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(rect)
+    private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
+        HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
+                                             horizontalSide: .leading,
+                                             verticalSide: .trailing,
+                                             horizontalFraction: horizontalFraction,
+                                             verticalFraction: verticalFraction)
     }
 }

--- a/Rectangle/WindowCalculation/LowerRightCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerRightCalculation.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-class LowerRightCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+class LowerRightCalculation: WindowCalculation, CornerCycleExpansionCalculation, QuartersRepeated {
     
     let horizontalSide: HalfSplitSide = .trailing
     let verticalSide: HalfSplitSide = .trailing

--- a/Rectangle/WindowCalculation/LowerRightCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerRightCalculation.swift
@@ -25,20 +25,29 @@ class LowerRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
     }
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(rect, subAction: .bottomRightQuarter)
+        return RectResult(cornerRect(visibleFrameOfScreen,
+                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0),
+                          subAction: .bottomRightQuarter)
+    }
+
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: fraction,
+                                     verticalFraction: fraction))
+    }
 
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
-        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        return RectResult(rect)
+    private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
+        HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
+                                             horizontalSide: .trailing,
+                                             verticalSide: .trailing,
+                                             horizontalFraction: horizontalFraction,
+                                             verticalFraction: verticalFraction)
     }
 }

--- a/Rectangle/WindowCalculation/LowerRightCalculation.swift
+++ b/Rectangle/WindowCalculation/LowerRightCalculation.swift
@@ -2,7 +2,12 @@
 
 import Foundation
 
-class LowerRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation, QuartersRepeated {
+class LowerRightCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+    
+    let horizontalSide: HalfSplitSide = .trailing
+    let verticalSide: HalfSplitSide = .trailing
+    var horizontalSplitFraction: Float { 1.0 - Defaults.horizontalSplitRatio.value / 100.0 }
+    var verticalSplitFraction: Float { 1.0 - Defaults.verticalSplitRatio.value / 100.0 }
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -26,27 +31,15 @@ class LowerRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         return RectResult(cornerRect(visibleFrameOfScreen,
-                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0),
+                                     horizontalFraction: horizontalSplitFraction,
+                                     verticalFraction: verticalSplitFraction),
                           subAction: .bottomRightQuarter)
-    }
-
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: 1.0 - Defaults.verticalSplitRatio.value / 100.0))
-    }
-
-    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: fraction,
-                                     verticalFraction: fraction))
     }
 
     private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
         HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
-                                             horizontalSide: .trailing,
-                                             verticalSide: .trailing,
+                                             horizontalSide: horizontalSide,
+                                             verticalSide: verticalSide,
                                              horizontalFraction: horizontalFraction,
                                              verticalFraction: verticalFraction)
     }

--- a/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
@@ -12,6 +12,14 @@ protocol RepeatedExecutionsCalculation {
 
 extension RepeatedExecutionsCalculation {
     
+    func sortedCycleSizes() -> [CycleSize] {
+        let useDefaultPositions = !Defaults.cycleSizesIsChanged.enabled
+        let positions = useDefaultPositions ? CycleSize.defaultSizes : Defaults.selectedCycleSizes.value
+        
+        return CycleSize.sortedSizes
+            .filter { positions.contains($0) }
+    }
+    
     func calculateRepeatedRect(_ params: RectCalculationParameters) -> RectResult {
         
         guard let count = params.lastAction?.count,
@@ -20,15 +28,84 @@ extension RepeatedExecutionsCalculation {
             return calculateFirstRect(params)
         }
         
-        let useDefaultPositions = !Defaults.cycleSizesIsChanged.enabled
-        let positions = useDefaultPositions ? CycleSize.defaultSizes : Defaults.selectedCycleSizes.value
-        
-        let sortedPositions = CycleSize.sortedSizes
-            .filter { positions.contains($0) }
+        let sortedPositions = sortedCycleSizes()
                 
         let position = count % sortedPositions.count
         
         return calculateRect(for: sortedPositions[position], params: params)
     }
     
+}
+
+protocol AxisLockedCornerRepeatedCalculation: RepeatedExecutionsCalculation {
+    var horizontalSide: HalfSplitSide { get }
+    var verticalSide: HalfSplitSide { get }
+    var horizontalSplitFraction: Float { get }
+    var verticalSplitFraction: Float { get }
+}
+
+extension AxisLockedCornerRepeatedCalculation {
+    
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        RectResult(cornerRect(params.visibleFrameOfScreen,
+                              horizontalFraction: horizontalSplitFraction,
+                              verticalFraction: verticalSplitFraction))
+    }
+    
+    func calculateRect(for cycleDivision: CycleSize, params: RectCalculationParameters) -> RectResult {
+        calculateFractionalRect(params, fraction: cycleDivision.fraction)
+    }
+    
+    func calculateRepeatedRect(_ params: RectCalculationParameters) -> RectResult {
+        guard params.lastAction?.action == params.action else {
+            return calculateFirstRect(params)
+        }
+
+        let sortedPositions = sortedCycleSizes()
+        let currentIndex = sortedPositions.firstIndex { cycleSize in
+            calculateRect(for: cycleSize, params: params).rect.equalTo(params.window.rect)
+        }
+
+        if let currentIndex {
+            let nextIndex = (currentIndex + 1) % sortedPositions.count
+            return calculateRect(for: sortedPositions[nextIndex], params: params)
+        }
+
+        guard let count = params.lastAction?.count else {
+            return calculateFirstRect(params)
+        }
+
+        return calculateRect(for: sortedPositions[count % sortedPositions.count], params: params)
+    }
+    
+    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
+        let normalRect = calculateFirstRect(params).rect
+
+        switch Defaults.repeatedCommandCycleAxis.value {
+        case .horizontal:
+            let cycledRect = cornerRect(params.visibleFrameOfScreen,
+                                        horizontalFraction: fraction,
+                                        verticalFraction: verticalSplitFraction)
+            return RectResult(CGRect(x: cycledRect.origin.x,
+                                     y: normalRect.origin.y,
+                                     width: cycledRect.width,
+                                     height: normalRect.height))
+        case .vertical:
+            let cycledRect = cornerRect(params.visibleFrameOfScreen,
+                                        horizontalFraction: horizontalSplitFraction,
+                                        verticalFraction: fraction)
+            return RectResult(CGRect(x: normalRect.origin.x,
+                                     y: cycledRect.origin.y,
+                                     width: normalRect.width,
+                                     height: cycledRect.height))
+        }
+    }
+    
+    private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
+        HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
+                                             horizontalSide: horizontalSide,
+                                             verticalSide: verticalSide,
+                                             horizontalFraction: horizontalFraction,
+                                             verticalFraction: verticalFraction)
+    }
 }

--- a/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
@@ -68,7 +68,7 @@ extension CornerCycleExpansionCalculation {
     }
     
     func calculateRepeatedRect(_ params: RectCalculationParameters) -> RectResult {
-        guard params.lastAction?.action == params.action else {
+        guard params.action.isCompatibleRepeatedResizeAction(with: params.lastAction?.action) else {
             return calculateFirstRect(params)
         }
 

--- a/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
@@ -37,14 +37,14 @@ extension RepeatedExecutionsCalculation {
     
 }
 
-protocol AxisLockedCornerRepeatedCalculation: RepeatedExecutionsCalculation {
+protocol CornerCycleExpansionCalculation: RepeatedExecutionsCalculation {
     var horizontalSide: HalfSplitSide { get }
     var verticalSide: HalfSplitSide { get }
     var horizontalSplitFraction: Float { get }
     var verticalSplitFraction: Float { get }
 }
 
-extension AxisLockedCornerRepeatedCalculation {
+extension CornerCycleExpansionCalculation {
     
     func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
         RectResult(cornerRect(params.visibleFrameOfScreen,
@@ -81,7 +81,7 @@ extension AxisLockedCornerRepeatedCalculation {
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
         let normalRect = calculateFirstRect(params).rect
 
-        switch Defaults.repeatedCommandCycleAxis.value {
+        switch Defaults.cornerCycleExpansionAxis.value {
         case .horizontal:
             let cycledRect = cornerRect(params.visibleFrameOfScreen,
                                         horizontalFraction: fraction,

--- a/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
@@ -29,10 +29,21 @@ extension RepeatedExecutionsCalculation {
         }
         
         let sortedPositions = sortedCycleSizes()
+        guard !sortedPositions.isEmpty else {
+            return calculateFirstRect(params)
+        }
                 
-        let position = count % sortedPositions.count
+        let position = cycleIndex(forExecutionCount: count, in: sortedPositions)
         
         return calculateRect(for: sortedPositions[position], params: params)
+    }
+
+    func cycleIndex(forExecutionCount count: Int, in sortedPositions: [CycleSize]) -> Int {
+        if sortedPositions.contains(.firstSize) {
+            return count % sortedPositions.count
+        }
+
+        return max(0, count - 1) % sortedPositions.count
     }
     
 }
@@ -62,6 +73,10 @@ extension CornerCycleExpansionCalculation {
         }
 
         let sortedPositions = sortedCycleSizes()
+        guard !sortedPositions.isEmpty else {
+            return calculateFirstRect(params)
+        }
+
         let currentIndex = sortedPositions.firstIndex { cycleSize in
             calculateRect(for: cycleSize, params: params).rect.equalTo(params.window.rect)
         }
@@ -75,7 +90,7 @@ extension CornerCycleExpansionCalculation {
             return calculateFirstRect(params)
         }
 
-        return calculateRect(for: sortedPositions[count % sortedPositions.count], params: params)
+        return calculateRect(for: sortedPositions[cycleIndex(forExecutionCount: count, in: sortedPositions)], params: params)
     }
     
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {

--- a/Rectangle/WindowCalculation/RepeatedExecutionsInThirdsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsInThirdsCalculation.swift
@@ -20,7 +20,7 @@ extension RepeatedExecutionsInThirdsCalculation {
     }
 
     func calculateRepeatedRect(_ params: RectCalculationParameters) -> RectResult {
-        guard params.lastAction?.action == params.action else {
+        guard params.action.isCompatibleRepeatedResizeAction(with: params.lastAction?.action) else {
             return calculateFirstRect(params)
         }
 

--- a/Rectangle/WindowCalculation/RepeatedExecutionsInThirdsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsInThirdsCalculation.swift
@@ -18,5 +18,31 @@ extension RepeatedExecutionsInThirdsCalculation {
         let fraction = cycleDivision.fraction
         return calculateFractionalRect(params, fraction: fraction)
     }
+
+    func calculateRepeatedRect(_ params: RectCalculationParameters) -> RectResult {
+        guard params.lastAction?.action == params.action else {
+            return calculateFirstRect(params)
+        }
+
+        let sortedPositions = sortedCycleSizes()
+        guard !sortedPositions.isEmpty else {
+            return calculateFirstRect(params)
+        }
+
+        let currentIndex = sortedPositions.firstIndex { cycleSize in
+            calculateRect(for: cycleSize, params: params).rect.equalTo(params.window.rect)
+        }
+
+        if let currentIndex {
+            let nextIndex = (currentIndex + 1) % sortedPositions.count
+            return calculateRect(for: sortedPositions[nextIndex], params: params)
+        }
+
+        guard let count = params.lastAction?.count else {
+            return calculateFirstRect(params)
+        }
+
+        return calculateRect(for: sortedPositions[cycleIndex(forExecutionCount: count, in: sortedPositions)], params: params)
+    }
     
 }

--- a/Rectangle/WindowCalculation/TopHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/TopHalfCalculation.swift
@@ -14,16 +14,11 @@ class TopHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculati
     }
     
     func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return calculateFractionalRect(params, fraction: Defaults.verticalSplitRatio.value / 100.0)
+        return RectResult(HalfSplitFrameCalculation.verticalRect(in: params.visibleFrameOfScreen, side: .leading, fraction: Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
-
-        var rect = visibleFrameOfScreen
-        rect.size.height = floor(visibleFrameOfScreen.height * CGFloat(fraction))
-        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
-        return RectResult(rect)
+        return RectResult(HalfSplitFrameCalculation.verticalRect(in: params.visibleFrameOfScreen, side: .leading, fraction: fraction))
     }
     
 }

--- a/Rectangle/WindowCalculation/UpperLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperLeftCalculation.swift
@@ -2,7 +2,12 @@
 
 import Foundation
 
-class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation, QuartersRepeated {
+class UpperLeftCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+    
+    let horizontalSide: HalfSplitSide = .leading
+    let verticalSide: HalfSplitSide = .leading
+    var horizontalSplitFraction: Float { Defaults.horizontalSplitRatio.value / 100.0 }
+    var verticalSplitFraction: Float { Defaults.verticalSplitRatio.value / 100.0 }
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -26,27 +31,15 @@ class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcula
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         return RectResult(cornerRect(visibleFrameOfScreen,
-                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0),
+                                     horizontalFraction: horizontalSplitFraction,
+                                     verticalFraction: verticalSplitFraction),
                           subAction: .topLeftQuarter)
-    }
-
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0))
-    }
-
-    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: fraction,
-                                     verticalFraction: fraction))
     }
 
     private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
         HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
-                                             horizontalSide: .leading,
-                                             verticalSide: .leading,
+                                             horizontalSide: horizontalSide,
+                                             verticalSide: verticalSide,
                                              horizontalFraction: horizontalFraction,
                                              verticalFraction: verticalFraction)
     }

--- a/Rectangle/WindowCalculation/UpperLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperLeftCalculation.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-class UpperLeftCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+class UpperLeftCalculation: WindowCalculation, CornerCycleExpansionCalculation, QuartersRepeated {
     
     let horizontalSide: HalfSplitSide = .leading
     let verticalSide: HalfSplitSide = .leading

--- a/Rectangle/WindowCalculation/UpperLeftCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperLeftCalculation.swift
@@ -25,20 +25,29 @@ class UpperLeftCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcula
     }
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
-        return RectResult(rect, subAction: .topLeftQuarter)
+        return RectResult(cornerRect(visibleFrameOfScreen,
+                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0),
+                          subAction: .topLeftQuarter)
+    }
+
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: fraction,
+                                     verticalFraction: fraction))
+    }
 
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
-        return RectResult(rect)
+    private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
+        HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
+                                             horizontalSide: .leading,
+                                             verticalSide: .leading,
+                                             horizontalFraction: horizontalFraction,
+                                             verticalFraction: verticalFraction)
     }
 }

--- a/Rectangle/WindowCalculation/UpperRightCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperRightCalculation.swift
@@ -2,7 +2,12 @@
 
 import Foundation
 
-class UpperRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculation, QuartersRepeated {
+class UpperRightCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+    
+    let horizontalSide: HalfSplitSide = .trailing
+    let verticalSide: HalfSplitSide = .leading
+    var horizontalSplitFraction: Float { 1.0 - Defaults.horizontalSplitRatio.value / 100.0 }
+    var verticalSplitFraction: Float { Defaults.verticalSplitRatio.value / 100.0 }
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
@@ -26,27 +31,15 @@ class UpperRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
         return RectResult(cornerRect(visibleFrameOfScreen,
-                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0),
+                                     horizontalFraction: horizontalSplitFraction,
+                                     verticalFraction: verticalSplitFraction),
                           subAction: .topRightQuarter)
-    }
-
-    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
-                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0))
-    }
-
-    func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        return RectResult(cornerRect(params.visibleFrameOfScreen,
-                                     horizontalFraction: fraction,
-                                     verticalFraction: fraction))
     }
 
     private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
         HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
-                                             horizontalSide: .trailing,
-                                             verticalSide: .leading,
+                                             horizontalSide: horizontalSide,
+                                             verticalSide: verticalSide,
                                              horizontalFraction: horizontalFraction,
                                              verticalFraction: verticalFraction)
     }

--- a/Rectangle/WindowCalculation/UpperRightCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperRightCalculation.swift
@@ -25,22 +25,29 @@ class UpperRightCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
     }
 
     func quarterRect(_ visibleFrameOfScreen: CGRect) -> RectResult {
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
-        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
-        return RectResult(rect, subAction: .topRightQuarter)
+        return RectResult(cornerRect(visibleFrameOfScreen,
+                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0),
+                          subAction: .topRightQuarter)
+    }
+
+    func calculateFirstRect(_ params: RectCalculationParameters) -> RectResult {
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: 1.0 - Defaults.horizontalSplitRatio.value / 100.0,
+                                     verticalFraction: Defaults.verticalSplitRatio.value / 100.0))
     }
 
     func calculateFractionalRect(_ params: RectCalculationParameters, fraction: Float) -> RectResult {
-        let visibleFrameOfScreen = params.visibleFrameOfScreen
+        return RectResult(cornerRect(params.visibleFrameOfScreen,
+                                     horizontalFraction: fraction,
+                                     verticalFraction: fraction))
+    }
 
-        var rect = visibleFrameOfScreen
-        rect.size.width = floor(visibleFrameOfScreen.width * CGFloat(fraction))
-        rect.origin.x = visibleFrameOfScreen.maxX - rect.width
-        rect.size.height = floor(visibleFrameOfScreen.height / 2.0)
-        rect.origin.y = visibleFrameOfScreen.maxY - rect.height
-        return RectResult(rect)
+    private func cornerRect(_ visibleFrameOfScreen: CGRect, horizontalFraction: Float, verticalFraction: Float) -> CGRect {
+        HalfSplitFrameCalculation.cornerRect(in: visibleFrameOfScreen,
+                                             horizontalSide: .trailing,
+                                             verticalSide: .leading,
+                                             horizontalFraction: horizontalFraction,
+                                             verticalFraction: verticalFraction)
     }
 }

--- a/Rectangle/WindowCalculation/UpperRightCalculation.swift
+++ b/Rectangle/WindowCalculation/UpperRightCalculation.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-class UpperRightCalculation: WindowCalculation, AxisLockedCornerRepeatedCalculation, QuartersRepeated {
+class UpperRightCalculation: WindowCalculation, CornerCycleExpansionCalculation, QuartersRepeated {
     
     let horizontalSide: HalfSplitSide = .trailing
     let verticalSide: HalfSplitSide = .leading

--- a/Rectangle/WindowCalculation/WindowCalculation.swift
+++ b/Rectangle/WindowCalculation/WindowCalculation.swift
@@ -116,6 +116,57 @@ struct WindowCalculationResult {
     }
 }
 
+enum HalfSplitSide {
+    case leading
+    case trailing
+}
+
+struct HalfSplitFrameCalculation {
+    private static let floorTolerance: CGFloat = 0.0001
+    
+    static func horizontalRect(in visibleFrameOfScreen: CGRect, side: HalfSplitSide, fraction: Float) -> CGRect {
+        var rect = visibleFrameOfScreen
+        rect.size.width = floorDimension(visibleFrameOfScreen.width * CGFloat(fraction))
+        
+        if side == .trailing {
+            rect.origin.x = visibleFrameOfScreen.maxX - rect.width
+        }
+        
+        return rect
+    }
+    
+    static func verticalRect(in visibleFrameOfScreen: CGRect, side: HalfSplitSide, fraction: Float) -> CGRect {
+        var rect = visibleFrameOfScreen
+        rect.size.height = floorDimension(visibleFrameOfScreen.height * CGFloat(fraction))
+        
+        if side == .leading {
+            rect.origin.y = visibleFrameOfScreen.maxY - rect.height
+        }
+        
+        return rect
+    }
+    
+    static func cornerRect(in visibleFrameOfScreen: CGRect,
+                           horizontalSide: HalfSplitSide,
+                           verticalSide: HalfSplitSide,
+                           horizontalFraction: Float,
+                           verticalFraction: Float) -> CGRect {
+        let horizontalRect = horizontalRect(in: visibleFrameOfScreen, side: horizontalSide, fraction: horizontalFraction)
+        let verticalRect = verticalRect(in: visibleFrameOfScreen, side: verticalSide, fraction: verticalFraction)
+        
+        var rect = visibleFrameOfScreen
+        rect.origin.x = horizontalRect.origin.x
+        rect.size.width = horizontalRect.width
+        rect.origin.y = verticalRect.origin.y
+        rect.size.height = verticalRect.height
+        return rect
+    }
+    
+    private static func floorDimension(_ value: CGFloat) -> CGFloat {
+        floor(value + floorTolerance)
+    }
+}
+
 class WindowCalculationFactory {
     
     static let leftHalfCalculation = LeftRightHalfCalculation()

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -139,6 +139,7 @@ class WindowManager {
                                                                               oldFocusedFrame: currentNormalizedRect,
                                                                               newFocusedFrame: calcResult.rect,
                                                                               screenFrame: visibleFrameOfDestinationScreen,
+                                                                              destinationScreenIsCurrentScreen: usableScreens.currentScreen == calcResult.screen,
                                                                               lastRectangleAction: lastRectangleAction)
         let resultParameters = ResultParameters(windowId: windowId,
                                                 action: action,
@@ -186,12 +187,16 @@ class WindowManager {
         : standardWindowMoverChain
         
         let newRect = result.calcResult.rect
-        let focusedWindowIsExpanding = CooperativeCornerResize.focusedWindowIsExpanding(oldFrame: result.windowElement.frame.screenFlipped,
-                                                                                        newFrame: newRect,
-                                                                                        axis: Defaults.cornerCycleExpansionAxis.value)
+        let cooperativeAxis = result.action.cooperativeResizeAxis
+        let focusedWindowIsExpanding = cooperativeAxis.map {
+            CooperativeCornerResize.focusedWindowIsExpanding(oldFrame: result.windowElement.frame.screenFlipped,
+                                                             newFrame: newRect,
+                                                             axis: $0)
+        } ?? false
 
         if focusedWindowIsExpanding {
-            apply(cooperativeCornerAdjustments)
+            apply(cooperativeCornerAdjustments, kind: .adjacent)
+            apply(cooperativeCornerAdjustments, kind: .matchingFocusedFrame)
         }
         
         for windowMover in windowMoverChain {
@@ -201,7 +206,8 @@ class WindowManager {
         let resultingRect = result.windowElement.frame
 
         if !focusedWindowIsExpanding {
-            apply(cooperativeCornerAdjustments)
+            apply(cooperativeCornerAdjustments, kind: .matchingFocusedFrame)
+            apply(cooperativeCornerAdjustments, kind: .adjacent)
         }
 
         return resultingRect
@@ -214,11 +220,13 @@ class WindowManager {
                                                     oldFocusedFrame: CGRect,
                                                     newFocusedFrame: CGRect,
                                                     screenFrame: CGRect,
+                                                    destinationScreenIsCurrentScreen: Bool,
                                                     lastRectangleAction: RectangleAction?) -> [CooperativeCornerWindowAdjustment] {
         guard Defaults.cooperativeCornerResize.enabled,
               source == .keyboardShortcut,
               !focusedWindowIsFixedSize,
-              action.isBasicCorner,
+              destinationScreenIsCurrentScreen,
+              let cooperativeAxis = action.cooperativeResizeAxis,
               lastRectangleAction?.action == action
         else {
             return []
@@ -256,18 +264,18 @@ class WindowManager {
                                                               newFocusedFrame: newFocusedFrame,
                                                               screenFrame: screenFrame,
                                                               candidates: candidates,
-                                                              axis: Defaults.cornerCycleExpansionAxis.value,
+                                                              axis: cooperativeAxis,
                                                               tolerance: tolerance,
                                                               minimumSize: minimumSize)
 
         return adjustments.compactMap { adjustment in
             guard let element = elementsById[adjustment.id] else { return nil }
-            return CooperativeCornerWindowAdjustment(element: element, newFrame: adjustment.newFrame)
+            return CooperativeCornerWindowAdjustment(element: element, newFrame: adjustment.newFrame, kind: adjustment.kind)
         }
     }
 
-    private func apply(_ adjustments: [CooperativeCornerWindowAdjustment]) {
-        adjustments.forEach { adjustment in
+    private func apply(_ adjustments: [CooperativeCornerWindowAdjustment], kind: CooperativeCornerResize.Adjustment.Kind) {
+        adjustments.filter { $0.kind == kind }.forEach { adjustment in
             adjustment.element.setFrame(adjustment.newFrame.screenFlipped)
         }
     }
@@ -408,15 +416,20 @@ enum ExecutionSource {
 private struct CooperativeCornerWindowAdjustment {
     let element: AccessibilityElement
     let newFrame: CGRect
+    let kind: CooperativeCornerResize.Adjustment.Kind
 }
 
 private extension WindowAction {
-    var isBasicCorner: Bool {
+    var cooperativeResizeAxis: CornerCycleExpansionAxis? {
         switch self {
         case .topLeft, .topRight, .bottomLeft, .bottomRight:
-            return true
+            return Defaults.cornerCycleExpansionAxis.value
+        case .leftHalf, .rightHalf:
+            return .horizontal
+        case .topHalf, .bottomHalf:
+            return .vertical
         default:
-            return false
+            return nil
         }
     }
 }

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -227,7 +227,7 @@ class WindowManager {
               !focusedWindowIsFixedSize,
               destinationScreenIsCurrentScreen,
               let cooperativeAxis = action.cooperativeResizeAxis,
-              lastRectangleAction?.action == action
+              action.isCompatibleRepeatedResizeAction(with: lastRectangleAction?.action)
         else {
             return []
         }
@@ -417,19 +417,4 @@ private struct CooperativeCornerWindowAdjustment {
     let element: AccessibilityElement
     let newFrame: CGRect
     let kind: CooperativeCornerResize.Adjustment.Kind
-}
-
-private extension WindowAction {
-    var cooperativeResizeAxis: CornerCycleExpansionAxis? {
-        switch self {
-        case .topLeft, .topRight, .bottomLeft, .bottomRight:
-            return Defaults.cornerCycleExpansionAxis.value
-        case .leftHalf, .rightHalf:
-            return .horizontal
-        case .topHalf, .bottomHalf:
-            return .vertical
-        default:
-            return nil
-        }
-    }
 }

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -130,8 +130,16 @@ class WindowManager {
             return
         }
         
-        let visibleFrameOfDestinationScreen = calcResult.resultingScreenFrame ?? calcResult.screen.adjustedVisibleFrame(ignoreTodo)
         let isFixedSize = (!frontmostWindowElement.isResizable() && action.resizes) || frontmostWindowElement.isSystemDialog == true
+        let visibleFrameOfDestinationScreen = calcResult.resultingScreenFrame ?? calcResult.screen.adjustedVisibleFrame(ignoreTodo)
+        let cooperativeCornerAdjustments = cooperativeCornerResizeAdjustments(focusedWindowId: windowId,
+                                                                              focusedWindowIsFixedSize: isFixedSize,
+                                                                              action: action,
+                                                                              source: parameters.source,
+                                                                              oldFocusedFrame: currentNormalizedRect,
+                                                                              newFocusedFrame: calcResult.rect,
+                                                                              screenFrame: visibleFrameOfDestinationScreen,
+                                                                              lastRectangleAction: lastRectangleAction)
         let resultParameters = ResultParameters(windowId: windowId,
                                                 action: action,
                                                 windowElement: frontmostWindowElement,
@@ -141,19 +149,19 @@ class WindowManager {
                                                 source: parameters.source,
                                                 isFixedSize: isFixedSize)
         
-        var resultingRect = apply(result: resultParameters)
+        var resultingRect = apply(result: resultParameters, cooperativeCornerAdjustments: cooperativeCornerAdjustments)
         
         let isMovedAcrossDisplays = usableScreens.currentScreen != calcResult.screen
         if isMovedAcrossDisplays {
             if calcResult.rect.height != resultingRect.height {
                 Logger.log("Window size wasn't applied perfectly across displays. Trying again.")
-                resultingRect = apply(result: resultParameters)
+                resultingRect = apply(result: resultParameters, cooperativeCornerAdjustments: cooperativeCornerAdjustments)
                 
                 if calcResult.rect.height != resultingRect.height {
                     Logger.log("Final attempt to adjust across displays.")
                     DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(25)) { [weak self] in
                         guard let self else { return }
-                        let finalRect = self.apply(result: resultParameters)
+                        let finalRect = self.apply(result: resultParameters, cooperativeCornerAdjustments: cooperativeCornerAdjustments)
                         self.windowMovedAcrossDisplays(windowElement: frontmostWindowElement, resultingRect: finalRect)
                         self.postProcess(result: resultParameters, resultingRect: finalRect)
                     }
@@ -169,17 +177,99 @@ class WindowManager {
     /// Move/resize a window based on the calculation results.
     /// - Returns: The rect of the window after applying the window action
     func apply(result: ResultParameters) -> CGRect {
+        apply(result: result, cooperativeCornerAdjustments: [])
+    }
+
+    private func apply(result: ResultParameters, cooperativeCornerAdjustments: [CooperativeCornerWindowAdjustment]) -> CGRect {
         let windowMoverChain = result.isFixedSize
         ? fixedSizeWindowMoverChain
         : standardWindowMoverChain
         
         let newRect = result.calcResult.rect
+        let focusedWindowIsExpanding = CooperativeCornerResize.focusedWindowIsExpanding(oldFrame: result.windowElement.frame.screenFlipped,
+                                                                                        newFrame: newRect,
+                                                                                        axis: Defaults.cornerCycleExpansionAxis.value)
+
+        if focusedWindowIsExpanding {
+            apply(cooperativeCornerAdjustments)
+        }
         
         for windowMover in windowMoverChain {
             windowMover.moveWindow(toRect: newRect, resultParameters: result)
         }
-        
-        return result.windowElement.frame
+
+        let resultingRect = result.windowElement.frame
+
+        if !focusedWindowIsExpanding {
+            apply(cooperativeCornerAdjustments)
+        }
+
+        return resultingRect
+    }
+
+    private func cooperativeCornerResizeAdjustments(focusedWindowId: CGWindowID,
+                                                    focusedWindowIsFixedSize: Bool,
+                                                    action: WindowAction,
+                                                    source: ExecutionSource,
+                                                    oldFocusedFrame: CGRect,
+                                                    newFocusedFrame: CGRect,
+                                                    screenFrame: CGRect,
+                                                    lastRectangleAction: RectangleAction?) -> [CooperativeCornerWindowAdjustment] {
+        guard Defaults.cooperativeCornerResize.enabled,
+              source == .keyboardShortcut,
+              !focusedWindowIsFixedSize,
+              action.isBasicCorner,
+              lastRectangleAction?.action == action
+        else {
+            return []
+        }
+
+        let tolerance = max(CGFloat(Defaults.gapSize.value) + 4, 4)
+        let screenFrameAX = screenFrame.screenFlipped
+        let elementsById = AccessibilityElement.getAllWindowElements().reduce(into: [CGWindowID: AccessibilityElement]()) { elements, element in
+            guard let candidateId = element.getWindowId(),
+                  candidateId != focusedWindowId,
+                  element.isWindow == true,
+                  element.isMinimized != true,
+                  element.isFullScreen != true,
+                  element.isHidden != true,
+                  element.isSheet != true,
+                  element.isResizable()
+            else {
+                return
+            }
+
+            let frame = element.frame
+            guard !frame.isNull, screenFrameAX.intersects(frame) else {
+                return
+            }
+
+            elements[candidateId] = element
+        }
+
+        let candidates = elementsById.map { id, element in
+            CooperativeCornerResize.Candidate(id: id, frame: element.frame.screenFlipped)
+        }
+        let minimumSize = CGSize(width: max(1, CGFloat(Defaults.minimumWindowWidth.value)),
+                                 height: max(1, CGFloat(Defaults.minimumWindowHeight.value)))
+        let adjustments = CooperativeCornerResize.adjustments(oldFocusedFrame: oldFocusedFrame,
+                                                              newFocusedFrame: newFocusedFrame,
+                                                              screenFrame: screenFrame,
+                                                              candidates: candidates,
+                                                              axis: Defaults.cornerCycleExpansionAxis.value,
+                                                              tolerance: tolerance,
+                                                              minimumSize: minimumSize)
+
+        return adjustments.compactMap { adjustment in
+            guard let element = elementsById[adjustment.id] else { return nil }
+            return CooperativeCornerWindowAdjustment(element: element, newFrame: adjustment.newFrame)
+        }
+    }
+
+    private func apply(_ adjustments: [CooperativeCornerWindowAdjustment]) {
+        adjustments.forEach { adjustment in
+            adjustment.element.setFrame(adjustment.newFrame.screenFlipped)
+        }
     }
     
     func windowMovedAcrossDisplays(windowElement: AccessibilityElement, resultingRect: CGRect) {
@@ -313,4 +403,20 @@ struct ExecutionParameters {
 
 enum ExecutionSource {
     case keyboardShortcut, dragToSnap, menuItem, url, titleBar
+}
+
+private struct CooperativeCornerWindowAdjustment {
+    let element: AccessibilityElement
+    let newFrame: CGRect
+}
+
+private extension WindowAction {
+    var isBasicCorner: Bool {
+        switch self {
+        case .topLeft, .topRight, .bottomLeft, .bottomRight:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Rectangle/WindowMover/StandardWindowMover.swift
+++ b/Rectangle/WindowMover/StandardWindowMover.swift
@@ -11,7 +11,7 @@ class StandardWindowMover: WindowMover {
     }
     
     private func shouldAdjustSizeFirst(_ action: WindowAction) -> Bool {
-        switch (action, Defaults.repeatedCommandCycleAxis.value) {
+        switch (action, Defaults.cornerCycleExpansionAxis.value) {
         case (.topRight, .horizontal),
              (.bottomRight, .horizontal),
              (.bottomLeft, .vertical),

--- a/Rectangle/WindowMover/StandardWindowMover.swift
+++ b/Rectangle/WindowMover/StandardWindowMover.swift
@@ -6,6 +6,19 @@ class StandardWindowMover: WindowMover {
     func moveWindow(toRect rect: CGRect, resultParameters: ResultParameters) {
         let windowElement = resultParameters.windowElement
         if windowElement.frame.isNull { return }
-        windowElement.setFrame(rect.screenFlipped)
+        windowElement.setFrame(rect.screenFlipped,
+                               adjustSizeFirst: shouldAdjustSizeFirst(resultParameters.action))
+    }
+    
+    private func shouldAdjustSizeFirst(_ action: WindowAction) -> Bool {
+        switch (action, Defaults.repeatedCommandCycleAxis.value) {
+        case (.topRight, .horizontal),
+             (.bottomRight, .horizontal),
+             (.bottomLeft, .vertical),
+             (.bottomRight, .vertical):
+            return false
+        default:
+            return true
+        }
     }
 }

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -37480,7 +37480,7 @@
         }
       }
     },
-    "Resize adjacent windows when cycling corner shortcuts" : {
+    "Resize adjacent windows when cycling side or corner shortcuts" : {
 
     },
     "rgM-f4-ycn.title" : {

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -28480,10 +28480,13 @@
         }
       }
     },
-    "Lock horizontal axis" : {
+    "Cyclic corner shortcuts expand:" : {
 
     },
-    "Lock vertical axis" : {
+    "horizontally" : {
+
+    },
+    "vertically" : {
 
     },
     "LqQ-pM-jRN.title" : {

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -1394,7 +1394,7 @@
       }
     },
     "01Z-t3-cBm.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"If you repeat move or half actions, the window will move to the next display instead of 1/2, 2/3, and 1/3 size.\"; ObjectID = \"01Z-t3-cBm\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"If you repeat move or side actions, the window will move to the next display instead of 1/2, 2/3, and 1/3 size.\"; ObjectID = \"01Z-t3-cBm\";",
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -1424,7 +1424,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "If you repeat move or half actions, the window will move to the next display instead of 1/2, 2/3, and 1/3 size."
+            "value" : "If you repeat move or side actions, the window will move to the next display instead of 1/2, 2/3, and 1/3 size."
           }
         },
         "es" : {
@@ -2438,7 +2438,7 @@
       }
     },
     "3GE-la-fAZ.title" : {
-      "comment" : "Class = \"NSMenuItem\"; title = \"move to adjacent on left/right, or cycle size on half\"; ObjectID = \"3GE-la-fAZ\";",
+      "comment" : "Class = \"NSMenuItem\"; title = \"move to adjacent on left/right, or cycle size on side\"; ObjectID = \"3GE-la-fAZ\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -2474,7 +2474,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "move to adjacent on left/right, or cycle size on half"
+            "value" : "move to adjacent on left/right, or cycle size on side"
           }
         },
         "es" : {
@@ -2534,7 +2534,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "move to adjacent on left/right, or cycle size on half"
+            "value" : "move to adjacent on left/right, or cycle size on side"
           }
         },
         "nn" : {
@@ -2546,19 +2546,19 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "move to adjacent on left/right, or cycle size on half"
+            "value" : "move to adjacent on left/right, or cycle size on side"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "move to adjacent on left/right, or cycle size on half"
+            "value" : "move to adjacent on left/right, or cycle size on side"
           }
         },
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "move to adjacent on left/right, or cycle size on half"
+            "value" : "move to adjacent on left/right, or cycle size on side"
           }
         },
         "ro" : {
@@ -10654,7 +10654,7 @@
       }
     },
     "bRX-dV-iAR.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Center Half\"; ObjectID = \"bRX-dV-iAR\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Center Section\"; ObjectID = \"bRX-dV-iAR\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -10690,13 +10690,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Center Half"
+            "value" : "Center Section"
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Centre Half"
+            "value" : "Centre Section"
           }
         },
         "es" : {
@@ -13021,7 +13021,7 @@
       }
     },
     "d7y-s8-7GE.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Top Half\"; ObjectID = \"d7y-s8-7GE\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Top Side\"; ObjectID = \"d7y-s8-7GE\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -13057,7 +13057,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Top Half"
+            "value" : "Top Side"
           }
         },
         "es" : {
@@ -15983,7 +15983,7 @@
       }
     },
     "ec4-FB-fMa.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Bottom Half\"; ObjectID = \"ec4-FB-fMa\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Bottom Side\"; ObjectID = \"ec4-FB-fMa\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -16019,7 +16019,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Bottom Half"
+            "value" : "Bottom Side"
           }
         },
         "es" : {
@@ -16776,7 +16776,7 @@
       }
     },
     "F8S-GI-LiB.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Right Half\"; ObjectID = \"F8S-GI-LiB\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Right Side\"; ObjectID = \"F8S-GI-LiB\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -16812,7 +16812,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Right Half"
+            "value" : "Right Side"
           }
         },
         "es" : {
@@ -19682,7 +19682,7 @@
       }
     },
     "gHH-BV-5kP.title" : {
-      "comment" : "Class = \"NSMenuItem\"; title = \"cycle sizes on half actions\"; ObjectID = \"gHH-BV-5kP\";",
+      "comment" : "Class = \"NSMenuItem\"; title = \"cycle sizes on side actions\"; ObjectID = \"gHH-BV-5kP\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -19718,7 +19718,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "cycle sizes on half actions"
+            "value" : "cycle sizes on side actions"
           }
         },
         "es" : {
@@ -21201,7 +21201,7 @@
         }
       }
     },
-    "Half Split Ratios" : {
+    "Side Split Ratio" : {
       "localizations" : {
         "ko" : {
           "stringUnit" : {
@@ -21217,7 +21217,7 @@
         }
       }
     },
-    "Halves" : {
+    "Sides" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -21306,7 +21306,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Halves"
+            "value" : "Sides"
           }
         },
         "nn" : {
@@ -27938,7 +27938,7 @@
         }
       }
     },
-    "Left half, top/bottom half near corners" : {
+    "Left side, top/bottom side near corners" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -27949,13 +27949,13 @@
         "ca" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "ca-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "cs" : {
@@ -27991,7 +27991,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "it" : {
@@ -28027,7 +28027,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "nn" : {
@@ -28039,7 +28039,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "pt-BR" : {
@@ -28051,13 +28051,13 @@
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "ro" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "ru" : {
@@ -28075,7 +28075,7 @@
         "sv-SE" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left half, top/bottom half near corners"
+            "value" : "Left side, top/bottom side near corners"
           }
         },
         "tr" : {
@@ -28116,7 +28116,7 @@
         }
       }
     },
-    "Left or right half" : {
+    "Left or right side" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -28127,13 +28127,13 @@
         "ca" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "ca-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "cs" : {
@@ -28169,7 +28169,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "it" : {
@@ -28205,7 +28205,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "nn" : {
@@ -28217,7 +28217,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "pt-BR" : {
@@ -28229,13 +28229,13 @@
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "ro" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "ru" : {
@@ -28253,7 +28253,7 @@
         "sv-SE" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Left or right half"
+            "value" : "Left or right side"
           }
         },
         "tr" : {
@@ -36144,13 +36144,13 @@
       }
     },
     "qCy-Kx-9mR.title" : {
-      "comment" : "Class = \"NSMenuItem\"; title = \"cycle positions on quadrants, cycle sizes on half\"; ObjectID = \"qCy-Kx-9mR\";",
+      "comment" : "Class = \"NSMenuItem\"; title = \"cycle positions on quadrants, cycle sizes on side\"; ObjectID = \"qCy-Kx-9mR\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "cycle positions on quadrants, cycle sizes on half"
+            "value" : "cycle positions on quadrants, cycle sizes on side"
           }
         },
         "ko" : {
@@ -37995,7 +37995,7 @@
         }
       }
     },
-    "Right half, top/bottom half near corners" : {
+    "Right side, top/bottom side near corners" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -38006,13 +38006,13 @@
         "ca" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "ca-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "cs" : {
@@ -38048,7 +38048,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "it" : {
@@ -38084,7 +38084,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "nn" : {
@@ -38096,7 +38096,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "pt-BR" : {
@@ -38108,13 +38108,13 @@
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "ro" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "ru" : {
@@ -38132,7 +38132,7 @@
         "sv-SE" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Right half, top/bottom half near corners"
+            "value" : "Right side, top/bottom side near corners"
           }
         },
         "tr" : {
@@ -40852,7 +40852,7 @@
         }
       }
     },
-    "Thirds, top/bottom half near corners" : {
+    "Thirds, top/bottom side near corners" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -40863,13 +40863,13 @@
         "ca" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "ca-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "cs" : {
@@ -40905,7 +40905,7 @@
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "it" : {
@@ -40941,7 +40941,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "nn" : {
@@ -40953,25 +40953,25 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "pt-PT" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "ro" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "ru" : {
@@ -40989,7 +40989,7 @@
         "sv-SE" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thirds, top/bottom half near corners"
+            "value" : "Thirds, top/bottom side near corners"
           }
         },
         "tr" : {
@@ -41772,7 +41772,7 @@
         }
       }
     },
-    "Top/bottom halves" : {
+    "Top/bottom sides" : {
       "extractionState" : "manual",
       "localizations" : {
         "ko" : {
@@ -47243,7 +47243,7 @@
       }
     },
     "Xc8-Sm-pig.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"Left Half\"; ObjectID = \"Xc8-Sm-pig\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"Left Side\"; ObjectID = \"Xc8-Sm-pig\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "ar" : {
@@ -47279,7 +47279,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Left Half"
+            "value" : "Left Side"
           }
         },
         "es" : {

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -28480,6 +28480,12 @@
         }
       }
     },
+    "Lock horizontal axis" : {
+
+    },
+    "Lock vertical axis" : {
+
+    },
     "LqQ-pM-jRN.title" : {
       "comment" : "Class = \"NSTextFieldCell\"; title = \"Bottom Left Sixth\"; ObjectID = \"LqQ-pM-jRN\";",
       "extractionState" : "extracted_with_value",

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -13020,6 +13020,9 @@
         }
       }
     },
+    "Cyclic corner shortcuts expand:" : {
+
+    },
     "d7y-s8-7GE.title" : {
       "comment" : "Class = \"NSTextFieldCell\"; title = \"Top Side\"; ObjectID = \"d7y-s8-7GE\";",
       "extractionState" : "extracted_with_value",
@@ -21201,194 +21204,6 @@
         }
       }
     },
-    "Side Split Ratio" : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "절반 분할 비율"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tỷ lệ chia một nửa"
-          }
-        }
-      }
-    },
-    "Sides" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Moitiés"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Meitats"
-          }
-        },
-        "ca-ES" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Meitats"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poloviny"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hälften"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mitades"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mitades"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Moitiés"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bagian"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metà"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "半分"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "절반"
-          }
-        },
-        "lt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pusės"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Halvdeler"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sides"
-          }
-        },
-        "nn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Halvdelar"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Połowy"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metades"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metades"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Половинки"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polovice"
-          }
-        },
-        "sv-SE" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hälfter"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yarımlar"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Половини"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Một nửa"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "半屏"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一半螢幕"
-          }
-        },
-        "zh-Hant-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一半螢幕"
-          }
-        }
-      }
-    },
     "heT-W6-Fyf.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Double-click window title bar to maximize/restore\"; ObjectID = \"heT-W6-Fyf\";",
       "extractionState" : "extracted_with_value",
@@ -22430,6 +22245,9 @@
           }
         }
       }
+    },
+    "horizontally" : {
+
     },
     "hQb-2v-fYv.title" : {
       "comment" : "Class = \"NSMenuItem\"; title = \"Smart Quotes\"; ObjectID = \"hQb-2v-fYv\";",
@@ -27938,184 +27756,6 @@
         }
       }
     },
-    "Left side, top/bottom side near corners" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Moitié gauche, moitié du haut/bas près des coins"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Left side, top/bottom side near corners"
-          }
-        },
-        "ca-ES" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Left side, top/bottom side near corners"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Levá polovina, horní/spodní polovina blízko rohů"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Linke Hälfte, Obere/Untere Hälfte in der Nähe der Ecken"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mitad izquierda, mitad superior/inferior cerca de las esquinas"
-          }
-        },
-        "es-419" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mitad izquierda, mitad superior/inferior cerca de las esquinas"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Moitié gauche, moitié du haut/bas près des coins"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Left side, top/bottom side near corners"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metà sinistra, metà superiore/inferiore vicino gli angoli"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "左半分、画面端付近の上半分・下半分"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "왼쪽 반, 위/아래 반에 근접한 모서리"
-          }
-        },
-        "lt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kairė pusė, viršutinė/apačioje pusė šalia kampų"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Venstre halvdel, øverste/nederste halvdel nære hjørne"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Left side, top/bottom side near corners"
-          }
-        },
-        "nn" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Venstre halvdel, øvste/nedste halvdel nære hjørne"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Left side, top/bottom side near corners"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metade esquerda, metade de cima/baixo próximo das bordas"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Left side, top/bottom side near corners"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Left side, top/bottom side near corners"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Левая половина, верхняя/нижняя половина возле углов"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ľavá polovica, horná/spodná polovica blízko rohov"
-          }
-        },
-        "sv-SE" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Left side, top/bottom side near corners"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sol yarım (köşelere yaklaşıldığında ise üst/alt yarım)"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ліва половина, верхня/нижня половина близько кутів"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nửa trái, nửa trên/dưới nếu ngay góc"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "左半屏，靠近角落则上／下半屏"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "左半，靠近角落則上半／下半"
-          }
-        },
-        "zh-Hant-HK" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "左半，靠近角落則上半／下半"
-          }
-        }
-      }
-    },
     "Left or right side" : {
       "localizations" : {
         "ar" : {
@@ -28290,6 +27930,184 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "左半或右半"
+          }
+        }
+      }
+    },
+    "Left side, top/bottom side near corners" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moitié gauche, moitié du haut/bas près des coins"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left side, top/bottom side near corners"
+          }
+        },
+        "ca-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left side, top/bottom side near corners"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Levá polovina, horní/spodní polovina blízko rohů"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linke Hälfte, Obere/Untere Hälfte in der Nähe der Ecken"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitad izquierda, mitad superior/inferior cerca de las esquinas"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitad izquierda, mitad superior/inferior cerca de las esquinas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moitié gauche, moitié du haut/bas près des coins"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left side, top/bottom side near corners"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metà sinistra, metà superiore/inferiore vicino gli angoli"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左半分、画面端付近の上半分・下半分"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "왼쪽 반, 위/아래 반에 근접한 모서리"
+          }
+        },
+        "lt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kairė pusė, viršutinė/apačioje pusė šalia kampų"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Venstre halvdel, øverste/nederste halvdel nære hjørne"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left side, top/bottom side near corners"
+          }
+        },
+        "nn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Venstre halvdel, øvste/nedste halvdel nære hjørne"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left side, top/bottom side near corners"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metade esquerda, metade de cima/baixo próximo das bordas"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left side, top/bottom side near corners"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left side, top/bottom side near corners"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Левая половина, верхняя/нижняя половина возле углов"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ľavá polovica, horná/spodná polovica blízko rohov"
+          }
+        },
+        "sv-SE" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left side, top/bottom side near corners"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sol yarım (köşelere yaklaşıldığında ise üst/alt yarım)"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ліва половина, верхня/нижня половина близько кутів"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nửa trái, nửa trên/dưới nếu ngay góc"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左半屏，靠近角落则上／下半屏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左半，靠近角落則上半／下半"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左半，靠近角落則上半／下半"
           }
         }
       }
@@ -28479,15 +28297,6 @@
           }
         }
       }
-    },
-    "Cyclic corner shortcuts expand:" : {
-
-    },
-    "horizontally" : {
-
-    },
-    "vertically" : {
-
     },
     "LqQ-pM-jRN.title" : {
       "comment" : "Class = \"NSTextFieldCell\"; title = \"Bottom Left Sixth\"; ObjectID = \"LqQ-pM-jRN\";",
@@ -37671,6 +37480,9 @@
         }
       }
     },
+    "Resize adjacent windows when cycling corner shortcuts" : {
+
+    },
     "rgM-f4-ycn.title" : {
       "comment" : "Class = \"NSMenuItem\"; title = \"Smart Dashes\"; ObjectID = \"rgM-f4-ycn\";",
       "extractionState" : "manual",
@@ -39067,6 +38879,194 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiển thị kích thước bổ sung trong menu"
+          }
+        }
+      }
+    },
+    "Side Split Ratio" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "절반 분할 비율"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tỷ lệ chia một nửa"
+          }
+        }
+      }
+    },
+    "Sides" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moitiés"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meitats"
+          }
+        },
+        "ca-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meitats"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poloviny"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hälften"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitades"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mitades"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moitiés"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagian"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metà"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "半分"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "절반"
+          }
+        },
+        "lt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pusės"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Halvdeler"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sides"
+          }
+        },
+        "nn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Halvdelar"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Połowy"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metades"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metades"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Половинки"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Polovice"
+          }
+        },
+        "sv-SE" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hälfter"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yarımlar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Половини"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Một nửa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "半屏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一半螢幕"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一半螢幕"
           }
         }
       }
@@ -44305,6 +44305,9 @@
           }
         }
       }
+    },
+    "vertically" : {
+
     },
     "Vfd-fe-hCe.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"ⓘ\"; ObjectID = \"Vfd-fe-hCe\";",

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -303,6 +303,53 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         assertRect(WindowCalculationFactory.bottomHalfCalculation.calculateRect(repeatedParams(for: .bottomHalf)).rect,
                    equals: CGRect(x: 10, y: 20, width: 1200, height: 600))
     }
+
+    func testRepeatedHalfActionStartsAtFirstSelectedCycleSizeWhenOneHalfIsDeselected() {
+        setSplitRatio(50)
+        Defaults.cycleSizesIsChanged.enabled = true
+        Defaults.selectedCycleSizes.value = [.oneThird, .twoThirds]
+
+        let firstRepeatedRect = WindowCalculationFactory.bottomHalfCalculation.calculateRepeatedRect(repeatedParams(for: .bottomHalf)).rect
+        let secondRepeatedRect = WindowCalculationFactory.bottomHalfCalculation.calculateRepeatedRect(repeatedParams(for: .bottomHalf, currentRect: firstRepeatedRect, count: 2)).rect
+
+        assertRect(firstRepeatedRect, equals: CGRect(x: 10, y: 20, width: 1200, height: 600))
+        assertRect(secondRepeatedRect, equals: CGRect(x: 10, y: 20, width: 1200, height: 300))
+    }
+
+    func testRepeatedBottomCornerStartsAtFirstSelectedCycleSizeWhenOneHalfIsDeselected() {
+        setSplitRatio(50)
+        Defaults.cornerCycleExpansionAxis.value = .vertical
+        Defaults.cycleSizesIsChanged.enabled = true
+        Defaults.selectedCycleSizes.value = [.oneThird, .twoThirds]
+
+        let firstRect = WindowCalculationFactory.lowerLeftCalculation.calculateRect(params(for: .bottomLeft)).rect
+        let firstRepeatedRect = WindowCalculationFactory.lowerLeftCalculation.calculateRect(repeatedParams(for: .bottomLeft, currentRect: firstRect)).rect
+        let secondRepeatedRect = WindowCalculationFactory.lowerLeftCalculation.calculateRect(repeatedParams(for: .bottomLeft, currentRect: firstRepeatedRect, count: 2)).rect
+
+        assertRect(firstRect, equals: CGRect(x: 10, y: 20, width: 600, height: 450))
+        assertRect(firstRepeatedRect, equals: CGRect(x: 10, y: 20, width: 600, height: 600))
+        assertRect(secondRepeatedRect, equals: CGRect(x: 10, y: 20, width: 600, height: 300))
+    }
+
+    func testRepeatedHalfActionWithNoCycleSizesSelectedUsesFirstRect() {
+        setSplitRatio(60)
+        Defaults.cycleSizesIsChanged.enabled = true
+        Defaults.selectedCycleSizes.value = []
+
+        assertRect(WindowCalculationFactory.leftHalfCalculation.calculateRepeatedRect(repeatedParams(for: .leftHalf)).rect,
+                   equals: CGRect(x: 10, y: 20, width: 720, height: 900))
+    }
+
+    func testRepeatedCornerActionWithNoCycleSizesSelectedUsesFirstRect() {
+        setSplitRatio(60)
+        Defaults.cycleSizesIsChanged.enabled = true
+        Defaults.selectedCycleSizes.value = []
+
+        let firstRect = WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect
+        let repeatedRect = WindowCalculationFactory.upperLeftCalculation.calculateRect(repeatedParams(for: .topLeft, currentRect: firstRect)).rect
+
+        assertRect(repeatedRect, equals: firstRect)
+    }
     
     private func setSplitRatio(_ percent: Float) {
         Defaults.horizontalSplitRatio.value = percent

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -153,7 +153,7 @@ class HalfSplitCornerCalculationTests: XCTestCase {
     private var savedHorizontalSplitRatio: Float = 50
     private var savedVerticalSplitRatio: Float = 50
     private var savedSubsequentExecutionMode: SubsequentExecutionMode = .resize
-    private var savedRepeatedCommandCycleAxis: RepeatedCommandCycleAxis = .horizontal
+    private var savedCornerCycleExpansionAxis: CornerCycleExpansionAxis = .horizontal
     private var savedCycleSizesIsChanged = false
     private var savedSelectedCycleSizes = Set<CycleSize>()
     private let visibleFrame = CGRect(x: 10, y: 20, width: 1200, height: 900)
@@ -163,7 +163,7 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         savedHorizontalSplitRatio = Defaults.horizontalSplitRatio.value
         savedVerticalSplitRatio = Defaults.verticalSplitRatio.value
         savedSubsequentExecutionMode = Defaults.subsequentExecutionMode.value
-        savedRepeatedCommandCycleAxis = Defaults.repeatedCommandCycleAxis.value
+        savedCornerCycleExpansionAxis = Defaults.cornerCycleExpansionAxis.value
         savedCycleSizesIsChanged = Defaults.cycleSizesIsChanged.enabled
         savedSelectedCycleSizes = Defaults.selectedCycleSizes.value
         Defaults.subsequentExecutionMode.value = .resize
@@ -174,7 +174,7 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         Defaults.horizontalSplitRatio.value = savedHorizontalSplitRatio
         Defaults.verticalSplitRatio.value = savedVerticalSplitRatio
         Defaults.subsequentExecutionMode.value = savedSubsequentExecutionMode
-        Defaults.repeatedCommandCycleAxis.value = savedRepeatedCommandCycleAxis
+        Defaults.cornerCycleExpansionAxis.value = savedCornerCycleExpansionAxis
         Defaults.cycleSizesIsChanged.enabled = savedCycleSizesIsChanged
         Defaults.selectedCycleSizes.value = savedSelectedCycleSizes
         super.tearDown()
@@ -237,9 +237,9 @@ class HalfSplitCornerCalculationTests: XCTestCase {
                    equals: CGRect(x: 10, y: 20, width: 1200, height: 360))
     }
 
-    func testRepeatedCornersWithHorizontalAxisLockCycleWidthOnly() {
+    func testRepeatedCornersWithHorizontalExpansionCycleWidthOnly() {
         setSplitRatio(60)
-        Defaults.repeatedCommandCycleAxis.value = .horizontal
+        Defaults.cornerCycleExpansionAxis.value = .horizontal
 
         assertRepeatedCornerRects(
             topLeft: CGRect(x: 10, y: 380, width: 800, height: 540),
@@ -251,7 +251,7 @@ class HalfSplitCornerCalculationTests: XCTestCase {
 
     func testSecondRepeatedCornerShortcutBeginsCyclingImmediately() {
         setSplitRatio(CycleSize.twoThirds.percentValue)
-        Defaults.repeatedCommandCycleAxis.value = .horizontal
+        Defaults.cornerCycleExpansionAxis.value = .horizontal
 
         let firstFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect
         let secondFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(repeatedParams(for: .topLeft, currentRect: firstFrame, count: 1)).rect
@@ -264,7 +264,7 @@ class HalfSplitCornerCalculationTests: XCTestCase {
 
     func testRepeatedCornerCyclingDoesNotReturnNoOpFrameWhenBaseMatchesCycleSize() {
         setSplitRatio(CycleSize.twoThirds.percentValue)
-        Defaults.repeatedCommandCycleAxis.value = .vertical
+        Defaults.cornerCycleExpansionAxis.value = .vertical
 
         let firstFrame = WindowCalculationFactory.upperRightCalculation.calculateRect(params(for: .topRight)).rect
         let secondFrame = WindowCalculationFactory.upperRightCalculation.calculateRect(repeatedParams(for: .topRight, currentRect: firstFrame, count: 1)).rect
@@ -275,9 +275,9 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         XCTAssertEqual(firstFrame.width, secondFrame.width, accuracy: 0.001)
     }
 
-    func testRepeatedCornersWithVerticalAxisLockCycleHeightOnly() {
+    func testRepeatedCornersWithVerticalExpansionCycleHeightOnly() {
         setSplitRatio(60)
-        Defaults.repeatedCommandCycleAxis.value = .vertical
+        Defaults.cornerCycleExpansionAxis.value = .vertical
 
         assertRepeatedCornerRects(
             topLeft: CGRect(x: 10, y: 320, width: 720, height: 600),
@@ -289,14 +289,14 @@ class HalfSplitCornerCalculationTests: XCTestCase {
 
     func testRepeatedHalfActionsStillCycleOnTheirNaturalAxis() {
         setSplitRatio(60)
-        Defaults.repeatedCommandCycleAxis.value = .vertical
+        Defaults.cornerCycleExpansionAxis.value = .vertical
 
         assertRect(WindowCalculationFactory.leftHalfCalculation.calculateRepeatedRect(repeatedParams(for: .leftHalf)).rect,
                    equals: CGRect(x: 10, y: 20, width: 800, height: 900))
         assertRect(WindowCalculationFactory.rightHalfCalculation.calculateRepeatedRect(repeatedParams(for: .rightHalf)).rect,
                    equals: CGRect(x: 410, y: 20, width: 800, height: 900))
 
-        Defaults.repeatedCommandCycleAxis.value = .horizontal
+        Defaults.cornerCycleExpansionAxis.value = .horizontal
 
         assertRect(WindowCalculationFactory.topHalfCalculation.calculateRect(repeatedParams(for: .topHalf)).rect,
                    equals: CGRect(x: 10, y: 320, width: 1200, height: 600))

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -127,6 +127,156 @@ class DefaultsExportTests: XCTestCase {
         XCTAssertTrue(keys.contains("cyclingOverlapOffset"), "cyclingOverlapOffset missing from Defaults.array")
         XCTAssertTrue(keys.contains("cyclingOverlapOffsetSize"), "cyclingOverlapOffsetSize missing from Defaults.array")
         XCTAssertTrue(keys.contains("cyclingOverlapMaxCascade"), "cyclingOverlapMaxCascade missing from Defaults.array")
+        XCTAssertTrue(keys.contains("cooperativeCornerResize"), "cooperativeCornerResize missing from Defaults.array")
+    }
+}
+
+class CooperativeCornerResizeTests: XCTestCase {
+    private let screenFrame = CGRect(x: 0, y: 0, width: 1200, height: 900)
+    private let minimumSize = CGSize(width: 100, height: 100)
+    private let tolerance: CGFloat = 8
+
+    func testBottomLeftVerticalExpansionShrinksTopLeftNeighbor() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 800, height: 300)
+        let focusedNew = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let topLeft = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 0, y: 300, width: 800, height: 600))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [topLeft], axis: .vertical)
+
+        XCTAssertEqual(adjustments.count, 1)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 0, y: 600, width: 800, height: 300))
+        XCTAssertEqual(focusedNew.maxY, adjustments[0].newFrame.minY, accuracy: 0.001)
+    }
+
+    func testBottomLeftVerticalShrinkExpandsTopLeftNeighbor() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let focusedNew = CGRect(x: 0, y: 0, width: 800, height: 300)
+        let topLeft = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 0, y: 600, width: 800, height: 300))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [topLeft], axis: .vertical)
+
+        XCTAssertEqual(adjustments.count, 1)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 0, y: 300, width: 800, height: 600))
+        XCTAssertEqual(focusedNew.maxY, adjustments[0].newFrame.minY, accuracy: 0.001)
+    }
+
+    func testTopLeftHorizontalExpansionShrinksTopRightNeighbor() {
+        let focusedOld = CGRect(x: 0, y: 300, width: 600, height: 600)
+        let focusedNew = CGRect(x: 0, y: 300, width: 800, height: 600)
+        let topRight = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 600, y: 300, width: 600, height: 600))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [topRight], axis: .horizontal)
+
+        XCTAssertEqual(adjustments.count, 1)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 800, y: 300, width: 400, height: 600))
+        XCTAssertEqual(focusedNew.maxX, adjustments[0].newFrame.minX, accuracy: 0.001)
+    }
+
+    func testTopLeftHorizontalShrinkExpandsTopRightNeighbor() {
+        let focusedOld = CGRect(x: 0, y: 300, width: 800, height: 600)
+        let focusedNew = CGRect(x: 0, y: 300, width: 600, height: 600)
+        let topRight = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 800, y: 300, width: 400, height: 600))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [topRight], axis: .horizontal)
+
+        XCTAssertEqual(adjustments.count, 1)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 600, y: 300, width: 600, height: 600))
+        XCTAssertEqual(focusedNew.maxX, adjustments[0].newFrame.minX, accuracy: 0.001)
+    }
+
+    func testNoAdjacentCandidateFound() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 800, height: 300)
+        let focusedNew = CGRect(x: 0, y: 0, width: 800, height: 600)
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [], axis: .vertical)
+
+        XCTAssertTrue(adjustments.isEmpty)
+    }
+
+    func testAmbiguousFloatingWindowIsIgnored() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 800, height: 300)
+        let focusedNew = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let floating = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 20, y: 302, width: 500, height: 240))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [floating], axis: .vertical)
+
+        XCTAssertTrue(adjustments.isEmpty)
+    }
+
+    func testToleranceMatchesNormalTiledNeighborsWithGaps() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 800, height: 300)
+        let focusedNew = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let topLeft = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 3, y: 305, width: 794, height: 592))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [topLeft], axis: .vertical)
+
+        XCTAssertEqual(adjustments.count, 1)
+        XCTAssertEqual(adjustments[0].newFrame.minY, focusedNew.maxY, accuracy: 0.001)
+    }
+
+    func testNonCycledAxisRemainsUnchanged() {
+        let focusedOld = CGRect(x: 0, y: 300, width: 600, height: 600)
+        let focusedNew = CGRect(x: 0, y: 300, width: 800, height: 600)
+        let topRight = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 600, y: 300, width: 600, height: 600))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [topRight], axis: .horizontal)
+
+        XCTAssertEqual(adjustments.count, 1)
+        XCTAssertEqual(adjustments[0].newFrame.minY, topRight.frame.minY, accuracy: 0.001)
+        XCTAssertEqual(adjustments[0].newFrame.height, topRight.frame.height, accuracy: 0.001)
+    }
+
+    func testDisabledExperimentalPreferenceLeavesCornerCalculationUnchanged() {
+        let savedValue = Defaults.cooperativeCornerResize.enabled
+        let savedAxis = Defaults.cornerCycleExpansionAxis.value
+        let savedHorizontalSplitRatio = Defaults.horizontalSplitRatio.value
+        let savedVerticalSplitRatio = Defaults.verticalSplitRatio.value
+        defer {
+            Defaults.cooperativeCornerResize.enabled = savedValue
+            Defaults.cornerCycleExpansionAxis.value = savedAxis
+            Defaults.horizontalSplitRatio.value = savedHorizontalSplitRatio
+            Defaults.verticalSplitRatio.value = savedVerticalSplitRatio
+        }
+
+        Defaults.cooperativeCornerResize.enabled = false
+        Defaults.cornerCycleExpansionAxis.value = .vertical
+        Defaults.horizontalSplitRatio.value = 50
+        Defaults.verticalSplitRatio.value = 50
+
+        let visibleFrame = CGRect(x: 10, y: 20, width: 1200, height: 900)
+        let firstRect = WindowCalculationFactory.lowerLeftCalculation.calculateRect(RectCalculationParameters(window: Window(id: 1, rect: visibleFrame),
+                                                                                                             visibleFrameOfScreen: visibleFrame,
+                                                                                                             action: .bottomLeft,
+                                                                                                             lastAction: nil)).rect
+        let repeatedRect = WindowCalculationFactory.lowerLeftCalculation.calculateRect(RectCalculationParameters(window: Window(id: 1, rect: firstRect),
+                                                                                                                visibleFrameOfScreen: visibleFrame,
+                                                                                                                action: .bottomLeft,
+                                                                                                                lastAction: RectangleAction(action: .bottomLeft,
+                                                                                                                                            subAction: nil,
+                                                                                                                                            rect: firstRect,
+                                                                                                                                            count: 1))).rect
+
+        assertRect(repeatedRect, equals: CGRect(x: 10, y: 20, width: 600, height: 600))
+    }
+
+    private func cooperativeAdjustments(focusedOld: CGRect,
+                                        focusedNew: CGRect,
+                                        candidates: [CooperativeCornerResize.Candidate],
+                                        axis: CornerCycleExpansionAxis) -> [CooperativeCornerResize.Adjustment] {
+        CooperativeCornerResize.adjustments(oldFocusedFrame: focusedOld,
+                                            newFocusedFrame: focusedNew,
+                                            screenFrame: screenFrame,
+                                            candidates: candidates,
+                                            axis: axis,
+                                            tolerance: tolerance,
+                                            minimumSize: minimumSize)
+    }
+
+    private func assertRect(_ rect: CGRect, equals expected: CGRect, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(rect.origin.x, expected.origin.x, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(rect.origin.y, expected.origin.y, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(rect.width, expected.width, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(rect.height, expected.height, accuracy: 0.001, file: file, line: line)
     }
 }
 

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -160,6 +160,23 @@ class CooperativeCornerResizeTests: XCTestCase {
         XCTAssertEqual(focusedNew.maxY, adjustments[0].newFrame.minY, accuracy: 0.001)
     }
 
+    func testMatchingBottomLeftWindowShrinksWithFocusedWindowBeforeNeighborExpands() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let focusedNew = CGRect(x: 0, y: 0, width: 800, height: 300)
+        let matchingBottomLeft = CooperativeCornerResize.Candidate(id: 2, frame: focusedOld)
+        let topLeft = CooperativeCornerResize.Candidate(id: 3, frame: CGRect(x: 0, y: 600, width: 800, height: 300))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [matchingBottomLeft, topLeft], axis: .vertical)
+
+        XCTAssertEqual(adjustments.count, 2)
+        XCTAssertEqual(adjustments[0].id, matchingBottomLeft.id)
+        XCTAssertEqual(adjustments[0].kind, .matchingFocusedFrame)
+        assertRect(adjustments[0].newFrame, equals: focusedNew)
+        XCTAssertEqual(adjustments[1].id, topLeft.id)
+        XCTAssertEqual(adjustments[1].kind, .adjacent)
+        assertRect(adjustments[1].newFrame, equals: CGRect(x: 0, y: 300, width: 800, height: 600))
+    }
+
     func testTopLeftHorizontalExpansionShrinksTopRightNeighbor() {
         let focusedOld = CGRect(x: 0, y: 300, width: 600, height: 600)
         let focusedNew = CGRect(x: 0, y: 300, width: 800, height: 600)
@@ -182,6 +199,95 @@ class CooperativeCornerResizeTests: XCTestCase {
         XCTAssertEqual(adjustments.count, 1)
         assertRect(adjustments[0].newFrame, equals: CGRect(x: 600, y: 300, width: 600, height: 600))
         XCTAssertEqual(focusedNew.maxX, adjustments[0].newFrame.minX, accuracy: 0.001)
+    }
+
+    func testLeftSideHorizontalExpansionShrinksRightSideNeighbor() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 600, height: 900)
+        let focusedNew = CGRect(x: 0, y: 0, width: 800, height: 900)
+        let rightSide = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 600, y: 0, width: 600, height: 900))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [rightSide], axis: .horizontal)
+
+        XCTAssertEqual(adjustments.count, 1)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 800, y: 0, width: 400, height: 900))
+        XCTAssertEqual(focusedNew.maxX, adjustments[0].newFrame.minX, accuracy: 0.001)
+    }
+
+    func testLeftSideHorizontalShrinkExpandsRightSideNeighbor() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 800, height: 900)
+        let focusedNew = CGRect(x: 0, y: 0, width: 600, height: 900)
+        let rightSide = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 800, y: 0, width: 400, height: 900))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [rightSide], axis: .horizontal)
+
+        XCTAssertEqual(adjustments.count, 1)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 600, y: 0, width: 600, height: 900))
+        XCTAssertEqual(focusedNew.maxX, adjustments[0].newFrame.minX, accuracy: 0.001)
+    }
+
+    func testMatchingLeftSideWindowShrinksWithFocusedWindowBeforeRightSideNeighborExpands() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 800, height: 900)
+        let focusedNew = CGRect(x: 0, y: 0, width: 600, height: 900)
+        let matchingLeftSide = CooperativeCornerResize.Candidate(id: 2, frame: focusedOld)
+        let rightSide = CooperativeCornerResize.Candidate(id: 3, frame: CGRect(x: 800, y: 0, width: 400, height: 900))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [matchingLeftSide, rightSide], axis: .horizontal)
+
+        XCTAssertEqual(adjustments.count, 2)
+        XCTAssertEqual(adjustments[0].id, matchingLeftSide.id)
+        XCTAssertEqual(adjustments[0].kind, .matchingFocusedFrame)
+        assertRect(adjustments[0].newFrame, equals: focusedNew)
+        XCTAssertEqual(adjustments[1].id, rightSide.id)
+        XCTAssertEqual(adjustments[1].kind, .adjacent)
+        assertRect(adjustments[1].newFrame, equals: CGRect(x: 600, y: 0, width: 600, height: 900))
+    }
+
+    func testRightSideHorizontalExpansionShrinksLeftSideNeighbor() {
+        let focusedOld = CGRect(x: 600, y: 0, width: 600, height: 900)
+        let focusedNew = CGRect(x: 400, y: 0, width: 800, height: 900)
+        let leftSide = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 0, y: 0, width: 600, height: 900))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [leftSide], axis: .horizontal)
+
+        XCTAssertEqual(adjustments.count, 1)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 0, y: 0, width: 400, height: 900))
+        XCTAssertEqual(adjustments[0].newFrame.maxX, focusedNew.minX, accuracy: 0.001)
+    }
+
+    func testTopSideVerticalExpansionShrinksBottomSideNeighbor() {
+        let focusedOld = CGRect(x: 0, y: 450, width: 1200, height: 450)
+        let focusedNew = CGRect(x: 0, y: 300, width: 1200, height: 600)
+        let bottomSide = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 0, y: 0, width: 1200, height: 450))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [bottomSide], axis: .vertical)
+
+        XCTAssertEqual(adjustments.count, 1)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 0, y: 0, width: 1200, height: 300))
+        XCTAssertEqual(adjustments[0].newFrame.maxY, focusedNew.minY, accuracy: 0.001)
+    }
+
+    func testTopSideVerticalShrinkExpandsBottomSideNeighbor() {
+        let focusedOld = CGRect(x: 0, y: 300, width: 1200, height: 600)
+        let focusedNew = CGRect(x: 0, y: 450, width: 1200, height: 450)
+        let bottomSide = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 0, y: 0, width: 1200, height: 300))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [bottomSide], axis: .vertical)
+
+        XCTAssertEqual(adjustments.count, 1)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 0, y: 0, width: 1200, height: 450))
+        XCTAssertEqual(adjustments[0].newFrame.maxY, focusedNew.minY, accuracy: 0.001)
+    }
+
+    func testBottomSideVerticalExpansionShrinksTopSideNeighbor() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 1200, height: 450)
+        let focusedNew = CGRect(x: 0, y: 0, width: 1200, height: 600)
+        let topSide = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 0, y: 450, width: 1200, height: 450))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [topSide], axis: .vertical)
+
+        XCTAssertEqual(adjustments.count, 1)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 0, y: 600, width: 1200, height: 300))
+        XCTAssertEqual(focusedNew.maxY, adjustments[0].newFrame.minY, accuracy: 0.001)
     }
 
     func testNoAdjacentCandidateFound() {
@@ -479,6 +585,26 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         assertRect(firstRect, equals: CGRect(x: 10, y: 20, width: 600, height: 450))
         assertRect(firstRepeatedRect, equals: CGRect(x: 10, y: 20, width: 600, height: 600))
         assertRect(secondRepeatedRect, equals: CGRect(x: 10, y: 20, width: 600, height: 300))
+    }
+
+    func testRepeatedSideShortcutAdvancesWhenCurrentFrameMatchesSplitRatioCycleSize() {
+        setSplitRatio(CycleSize.twoThirds.percentValue)
+
+        let leftFrame = WindowCalculationFactory.leftHalfCalculation.calculateRect(params(for: .leftHalf)).rect
+        let repeatedLeftFrame = WindowCalculationFactory.leftHalfCalculation.calculateRepeatedRect(repeatedParams(for: .leftHalf, currentRect: leftFrame)).rect
+
+        assertRect(leftFrame, equals: CGRect(x: 10, y: 20, width: 800, height: 900))
+        assertRect(repeatedLeftFrame, equals: CGRect(x: 10, y: 20, width: 400, height: 900))
+    }
+
+    func testRepeatedTopShortcutAdvancesWhenCurrentFrameMatchesSplitRatioCycleSize() {
+        setSplitRatio(CycleSize.twoThirds.percentValue)
+
+        let topFrame = WindowCalculationFactory.topHalfCalculation.calculateRect(params(for: .topHalf)).rect
+        let repeatedTopFrame = WindowCalculationFactory.topHalfCalculation.calculateRepeatedRect(repeatedParams(for: .topHalf, currentRect: topFrame)).rect
+
+        assertRect(topFrame, equals: CGRect(x: 10, y: 320, width: 1200, height: 600))
+        assertRect(repeatedTopFrame, equals: CGRect(x: 10, y: 620, width: 1200, height: 300))
     }
 
     func testRepeatedHalfActionWithNoCycleSizesSelectedUsesFirstRect() {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -702,6 +702,33 @@ class ShortcutCycleTests: XCTestCase {
         MASShortcut(keyCode: keyCode, modifierFlags: flags)
     }
 
+    func testSideShortcutActionsUseRenamedDefaultsKeys() {
+        XCTAssertEqual(WindowAction.leftHalf.name, "leftSide")
+        XCTAssertEqual(WindowAction.rightHalf.name, "rightSide")
+        XCTAssertEqual(WindowAction.centerHalf.name, "centerSection")
+        XCTAssertEqual(WindowAction.topHalf.name, "topSide")
+        XCTAssertEqual(WindowAction.bottomHalf.name, "bottomSide")
+    }
+
+    func testRenamedSideShortcutMigrationMovesLegacyDefaultsKeys() {
+        let suiteName = "ShortcutCycleTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let centerSectionShortcut = shortcut(1, [.option, .command])
+        let dictTransformer = ValueTransformer(forName: NSValueTransformerName(rawValue: MASDictionaryTransformerName))!
+        let shortcutDict = dictTransformer.reverseTransformedValue(centerSectionShortcut)
+        userDefaults.setValue(shortcutDict, forKey: "centerHalf")
+
+        MASShortcutMigration.migrateRenamedSideShortcutKeys(userDefaults: userDefaults)
+
+        XCTAssertNil(userDefaults.object(forKey: "centerHalf"))
+        XCTAssertNotNil(userDefaults.object(forKey: "centerSection"))
+        XCTAssertNotNil(ShortcutCycle.shortcut(for: .centerHalf, userDefaults: userDefaults))
+    }
+
     func testUniqueShortcutsProduceSingletonGroups() {
         let groups = ShortcutCycle.groups(
             actions: [.centerHalf, .centerThird],

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -130,6 +130,24 @@ class DefaultsExportTests: XCTestCase {
     }
 }
 
+class CycleSizeRatioPresetTests: XCTestCase {
+
+    func testPercentValuesMatchCycleSizeFractions() {
+        XCTAssertEqual(CycleSize.oneHalf.percentValue, 50, accuracy: 0.001)
+        XCTAssertEqual(CycleSize.twoThirds.percentValue, 66.666, accuracy: 0.001)
+        XCTAssertEqual(CycleSize.oneThird.percentValue, 33.333, accuracy: 0.001)
+    }
+
+    func testMatchingPercentValueUsesTolerance() {
+        XCTAssertEqual(CycleSize.matching(percentValue: 33.3334), .oneThird)
+        XCTAssertEqual(CycleSize.matching(percentValue: 66.6666), .twoThirds)
+    }
+
+    func testCustomPercentValueDoesNotMatchPreset() {
+        XCTAssertNil(CycleSize.matching(percentValue: 60))
+    }
+}
+
 class OverlapOffsetGuardsTests: XCTestCase {
 
     func testMaxCascadeClampedToMinOne() {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -213,6 +213,19 @@ class CooperativeCornerResizeTests: XCTestCase {
         XCTAssertEqual(focusedNew.maxX, adjustments[0].newFrame.minX, accuracy: 0.001)
     }
 
+    func testLeftSideHorizontalExpansionShrinksStackedRightCornerNeighbors() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 600, height: 900)
+        let focusedNew = CGRect(x: 0, y: 0, width: 800, height: 900)
+        let bottomRight = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 600, y: 0, width: 600, height: 450))
+        let topRight = CooperativeCornerResize.Candidate(id: 3, frame: CGRect(x: 600, y: 450, width: 600, height: 450))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [bottomRight, topRight], axis: .horizontal)
+
+        XCTAssertEqual(adjustments.count, 2)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 800, y: 0, width: 400, height: 450))
+        assertRect(adjustments[1].newFrame, equals: CGRect(x: 800, y: 450, width: 400, height: 450))
+    }
+
     func testLeftSideHorizontalShrinkExpandsRightSideNeighbor() {
         let focusedOld = CGRect(x: 0, y: 0, width: 800, height: 900)
         let focusedNew = CGRect(x: 0, y: 0, width: 600, height: 900)
@@ -264,6 +277,19 @@ class CooperativeCornerResizeTests: XCTestCase {
         XCTAssertEqual(adjustments.count, 1)
         assertRect(adjustments[0].newFrame, equals: CGRect(x: 0, y: 0, width: 1200, height: 300))
         XCTAssertEqual(adjustments[0].newFrame.maxY, focusedNew.minY, accuracy: 0.001)
+    }
+
+    func testTopSideVerticalExpansionShrinksStackedBottomCornerNeighbors() {
+        let focusedOld = CGRect(x: 0, y: 450, width: 1200, height: 450)
+        let focusedNew = CGRect(x: 0, y: 300, width: 1200, height: 600)
+        let bottomLeft = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 0, y: 0, width: 600, height: 450))
+        let bottomRight = CooperativeCornerResize.Candidate(id: 3, frame: CGRect(x: 600, y: 0, width: 600, height: 450))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld, focusedNew: focusedNew, candidates: [bottomLeft, bottomRight], axis: .vertical)
+
+        XCTAssertEqual(adjustments.count, 2)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 0, y: 0, width: 600, height: 300))
+        assertRect(adjustments[1].newFrame, equals: CGRect(x: 600, y: 0, width: 600, height: 300))
     }
 
     func testTopSideVerticalShrinkExpandsBottomSideNeighbor() {
@@ -605,6 +631,38 @@ class HalfSplitCornerCalculationTests: XCTestCase {
 
         assertRect(topFrame, equals: CGRect(x: 10, y: 320, width: 1200, height: 600))
         assertRect(repeatedTopFrame, equals: CGRect(x: 10, y: 620, width: 1200, height: 300))
+    }
+
+    func testHorizontalCornerShortcutCanCycleAfterCompatibleSideShortcut() {
+        setSplitRatio(50)
+        Defaults.cornerCycleExpansionAxis.value = .horizontal
+
+        let leftFrame = WindowCalculationFactory.leftHalfCalculation.calculateRect(params(for: .leftHalf)).rect
+        let topLeftFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(RectCalculationParameters(window: Window(id: 1, rect: leftFrame),
+                                                                                                                visibleFrameOfScreen: visibleFrame,
+                                                                                                                action: .topLeft,
+                                                                                                                lastAction: RectangleAction(action: .leftHalf,
+                                                                                                                                            subAction: nil,
+                                                                                                                                            rect: leftFrame,
+                                                                                                                                            count: 1))).rect
+
+        assertRect(topLeftFrame, equals: CGRect(x: 10, y: 470, width: 800, height: 450))
+    }
+
+    func testVerticalCornerShortcutCanCycleAfterCompatibleSideShortcut() {
+        setSplitRatio(50)
+        Defaults.cornerCycleExpansionAxis.value = .vertical
+
+        let topFrame = WindowCalculationFactory.topHalfCalculation.calculateRect(params(for: .topHalf)).rect
+        let topLeftFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(RectCalculationParameters(window: Window(id: 1, rect: topFrame),
+                                                                                                                visibleFrameOfScreen: visibleFrame,
+                                                                                                                action: .topLeft,
+                                                                                                                lastAction: RectangleAction(action: .topHalf,
+                                                                                                                                            subAction: nil,
+                                                                                                                                            rect: topFrame,
+                                                                                                                                            count: 1))).rect
+
+        assertRect(topLeftFrame, equals: CGRect(x: 10, y: 320, width: 600, height: 600))
     }
 
     func testRepeatedHalfActionWithNoCycleSizesSelectedUsesFirstRect() {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -153,6 +153,9 @@ class HalfSplitCornerCalculationTests: XCTestCase {
     private var savedHorizontalSplitRatio: Float = 50
     private var savedVerticalSplitRatio: Float = 50
     private var savedSubsequentExecutionMode: SubsequentExecutionMode = .resize
+    private var savedRepeatedCommandCycleAxis: RepeatedCommandCycleAxis = .horizontal
+    private var savedCycleSizesIsChanged = false
+    private var savedSelectedCycleSizes = Set<CycleSize>()
     private let visibleFrame = CGRect(x: 10, y: 20, width: 1200, height: 900)
     
     override func setUp() {
@@ -160,13 +163,20 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         savedHorizontalSplitRatio = Defaults.horizontalSplitRatio.value
         savedVerticalSplitRatio = Defaults.verticalSplitRatio.value
         savedSubsequentExecutionMode = Defaults.subsequentExecutionMode.value
+        savedRepeatedCommandCycleAxis = Defaults.repeatedCommandCycleAxis.value
+        savedCycleSizesIsChanged = Defaults.cycleSizesIsChanged.enabled
+        savedSelectedCycleSizes = Defaults.selectedCycleSizes.value
         Defaults.subsequentExecutionMode.value = .resize
+        Defaults.cycleSizesIsChanged.enabled = false
     }
     
     override func tearDown() {
         Defaults.horizontalSplitRatio.value = savedHorizontalSplitRatio
         Defaults.verticalSplitRatio.value = savedVerticalSplitRatio
         Defaults.subsequentExecutionMode.value = savedSubsequentExecutionMode
+        Defaults.repeatedCommandCycleAxis.value = savedRepeatedCommandCycleAxis
+        Defaults.cycleSizesIsChanged.enabled = savedCycleSizesIsChanged
+        Defaults.selectedCycleSizes.value = savedSelectedCycleSizes
         super.tearDown()
     }
     
@@ -226,6 +236,73 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         assertRect(WindowCalculationFactory.bottomHalfCalculation.calculateRect(params(for: .bottomHalf)).rect,
                    equals: CGRect(x: 10, y: 20, width: 1200, height: 360))
     }
+
+    func testRepeatedCornersWithHorizontalAxisLockCycleWidthOnly() {
+        setSplitRatio(60)
+        Defaults.repeatedCommandCycleAxis.value = .horizontal
+
+        assertRepeatedCornerRects(
+            topLeft: CGRect(x: 10, y: 380, width: 800, height: 540),
+            topRight: CGRect(x: 410, y: 380, width: 800, height: 540),
+            bottomLeft: CGRect(x: 10, y: 20, width: 800, height: 360),
+            bottomRight: CGRect(x: 410, y: 20, width: 800, height: 360)
+        )
+    }
+
+    func testSecondRepeatedCornerShortcutBeginsCyclingImmediately() {
+        setSplitRatio(CycleSize.twoThirds.percentValue)
+        Defaults.repeatedCommandCycleAxis.value = .horizontal
+
+        let firstFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect
+        let secondFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(repeatedParams(for: .topLeft, currentRect: firstFrame, count: 1)).rect
+        let thirdFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(repeatedParams(for: .topLeft, currentRect: secondFrame, count: 2)).rect
+
+        assertRect(firstFrame, equals: CGRect(x: 10, y: 320, width: 800, height: 600))
+        assertRect(secondFrame, equals: CGRect(x: 10, y: 320, width: 400, height: 600))
+        assertRect(thirdFrame, equals: CGRect(x: 10, y: 320, width: 600, height: 600))
+    }
+
+    func testRepeatedCornerCyclingDoesNotReturnNoOpFrameWhenBaseMatchesCycleSize() {
+        setSplitRatio(CycleSize.twoThirds.percentValue)
+        Defaults.repeatedCommandCycleAxis.value = .vertical
+
+        let firstFrame = WindowCalculationFactory.upperRightCalculation.calculateRect(params(for: .topRight)).rect
+        let secondFrame = WindowCalculationFactory.upperRightCalculation.calculateRect(repeatedParams(for: .topRight, currentRect: firstFrame, count: 1)).rect
+
+        XCTAssertFalse(firstFrame.equalTo(secondFrame))
+        XCTAssertEqual(firstFrame.maxY, secondFrame.maxY, accuracy: 0.001)
+        XCTAssertEqual(firstFrame.origin.x, secondFrame.origin.x, accuracy: 0.001)
+        XCTAssertEqual(firstFrame.width, secondFrame.width, accuracy: 0.001)
+    }
+
+    func testRepeatedCornersWithVerticalAxisLockCycleHeightOnly() {
+        setSplitRatio(60)
+        Defaults.repeatedCommandCycleAxis.value = .vertical
+
+        assertRepeatedCornerRects(
+            topLeft: CGRect(x: 10, y: 320, width: 720, height: 600),
+            topRight: CGRect(x: 730, y: 320, width: 480, height: 600),
+            bottomLeft: CGRect(x: 10, y: 20, width: 720, height: 600),
+            bottomRight: CGRect(x: 730, y: 20, width: 480, height: 600)
+        )
+    }
+
+    func testRepeatedHalfActionsStillCycleOnTheirNaturalAxis() {
+        setSplitRatio(60)
+        Defaults.repeatedCommandCycleAxis.value = .vertical
+
+        assertRect(WindowCalculationFactory.leftHalfCalculation.calculateRepeatedRect(repeatedParams(for: .leftHalf)).rect,
+                   equals: CGRect(x: 10, y: 20, width: 800, height: 900))
+        assertRect(WindowCalculationFactory.rightHalfCalculation.calculateRepeatedRect(repeatedParams(for: .rightHalf)).rect,
+                   equals: CGRect(x: 410, y: 20, width: 800, height: 900))
+
+        Defaults.repeatedCommandCycleAxis.value = .horizontal
+
+        assertRect(WindowCalculationFactory.topHalfCalculation.calculateRect(repeatedParams(for: .topHalf)).rect,
+                   equals: CGRect(x: 10, y: 320, width: 1200, height: 600))
+        assertRect(WindowCalculationFactory.bottomHalfCalculation.calculateRect(repeatedParams(for: .bottomHalf)).rect,
+                   equals: CGRect(x: 10, y: 20, width: 1200, height: 600))
+    }
     
     private func setSplitRatio(_ percent: Float) {
         Defaults.horizontalSplitRatio.value = percent
@@ -238,12 +315,34 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         assertRect(WindowCalculationFactory.lowerLeftCalculation.calculateRect(params(for: .bottomLeft)).rect, equals: bottomLeft)
         assertRect(WindowCalculationFactory.lowerRightCalculation.calculateRect(params(for: .bottomRight)).rect, equals: bottomRight)
     }
+
+    private func assertRepeatedCornerRects(topLeft: CGRect, topRight: CGRect, bottomLeft: CGRect, bottomRight: CGRect) {
+        let topLeftBase = WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect
+        let topRightBase = WindowCalculationFactory.upperRightCalculation.calculateRect(params(for: .topRight)).rect
+        let bottomLeftBase = WindowCalculationFactory.lowerLeftCalculation.calculateRect(params(for: .bottomLeft)).rect
+        let bottomRightBase = WindowCalculationFactory.lowerRightCalculation.calculateRect(params(for: .bottomRight)).rect
+
+        assertRect(WindowCalculationFactory.upperLeftCalculation.calculateRect(repeatedParams(for: .topLeft, currentRect: topLeftBase)).rect, equals: topLeft)
+        assertRect(WindowCalculationFactory.upperRightCalculation.calculateRect(repeatedParams(for: .topRight, currentRect: topRightBase)).rect, equals: topRight)
+        assertRect(WindowCalculationFactory.lowerLeftCalculation.calculateRect(repeatedParams(for: .bottomLeft, currentRect: bottomLeftBase)).rect, equals: bottomLeft)
+        assertRect(WindowCalculationFactory.lowerRightCalculation.calculateRect(repeatedParams(for: .bottomRight, currentRect: bottomRightBase)).rect, equals: bottomRight)
+    }
     
     private func params(for action: WindowAction) -> RectCalculationParameters {
         RectCalculationParameters(window: Window(id: 1, rect: visibleFrame),
                                   visibleFrameOfScreen: visibleFrame,
                                   action: action,
                                   lastAction: nil)
+    }
+
+    private func repeatedParams(for action: WindowAction, currentRect: CGRect? = nil, count: Int = 1) -> RectCalculationParameters {
+        RectCalculationParameters(window: Window(id: 1, rect: currentRect ?? visibleFrame),
+                                  visibleFrameOfScreen: visibleFrame,
+                                  action: action,
+                                  lastAction: RectangleAction(action: action,
+                                                              subAction: nil,
+                                                              rect: currentRect ?? visibleFrame,
+                                                              count: count))
     }
     
     private func assertRect(_ rect: CGRect, equals expected: CGRect, file: StaticString = #filePath, line: UInt = #line) {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -255,6 +255,26 @@ class CooperativeCornerResizeTests: XCTestCase {
         assertRect(adjustments[1].newFrame, equals: CGRect(x: 600, y: 0, width: 600, height: 900))
     }
 
+    func testLeftSideShrinkAlsoShrinksPartialBottomLeftOccupant() {
+        let focusedOld = CGRect(x: 0, y: 0, width: 800, height: 900)
+        let focusedNew = CGRect(x: 0, y: 0, width: 400, height: 900)
+        let bottomLeft = CooperativeCornerResize.Candidate(id: 2, frame: CGRect(x: 0, y: 0, width: 800, height: 300))
+        let bottomRight = CooperativeCornerResize.Candidate(id: 3, frame: CGRect(x: 800, y: 0, width: 400, height: 300))
+        let topRight = CooperativeCornerResize.Candidate(id: 4, frame: CGRect(x: 800, y: 300, width: 400, height: 600))
+
+        let adjustments = cooperativeAdjustments(focusedOld: focusedOld,
+                                                focusedNew: focusedNew,
+                                                candidates: [bottomLeft, bottomRight, topRight],
+                                                axis: .horizontal)
+
+        XCTAssertEqual(adjustments.count, 3)
+        XCTAssertEqual(adjustments[0].id, bottomLeft.id)
+        XCTAssertEqual(adjustments[0].kind, .matchingFocusedFrame)
+        assertRect(adjustments[0].newFrame, equals: CGRect(x: 0, y: 0, width: 400, height: 300))
+        assertRect(adjustments[1].newFrame, equals: CGRect(x: 400, y: 0, width: 800, height: 300))
+        assertRect(adjustments[2].newFrame, equals: CGRect(x: 400, y: 300, width: 800, height: 600))
+    }
+
     func testRightSideHorizontalExpansionShrinksLeftSideNeighbor() {
         let focusedOld = CGRect(x: 600, y: 0, width: 600, height: 900)
         let focusedNew = CGRect(x: 400, y: 0, width: 800, height: 900)

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -148,6 +148,112 @@ class CycleSizeRatioPresetTests: XCTestCase {
     }
 }
 
+class HalfSplitCornerCalculationTests: XCTestCase {
+    
+    private var savedHorizontalSplitRatio: Float = 50
+    private var savedVerticalSplitRatio: Float = 50
+    private var savedSubsequentExecutionMode: SubsequentExecutionMode = .resize
+    private let visibleFrame = CGRect(x: 10, y: 20, width: 1200, height: 900)
+    
+    override func setUp() {
+        super.setUp()
+        savedHorizontalSplitRatio = Defaults.horizontalSplitRatio.value
+        savedVerticalSplitRatio = Defaults.verticalSplitRatio.value
+        savedSubsequentExecutionMode = Defaults.subsequentExecutionMode.value
+        Defaults.subsequentExecutionMode.value = .resize
+    }
+    
+    override func tearDown() {
+        Defaults.horizontalSplitRatio.value = savedHorizontalSplitRatio
+        Defaults.verticalSplitRatio.value = savedVerticalSplitRatio
+        Defaults.subsequentExecutionMode.value = savedSubsequentExecutionMode
+        super.tearDown()
+    }
+    
+    func testCornersUseHalfSplitRatioOneHalf() {
+        setSplitRatio(50)
+        
+        assertCornerRects(
+            topLeft: CGRect(x: 10, y: 470, width: 600, height: 450),
+            topRight: CGRect(x: 610, y: 470, width: 600, height: 450),
+            bottomLeft: CGRect(x: 10, y: 20, width: 600, height: 450),
+            bottomRight: CGRect(x: 610, y: 20, width: 600, height: 450)
+        )
+    }
+    
+    func testCornersUseHalfSplitRatioTwoThirds() {
+        setSplitRatio(CycleSize.twoThirds.percentValue)
+        
+        assertCornerRects(
+            topLeft: CGRect(x: 10, y: 320, width: 800, height: 600),
+            topRight: CGRect(x: 810, y: 320, width: 400, height: 600),
+            bottomLeft: CGRect(x: 10, y: 20, width: 800, height: 300),
+            bottomRight: CGRect(x: 810, y: 20, width: 400, height: 300)
+        )
+    }
+    
+    func testCornersUseHalfSplitRatioThreeQuarters() {
+        setSplitRatio(CycleSize.threeQuarters.percentValue)
+        
+        assertCornerRects(
+            topLeft: CGRect(x: 10, y: 245, width: 900, height: 675),
+            topRight: CGRect(x: 910, y: 245, width: 300, height: 675),
+            bottomLeft: CGRect(x: 10, y: 20, width: 900, height: 225),
+            bottomRight: CGRect(x: 910, y: 20, width: 300, height: 225)
+        )
+    }
+    
+    func testCornersUseCustomHalfSplitRatio() {
+        setSplitRatio(60)
+        
+        assertCornerRects(
+            topLeft: CGRect(x: 10, y: 380, width: 720, height: 540),
+            topRight: CGRect(x: 730, y: 380, width: 480, height: 540),
+            bottomLeft: CGRect(x: 10, y: 20, width: 720, height: 360),
+            bottomRight: CGRect(x: 730, y: 20, width: 480, height: 360)
+        )
+    }
+    
+    func testHalfActionsStillUseHalfSplitRatio() {
+        setSplitRatio(60)
+        
+        assertRect(WindowCalculationFactory.leftHalfCalculation.calculateRect(params(for: .leftHalf)).rect,
+                   equals: CGRect(x: 10, y: 20, width: 720, height: 900))
+        assertRect(WindowCalculationFactory.rightHalfCalculation.calculateRect(params(for: .rightHalf)).rect,
+                   equals: CGRect(x: 730, y: 20, width: 480, height: 900))
+        assertRect(WindowCalculationFactory.topHalfCalculation.calculateRect(params(for: .topHalf)).rect,
+                   equals: CGRect(x: 10, y: 380, width: 1200, height: 540))
+        assertRect(WindowCalculationFactory.bottomHalfCalculation.calculateRect(params(for: .bottomHalf)).rect,
+                   equals: CGRect(x: 10, y: 20, width: 1200, height: 360))
+    }
+    
+    private func setSplitRatio(_ percent: Float) {
+        Defaults.horizontalSplitRatio.value = percent
+        Defaults.verticalSplitRatio.value = percent
+    }
+    
+    private func assertCornerRects(topLeft: CGRect, topRight: CGRect, bottomLeft: CGRect, bottomRight: CGRect) {
+        assertRect(WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect, equals: topLeft)
+        assertRect(WindowCalculationFactory.upperRightCalculation.calculateRect(params(for: .topRight)).rect, equals: topRight)
+        assertRect(WindowCalculationFactory.lowerLeftCalculation.calculateRect(params(for: .bottomLeft)).rect, equals: bottomLeft)
+        assertRect(WindowCalculationFactory.lowerRightCalculation.calculateRect(params(for: .bottomRight)).rect, equals: bottomRight)
+    }
+    
+    private func params(for action: WindowAction) -> RectCalculationParameters {
+        RectCalculationParameters(window: Window(id: 1, rect: visibleFrame),
+                                  visibleFrameOfScreen: visibleFrame,
+                                  action: action,
+                                  lastAction: nil)
+    }
+    
+    private func assertRect(_ rect: CGRect, equals expected: CGRect, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(rect.origin.x, expected.origin.x, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(rect.origin.y, expected.origin.y, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(rect.width, expected.width, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(rect.height, expected.height, accuracy: 0.001, file: file, line: line)
+    }
+}
+
 class OverlapOffsetGuardsTests: XCTestCase {
 
     func testMaxCascadeClampedToMinOne() {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -685,6 +685,23 @@ class HalfSplitCornerCalculationTests: XCTestCase {
         assertRect(topLeftFrame, equals: CGRect(x: 10, y: 320, width: 600, height: 600))
     }
 
+    func testDifferentTopCornerShortcutDoesNotTriggerVerticalExpansionCycleAtOneThirdSplit() {
+        setSplitRatio(CycleSize.oneThird.percentValue)
+        Defaults.cornerCycleExpansionAxis.value = .vertical
+
+        let topLeftFrame = WindowCalculationFactory.upperLeftCalculation.calculateRect(params(for: .topLeft)).rect
+        let topRightFrame = WindowCalculationFactory.upperRightCalculation.calculateRect(RectCalculationParameters(window: Window(id: 1, rect: topLeftFrame),
+                                                                                                                  visibleFrameOfScreen: visibleFrame,
+                                                                                                                  action: .topRight,
+                                                                                                                  lastAction: RectangleAction(action: .topLeft,
+                                                                                                                                              subAction: nil,
+                                                                                                                                              rect: topLeftFrame,
+                                                                                                                                              count: 1))).rect
+
+        assertRect(topLeftFrame, equals: CGRect(x: 10, y: 620, width: 400, height: 300))
+        assertRect(topRightFrame, equals: CGRect(x: 410, y: 620, width: 800, height: 300))
+    }
+
     func testRepeatedHalfActionWithNoCycleSizesSelectedUsesFirstRect() {
         setSplitRatio(60)
         Defaults.cycleSizesIsChanged.enabled = true


### PR DESCRIPTION
I'll rebase to clean up the commits when the Side Split Ratio PR merges. 

https://i.imgur.com/hXlCZfk.mp4

The Cooperative Window Resizer will automatically adjust the windows around it to avoid having to cmd tab and resize.

## Summary

- Adds cooperative resizing for repeated side and corner shortcut cycling.
- Adds a new opt-in preference: “Resize adjacent windows when cycling side or corner shortcuts”
- Resizes directly adjacent tiled windows inversely when a repeated side/corner cycle changes the focused window
- Supports co-occupying windows in the same side/corner position so they follow the focused window’s resize
- Makes side and corner repeated shortcuts interoperable across compatible cycle lanes
- Handles clean side-to-corner tiled layouts, including stacked corner neighbors
- Keeps behavior conservative for ambiguous partial overlaps and unrelated floating windows

## Testing

- Added frame-math tests for vertical/horizontal expansion and shrink
- Added tests for side actions, corner actions, side/corner interoperability, co-occupying windows, and the 2/3 split-ratio first-cycle regression
- Added regression coverage for partial same-side occupants in a four-corner 2/3 fixture 