### PR TITLE
Align clamped windows to snap edges by default

### DIFF
--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -23,7 +23,7 @@ class Defaults {
     static let snapEdgeMarginRight = FloatDefault(key: "snapEdgeMarginRight", defaultValue: 5)
     static let centeredDirectionalMove = OptionalBoolDefault(key: "centeredDirectionalMove")
     static let resizeOnDirectionalMove = BoolDefault(key: "resizeOnDirectionalMove")
-    static let moveFixedSizeToEdge = IntEnumDefault<EdgeAlignment>(key: "moveFixedSizeToEdge", defaultValue: .centered)
+    static let moveFixedSizeToEdge = IntEnumDefault<EdgeAlignment>(key: "moveFixedSizeToEdge", defaultValue: .edgesAndCorners)
     static let ignoredSnapAreas = IntDefault(key: "ignoredSnapAreas")
     static let traverseSingleScreen = OptionalBoolDefault(key: "traverseSingleScreen")
     static let useCursorScreenDetection = BoolDefault(key: "useCursorScreenDetection")

--- a/Rectangle/WindowMover/FixedSizeWindowMover.swift
+++ b/Rectangle/WindowMover/FixedSizeWindowMover.swift
@@ -2,8 +2,7 @@
 
 import Foundation
 
-/// Handle windows that are a fixed size. With `moveFixedSizeToEdge` enabled, anchor them
-/// to the snap zone's screen edges; otherwise center them in the zone (legacy behavior).
+/// Handle windows that are a fixed size. Align or center them according to `moveFixedSizeToEdge`.
 class FixedSizeWindowMover: WindowMover {
 
     func moveWindow(toRect rect: CGRect, resultParameters: ResultParameters) {
@@ -11,9 +10,10 @@ class FixedSizeWindowMover: WindowMover {
         let currentWindowRect: CGRect = windowElement.frame
         if currentWindowRect.isNull { return }
 
-        let initialFlippedRect = resultParameters.calcResult.initialRect.screenFlipped
-        let screenFrame = resultParameters.visibleFrameOfScreen.screenFlipped
-        let sharedEdges: Edge = getAlignmentEdges(initialNormalizedRect: initialFlippedRect, normalizedScreenFrame: screenFrame)
+        let sharedEdges = Defaults.moveFixedSizeToEdge.value.alignmentEdges(
+            for: resultParameters.calcResult.initialRect.screenFlipped,
+            in: resultParameters.visibleFrameOfScreen.screenFlipped
+        )
 
         let adjusted = ClampedWindowAligner.aligned(window: currentWindowRect,
                                                     inZone: rect.screenFlipped,
@@ -23,19 +23,4 @@ class FixedSizeWindowMover: WindowMover {
             windowElement.setFrame(adjusted)
         }
     }
-    
-    private func getAlignmentEdges(initialNormalizedRect rect: CGRect, normalizedScreenFrame: CGRect) -> Edge {
-        let alignment = Defaults.moveFixedSizeToEdge.value
-        
-        switch alignment {
-        case .edgesAndCorners:
-            return rect.sharedEdges(withRect: normalizedScreenFrame)
-        case .corners:
-            let sharedEdges = rect.sharedEdges(withRect: normalizedScreenFrame)
-            return sharedEdges.isCorner ? sharedEdges : .none
-        case .centered:
-            return .none
-        }
-    }
-    
 }

--- a/Rectangle/WindowMover/WindowMover.swift
+++ b/Rectangle/WindowMover/WindowMover.swift
@@ -43,19 +43,21 @@ enum ClampedWindowAligner {
 
 /// For resizable windows that clamp smaller than their snap zone (e.g. FaceTime keeping a
 /// fixed aspect ratio), `StandardWindowMover` leaves them at the zone's leading corner with
-/// a gap on the screen-edge side. When `moveFixedSizeToEdge` is enabled, re-anchor them to
-/// the zone's screen edges. No-op when the flag is off or the window already fills the zone.
+/// a gap on the screen-edge side. Re-anchor or center them according to `moveFixedSizeToEdge`.
+/// No-op when the window already fills the zone.
 class EdgeAlignmentWindowMover: WindowMover {
 
     func moveWindow(toRect rect: CGRect, resultParameters: ResultParameters) {
-        guard Defaults.moveFixedSizeToEdge.value != .centered, resultParameters.action.resizes else { return }
+        guard resultParameters.action.resizes else { return }
 
         let windowElement = resultParameters.windowElement
         let currentWindowRect: CGRect = windowElement.frame
         if currentWindowRect.isNull { return }
 
-        let sharedEdges = resultParameters.calcResult.initialRect.screenFlipped
-            .sharedEdges(withRect: resultParameters.visibleFrameOfScreen.screenFlipped)
+        let sharedEdges = Defaults.moveFixedSizeToEdge.value.alignmentEdges(
+            for: resultParameters.calcResult.initialRect.screenFlipped,
+            in: resultParameters.visibleFrameOfScreen.screenFlipped
+        )
 
         let adjusted = ClampedWindowAligner.aligned(window: currentWindowRect,
                                                     inZone: rect.screenFlipped,
@@ -71,4 +73,17 @@ enum EdgeAlignment: Int {
     case edgesAndCorners = 1
     case corners = 2
     case centered = 3
+
+    func alignmentEdges(for rect: CGRect, in screenFrame: CGRect) -> Edge {
+        let sharedEdges = rect.sharedEdges(withRect: screenFrame)
+
+        switch self {
+        case .edgesAndCorners:
+            return sharedEdges
+        case .corners:
+            return sharedEdges.isCorner ? sharedEdges : .none
+        case .centered:
+            return .none
+        }
+    }
 }

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -943,4 +943,32 @@ class ClampedWindowAlignerTests: XCTestCase {
         let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
         XCTAssertTrue(result.equalTo(window))
     }
+
+    func testEdgesAndCornersAlignmentKeepsHalfEdges() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
+        let rightHalf = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let result = EdgeAlignment.edgesAndCorners.alignmentEdges(for: rightHalf, in: screenFrame)
+        XCTAssertEqual(result, [.right, .top, .bottom])
+    }
+
+    func testCornersAlignmentCentersHalfEdges() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
+        let rightHalf = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let result = EdgeAlignment.corners.alignmentEdges(for: rightHalf, in: screenFrame)
+        XCTAssertEqual(result, .none)
+    }
+
+    func testCornersAlignmentKeepsCornerEdges() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
+        let topRight = CGRect(x: 1000, y: 600, width: 1000, height: 600)
+        let result = EdgeAlignment.corners.alignmentEdges(for: topRight, in: screenFrame)
+        XCTAssertEqual(result, [.right, .top])
+    }
+
+    func testCenteredAlignmentIgnoresSharedEdges() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
+        let topRight = CGRect(x: 1000, y: 600, width: 1000, height: 600)
+        let result = EdgeAlignment.centered.alignmentEdges(for: topRight, in: screenFrame)
+        XCTAssertEqual(result, .none)
+    }
 }

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -542,8 +542,10 @@ defaults write com.knollsoft.Rectangle cyclingOverlapMaxCascade -int 3
 
 ## Move windows that can't fill the snap area to the edge
 
-Some windows can't be resized to fill a snap area — either because they're a fixed size, or because they're resizable but have a maximum size or a fixed aspect ratio (FaceTime is a common example). By default such a window is centered within the snap area, which can leave a gap against the screen edge (e.g. snapping FaceTime to the right half leaves it floating left of the screen's right edge). Enable this to instead align the window to the snap area's screen edge(s): a right-half snap anchors flush right, a corner snap anchors into the corner, and the window stays centered on any axis it can't fill. Off by default.
+Some windows can't be resized to fill a snap area — either because they're a fixed size, or because they're resizable but have a maximum size or a fixed aspect ratio (FaceTime is a common example). By default such a window aligns to the snap area's screen edge(s): a right-half snap anchors flush right, a corner snap anchors into the corner, and the window stays centered on any axis it can't fill. To choose a different behavior:
 
 ```bash
-defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -bool true
+defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 1  # align edges and corners (default)
+defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 2  # align corners only, center halves/sides
+defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 3  # center within the snap area
 ```


### PR DESCRIPTION
## Summary
- align constrained and fixed-size windows to snap edges and corners by default
- share moveFixedSizeToEdge enum handling between fixed-size and resizable-clamped windows
- document the enum values and cover edge, corner, and centered modes in tests

Fixes #185

## Testing
- xcodebuild test -project Rectangle.xcodeproj -scheme Rectangle -destination 'platform=macOS'