### PR TITLE
Execute window actions when the window id is unavailable

### DIFF
--- a/Rectangle/AccessibilityElement.swift
+++ b/Rectangle/AccessibilityElement.swift
@@ -368,6 +368,25 @@ extension AccessibilityElement {
             }
             return windowElement
         }
+
+        // Last resort for when the window server isn't vending window info (#640):
+        // the frontmost app's own accessibility windows don't depend on it.
+        if let frontAppElement = getFrontApplicationElement(),
+           let windowElements = frontAppElement.windowElements {
+            let windowElement = windowElements
+                .map { (element: $0, frame: $0.frame) }
+                .filter { !$0.frame.isNull && $0.frame.contains(position) }
+                .min { $0.frame.width * $0.frame.height < $1.frame.width * $1.frame.height }?
+                .element
+            if let windowElement {
+                if Logger.logging, let pid = windowElement.pid {
+                    let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? ""
+                    Logger.log("Window under cursor frontmost app fallback matched: \(appName)")
+                }
+                return windowElement
+            }
+        }
+
         Logger.log("Unable to obtain the accessibility element with the specified attribute at mouse location")
         return nil
     }

--- a/Rectangle/AccessibilityElement.swift
+++ b/Rectangle/AccessibilityElement.swift
@@ -205,8 +205,22 @@ class AccessibilityElement {
         if let pid = pid, let info = (WindowUtil.getWindowList().first { $0.pid == pid && $0.frame == frame }) {
             return info.id
         }
+        if !frame.isNull {
+            // Last resort (#640): derive a stand-in id from the accessibility
+            // element's identity so window-id-keyed bookkeeping keeps working
+            // when macOS isn't vending real window ids. CFHash is constant for
+            // the same window across fetches and unaffected by moves/resizes.
+            Logger.log("Using a derived window id for bookkeeping")
+            return AccessibilityElement.deriveWindowId(fromElementHash: CFHash(wrappedElement))
+        }
         Logger.log("Unable to obtain window id")
         return nil
+    }
+
+    /// The high bit keeps derived ids out of the real window id space;
+    /// real ids are assigned incrementally by the window server.
+    static func deriveWindowId(fromElementHash hash: CFHashCode) -> CGWindowID {
+        CGWindowID(0x8000_0000) | (CGWindowID(truncatingIfNeeded: hash) & 0x7FFF_FFFF)
     }
     
     var pid: pid_t? {

--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -210,11 +210,12 @@ class SnappingManager {
                 // this typically only happens if the user is dragging and dropping windows really quickly
                 // in this scenario, the footprint doesn't display but the snap will still occur, as long as the window position is updated as of mouse up.
                 if let currentRect = windowElement?.frame,
-                   let windowId = windowId,
                    currentRect.size == initialWindowRect?.size,
                    currentRect.origin != initialWindowRect?.origin {
   
-                    unsnapRestore(windowId: windowId, currentRect: currentRect, cursorLoc: event.cgEvent?.location)
+                    if let windowId {
+                        unsnapRestore(windowId: windowId, currentRect: currentRect, cursorLoc: event.cgEvent?.location)
+                    }
                     
                     if let snapArea = snapAreaContainingCursor(priorSnapArea: currentSnapArea)  {
                         box?.orderOut(nil)
@@ -246,18 +247,19 @@ class SnappingManager {
                 windowIdAttempt += 1
                 lastWindowIdAttempt = event.timestamp
             }
-            guard let currentRect = windowElement?.frame,
-                let windowId = windowId
+            guard let currentRect = windowElement?.frame
             else { return }
             
             if !windowMoving {
                 if let initialWindowRect, (currentRect.size == initialWindowRect.size || currentRect.numSharedEdges(withRect: initialWindowRect) < 2) {
                     if currentRect.origin != initialWindowRect.origin {
                         windowMoving = true
-                        unsnapRestore(windowId: windowId, currentRect: currentRect, cursorLoc: event.cgEvent?.location)
+                        if let windowId {
+                            unsnapRestore(windowId: windowId, currentRect: currentRect, cursorLoc: event.cgEvent?.location)
+                        }
                     }
                 }
-                else {
+                else if let windowId {
                     AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: windowId)
                 }
             }
@@ -378,7 +380,7 @@ class SnappingManager {
     func getBoxRect(hotSpot: SnapArea, currentWindow: Window) -> CGRect? {
         if let calculation = WindowCalculationFactory.calculationsByAction[hotSpot.action] {
             
-            let ignoreTodo = TodoManager.isTodoWindow(currentWindow.id)
+            let ignoreTodo = currentWindow.id.map { TodoManager.isTodoWindow($0) } ?? false
             let rectCalcParams = RectCalculationParameters(window: currentWindow, visibleFrameOfScreen: hotSpot.screen.adjustedVisibleFrame(ignoreTodo), action: hotSpot.action, lastAction: nil)
             let rectResult = calculation.calculateRect(rectCalcParams)
             

--- a/Rectangle/WindowCalculation/NextPrevDisplayCalculation.swift
+++ b/Rectangle/WindowCalculation/NextPrevDisplayCalculation.swift
@@ -24,7 +24,9 @@ class NextPrevDisplayCalculation: WindowCalculation {
                 if let lastAction = params.lastAction,
                    let calculation = WindowCalculationFactory.calculationsByAction[lastAction.action] {
                     
-                    AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: params.window.id)
+                    if let windowId = params.window.id {
+                        AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: windowId)
+                    }
                     
                     let newCalculationParams = RectCalculationParameters(
                         window: rectParams.window,

--- a/Rectangle/WindowCalculation/SpecificDisplayCalculation.swift
+++ b/Rectangle/WindowCalculation/SpecificDisplayCalculation.swift
@@ -25,7 +25,9 @@ class SpecificDisplayCalculation: WindowCalculation {
             if let lastAction = params.lastAction,
                let calculation = WindowCalculationFactory.calculationsByAction[lastAction.action] {
 
-                AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: params.window.id)
+                if let windowId = params.window.id {
+                    AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: windowId)
+                }
 
                 let newCalculationParams = RectCalculationParameters(
                     window: rectParams.window,

--- a/Rectangle/WindowCalculation/WindowCalculation.swift
+++ b/Rectangle/WindowCalculation/WindowCalculation.swift
@@ -47,7 +47,7 @@ class WindowCalculation: Calculation {
 }
 
 struct Window {
-    let id: CGWindowID
+    let id: CGWindowID?
     let rect: CGRect
 }
 

--- a/Rectangle/WindowManager+CooperativeCornerResize.swift
+++ b/Rectangle/WindowManager+CooperativeCornerResize.swift
@@ -82,7 +82,7 @@ extension WindowManager {
         return resultingRect
     }
 
-    func cooperativeCornerResizePlan(focusedWindowId: CGWindowID,
+    func cooperativeCornerResizePlan(focusedWindowId: CGWindowID?,
                                      focusedWindowIsFixedSize: Bool,
                                      focusedWindowMinimumSize: CGSize?,
                                      action: WindowAction,
@@ -94,6 +94,7 @@ extension WindowManager {
                                      lastRectangleAction: RectangleAction?) -> CooperativeCornerApplicationPlan? {
         guard Defaults.cooperativeCornerResize.enabled,
               source.allowsCooperativeResize,
+              let focusedWindowId,
               !focusedWindowIsFixedSize,
               destinationScreenIsCurrentScreen,
               let cooperativeAxis = action.cooperativeResizeAxis,
@@ -210,7 +211,7 @@ extension WindowManager {
                                                 debugLog: plan.debugLog)
     }
 
-    func applyCooperativeCornerCleanupIfNeeded(focusedWindowId: CGWindowID,
+    func applyCooperativeCornerCleanupIfNeeded(focusedWindowId: CGWindowID?,
                                                source: ExecutionSource,
                                                oldFocusedFrame: CGRect,
                                                newFocusedFrame: CGRect,
@@ -226,7 +227,8 @@ extension WindowManager {
               !oldFocusedFrame.isNull,
               !newFocusedFrame.isNull,
               !screenFrame.isNull,
-              screenFrame.intersects(oldFocusedFrame)
+              screenFrame.intersects(oldFocusedFrame),
+              let focusedWindowId
         else {
             return
         }

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -21,7 +21,8 @@ class WindowManager {
         ]
     }
     
-    private func recordAction(windowId: CGWindowID, resultingRect: CGRect, action: WindowAction, subAction: SubWindowAction?) {
+    private func recordAction(windowId: CGWindowID?, resultingRect: CGRect, action: WindowAction, subAction: SubWindowAction?) {
+        guard let windowId else { return }
         let newCount: Int
         if let lastRectangleAction = AppDelegate.windowHistory.lastRectangleActions[windowId], lastRectangleAction.action == action {
             newCount = lastRectangleAction.count + 1
@@ -38,16 +39,24 @@ class WindowManager {
     }
     
     func execute(_ parameters: ExecutionParameters) {
-        guard let frontmostWindowElement = parameters.windowElement ?? AccessibilityElement.getFrontWindowElement(),
-              let windowId = parameters.windowId ?? frontmostWindowElement.getWindowId()
+        guard let frontmostWindowElement = parameters.windowElement ?? AccessibilityElement.getFrontWindowElement()
         else {
             NSSound.beep()
             return
         }
         
+        // The window id can be unavailable when macOS stops vending window info
+        // after a session transition (#640). Actions still execute; only
+        // window-id-keyed history is skipped.
+        let windowId = parameters.windowId ?? frontmostWindowElement.getWindowId()
+
         let action = parameters.action
         
         if action == .restore {
+            guard let windowId else {
+                NSSound.beep()
+                return
+            }
             if let restoreRect = AppDelegate.windowHistory.restoreRects[windowId] {
                 frontmostWindowElement.setFrame(restoreRect)
             }
@@ -72,23 +81,25 @@ class WindowManager {
         
         let currentWindowRect: CGRect = frontmostWindowElement.frame
         
-        var lastRectangleAction = AppDelegate.windowHistory.lastRectangleActions[windowId]
+        var lastRectangleAction = windowId.flatMap { AppDelegate.windowHistory.lastRectangleActions[$0] }
         
         let windowMovedExternally = currentWindowRect != lastRectangleAction?.rect
         
         if windowMovedExternally {
             lastRectangleAction = nil
-            AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: windowId)
+            if let windowId {
+                AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: windowId)
+            }
         }
         
-        if parameters.updateRestoreRect {
+        if parameters.updateRestoreRect, let windowId {
             if AppDelegate.windowHistory.restoreRects[windowId] == nil
                 || windowMovedExternally {
                 AppDelegate.windowHistory.restoreRects[windowId] = currentWindowRect
             }
         }
         
-        let ignoreTodo = TodoManager.isTodoWindow(windowId)
+        let ignoreTodo = windowId.map { TodoManager.isTodoWindow($0) } ?? false
         
         if frontmostWindowElement.isSheet == true
             || currentWindowRect.isNull
@@ -191,9 +202,13 @@ class WindowManager {
         }
     }
     
-    private func applyOverlapOffsetIfNeeded(_ rect: CGRect, windowId: CGWindowID, screen: NSScreen) -> CGRect {
+    private func applyOverlapOffsetIfNeeded(_ rect: CGRect, windowId: CGWindowID?, screen: NSScreen) -> CGRect {
         let overlapOffset = CGFloat(Defaults.cyclingOverlapOffsetSize.value)
         guard overlapOffset > 0 else { return rect }
+
+        // Without a window id the current window can't be excluded from the
+        // overlap scan, so skip the offset rather than cascade against itself.
+        guard let windowId else { return rect }
 
         let screenFrameAX = screen.adjustedVisibleFrame().screenFlipped
         let tolerance: CGFloat = 4
@@ -277,7 +292,7 @@ class WindowManager {
 }
 
 struct ResultParameters {
-    let windowId: CGWindowID
+    let windowId: CGWindowID?
     let action: WindowAction
     let windowElement: AccessibilityElement
     let calcResult: WindowCalculationResult

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -969,3 +969,21 @@ class NilWindowIdCalculationTests: XCTestCase {
                                   lastAction: nil)
     }
 }
+
+class DerivedWindowIdTests: XCTestCase {
+    
+    func testDerivedIdHasHighBitSet() {
+        XCTAssertEqual(AccessibilityElement.deriveWindowId(fromElementHash: 0) & 0x8000_0000, 0x8000_0000)
+        XCTAssertEqual(AccessibilityElement.deriveWindowId(fromElementHash: CFHashCode.max) & 0x8000_0000, 0x8000_0000)
+    }
+    
+    func testDerivedIdIsDeterministic() {
+        XCTAssertEqual(AccessibilityElement.deriveWindowId(fromElementHash: 1668292462),
+                       AccessibilityElement.deriveWindowId(fromElementHash: 1668292462))
+    }
+    
+    func testDistinctHashesGiveDistinctIds() {
+        let ids: [CGWindowID] = [1668318964, 1668318948, 1668321588].map { AccessibilityElement.deriveWindowId(fromElementHash: CFHashCode($0)) }
+        XCTAssertEqual(Set(ids).count, ids.count)
+    }
+}

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -944,3 +944,28 @@ class ClampedWindowAlignerTests: XCTestCase {
         XCTAssertTrue(result.equalTo(window))
     }
 }
+
+class NilWindowIdCalculationTests: XCTestCase {
+    
+    private let visibleFrame = CGRect(x: 10, y: 20, width: 1200, height: 900)
+    private let windowRect = CGRect(x: 100, y: 100, width: 600, height: 400)
+    
+    /// The window id is bookkeeping only (#640); geometry must not depend on it.
+    func testRectCalculationsMatchWithAndWithoutWindowId() {
+        for action in WindowAction.active {
+            guard let calculation = WindowCalculationFactory.calculationsByAction[action] else { continue }
+            
+            let withId = calculation.calculateRect(params(windowId: 1, action: action)).rect
+            let withoutId = calculation.calculateRect(params(windowId: nil, action: action)).rect
+            
+            XCTAssertEqual(withId, withoutId, "\(action.name) geometry should not depend on window id")
+        }
+    }
+    
+    private func params(windowId: CGWindowID?, action: WindowAction) -> RectCalculationParameters {
+        RectCalculationParameters(window: Window(id: windowId, rect: windowRect),
+                                  visibleFrameOfScreen: visibleFrame,
+                                  action: action,
+                                  lastAction: nil)
+    }
+}


### PR DESCRIPTION
The failure in #640 (also #1244, #1325, #1673): after waking to the login window or an idle logout, every action beeps and nothing moves until you lock and unlock the screen. Restarting Rectangle doesn't clear it. Rebooting does.

The logs in those threads show what macOS is actually withholding. "Unable to obtain window id" on commands means the focused window element was retrieved fine and both id sources then failed: `_AXUIElementGetWindow`, and the window list frame+pid fallback. The hit-test failure on drags means `CGWindowListCopyWindowInfo` and the system-wide element are dead too. Per-app accessibility keeps working the whole time, which also matches Magnet, BetterTouchTool, and HyperSwitch breaking simultaneously: the window server stops vending cross-app window info until a lock/unlock resets the session. I don't think Rectangle can clear that state. It can stop needing the window id to act. The id only feeds history bookkeeping (restore rects, cycling, todo and stage checks), but `execute()` requires it in the same guard as the window element, so a bookkeeping miss fails the whole action with a beep, and the drag path bails the same way.

With this change the id is optional. Actions run without it and skip the id-keyed bookkeeping: cycling restarts from the first step, no restore rect gets recorded. Restore alone still requires it and beeps, since it's pure history. The drag path tolerates a missing id, and window-under-cursor gets a last-resort fallback that hit-tests the frontmost app's own AX windows, since both existing lookups depend on window server info.

Verified by stubbing the two failing calls (`_AXUIElementGetWindow` erroring, `CGWindowListCopyWindowInfo` empty) and driving `rectangle://execute-action?name=left-half` at a real TextEdit window: on main nothing moves, on this branch it snaps, and with the stubs removed behavior is unchanged and the tests pass. There's a new test pinning that calculated geometry never depends on the id. The one thing I can't confirm on a healthy machine is the drag fallback under the real condition. If someone from #640 or #1673 can run this branch after the next occurrence, that settles it.

Multi-window actions and todo reflow still need the real window list, so they stay degraded in the broken state. Left alone on purpose.
