### PR TITLE
Add a Settings toggle to keep window size when moving a maximized window to another display

### DIFF
--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -48,6 +48,7 @@ class SettingsViewController: NSViewController {
     private var cooperativeCornerResizeCheckbox: NSButton?
     private var combinedDisplayModeCheckbox: NSButton?
     private var greenButtonOverrideCheckbox: NSButton?
+    private var autoMaximizeCheckbox: NSButton?
     
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
         let newSetting: Bool = sender.state == .on
@@ -174,6 +175,12 @@ class SettingsViewController: NSViewController {
     @objc func toggleGreenButtonOverride(_ sender: NSButton) {
         Defaults.greenButtonOverride.enabled = sender.state == .on
         Notification.Name.greenButtonOverride.post()
+    }
+
+    @objc func toggleAutoMaximize(_ sender: NSButton) {
+        // autoMaximize is tri-state; the re-maximize behavior is active unless explicitly disabled.
+        // Checked = keep default behavior (nil), unchecked = disabled (false).
+        Defaults.autoMaximize.enabled = sender.state == .on ? nil : false
     }
 
     @IBAction func toggleTodoMode(_ sender: NSButton) {
@@ -1061,6 +1068,8 @@ class SettingsViewController: NSViewController {
 
         initializeGreenButtonOverrideCheckbox()
 
+        initializeAutoMaximizeCheckbox()
+
         Notification.Name.configImported.onPost(using: {_ in
             self.initializeTodoModeSettings()
             self.initializeToggles()
@@ -1129,6 +1138,8 @@ class SettingsViewController: NSViewController {
         combinedDisplayModeCheckbox?.state = Defaults.combinedDisplayMode.userEnabled ? .on : .off
 
         greenButtonOverrideCheckbox?.state = Defaults.greenButtonOverride.enabled ? .on : .off
+
+        autoMaximizeCheckbox?.state = Defaults.autoMaximize.userDisabled ? .off : .on
 
         if StageUtil.stageCapable {
             stageSlider.intValue = Int32(Defaults.stageSize.value)
@@ -1213,6 +1224,34 @@ class SettingsViewController: NSViewController {
             parentStack.insertArrangedSubview(checkbox, at: insertIdx + 1)
             parentStack.insertArrangedSubview(descLabel, at: insertIdx + 2)
             greenButtonOverrideCheckbox = checkbox
+        }
+    }
+
+    private func initializeAutoMaximizeCheckbox() {
+        if autoMaximizeCheckbox == nil,
+           let parentStack = doubleClickTitleBarCheckbox.superview as? NSStackView,
+           let insertIdx = parentStack.arrangedSubviews.firstIndex(of: doubleClickTitleBarCheckbox) {
+
+            let checkbox = NSButton(checkboxWithTitle: NSLocalizedString("Maximize window when moved to another display", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleAutoMaximize(_:)))
+            // autoMaximize is tri-state; the re-maximize behavior is active unless explicitly disabled.
+            checkbox.state = Defaults.autoMaximize.userDisabled ? .off : .on
+            // Match storyboard checkbox content priorities to prevent vertical compression
+            checkbox.setContentCompressionResistancePriority(.required, for: .vertical)
+            checkbox.setContentHuggingPriority(.defaultHigh, for: .vertical)
+
+            // Must be set before inserting: NSStackView queries intrinsicContentSize once on
+            // insertion, so preferredMaxLayoutWidth=0 would give zero height permanently.
+            let descLabel = NSTextField(wrappingLabelWithString: NSLocalizedString("When off, a maximized window keeps its size and is centered on the new display instead of filling it.", tableName: "Main", value: "", comment: ""))
+            descLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+            descLabel.textColor = .secondaryLabelColor
+            descLabel.translatesAutoresizingMaskIntoConstraints = false
+            descLabel.preferredMaxLayoutWidth = 500
+            descLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+            descLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
+
+            parentStack.insertArrangedSubview(checkbox, at: insertIdx + 1)
+            parentStack.insertArrangedSubview(descLabel, at: insertIdx + 2)
+            autoMaximizeCheckbox = checkbox
         }
     }
 

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -178,9 +178,7 @@ class SettingsViewController: NSViewController {
     }
 
     @objc func toggleAutoMaximize(_ sender: NSButton) {
-        // autoMaximize is tri-state; the re-maximize behavior is active unless explicitly disabled.
-        // Checked = keep default behavior (nil), unchecked = disabled (false).
-        Defaults.autoMaximize.enabled = sender.state == .on ? nil : false
+        Defaults.autoMaximize.enabled = sender.state == .on
     }
 
     @IBAction func toggleTodoMode(_ sender: NSButton) {
@@ -1233,9 +1231,7 @@ class SettingsViewController: NSViewController {
            let insertIdx = parentStack.arrangedSubviews.firstIndex(of: doubleClickTitleBarCheckbox) {
 
             let checkbox = NSButton(checkboxWithTitle: NSLocalizedString("Preserve maximize state when moving across displays", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleAutoMaximize(_:)))
-            // autoMaximize is tri-state; the re-maximize behavior is active unless explicitly disabled.
             checkbox.state = Defaults.autoMaximize.userDisabled ? .off : .on
-            // Match storyboard checkbox content priorities to prevent vertical compression
             checkbox.setContentCompressionResistancePriority(.required, for: .vertical)
             checkbox.setContentHuggingPriority(.defaultHigh, for: .vertical)
 

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -1232,25 +1232,14 @@ class SettingsViewController: NSViewController {
            let parentStack = doubleClickTitleBarCheckbox.superview as? NSStackView,
            let insertIdx = parentStack.arrangedSubviews.firstIndex(of: doubleClickTitleBarCheckbox) {
 
-            let checkbox = NSButton(checkboxWithTitle: NSLocalizedString("Maximize window when moved to another display", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleAutoMaximize(_:)))
+            let checkbox = NSButton(checkboxWithTitle: NSLocalizedString("Preserve maximize state when moving across displays", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleAutoMaximize(_:)))
             // autoMaximize is tri-state; the re-maximize behavior is active unless explicitly disabled.
             checkbox.state = Defaults.autoMaximize.userDisabled ? .off : .on
             // Match storyboard checkbox content priorities to prevent vertical compression
             checkbox.setContentCompressionResistancePriority(.required, for: .vertical)
             checkbox.setContentHuggingPriority(.defaultHigh, for: .vertical)
 
-            // Must be set before inserting: NSStackView queries intrinsicContentSize once on
-            // insertion, so preferredMaxLayoutWidth=0 would give zero height permanently.
-            let descLabel = NSTextField(wrappingLabelWithString: NSLocalizedString("When off, a maximized window keeps its size and is centered on the new display instead of filling it.", tableName: "Main", value: "", comment: ""))
-            descLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
-            descLabel.textColor = .secondaryLabelColor
-            descLabel.translatesAutoresizingMaskIntoConstraints = false
-            descLabel.preferredMaxLayoutWidth = 500
-            descLabel.setContentCompressionResistancePriority(.required, for: .vertical)
-            descLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
-
             parentStack.insertArrangedSubview(checkbox, at: insertIdx + 1)
-            parentStack.insertArrangedSubview(descLabel, at: insertIdx + 2)
             autoMaximizeCheckbox = checkbox
         }
     }

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -20156,6 +20156,12 @@
         }
       }
     },
+    "Maximize window when moved to another display" : {
+
+    },
+    "When off, a maximized window keeps its size and is centered on the new display instead of filling it." : {
+
+    },
     "Green stoplight button maximizes instead of Full Screen" : {
 
     },

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -20156,12 +20156,6 @@
         }
       }
     },
-    "Maximize window when moved to another display" : {
-
-    },
-    "When off, a maximized window keeps its size and is centered on the new display instead of filling it." : {
-
-    },
     "Green stoplight button maximizes instead of Full Screen" : {
 
     },
@@ -34565,6 +34559,9 @@
           }
         }
       }
+    },
+    "Preserve maximize state when moving across displays" : {
+
     },
     "Press the shortcut repeatedly to cycle through all positions in the grid." : {
       "localizations" : {

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -35,6 +35,7 @@ The preferences window is purposefully slim, but there's a lot that can be modif
 - [Prevent a window that is quickly dragged above the menu bar from going into Mission Control](#prevent-a-window-that-is-quickly-dragged-above-the-menu-bar-from-going-into-mission-control)
 - [Change the behavior of double-click window title bar](#change-the-behavior-of-double-click-window-title-bar)
 - [Change the order of displays to order by x coordinate](#change-the-order-of-displays-to-order-by-x-coordinate-for-next-and-prev-displays-commands)
+- [Keep window size when moving a maximized window to another display](#keep-window-size-when-moving-a-maximized-window-to-another-display)
 - [Offset cycling position when overlapping another window](#offset-cycling-position-when-overlapping-another-window)
 - [Move windows that can't fill the snap area to the edge](#move-windows-that-cant-fill-the-snap-area-to-the-edge)
 
@@ -518,6 +519,20 @@ By default, display order is left-to-right, line-by-line. You can change this to
 
 ```bash
 defaults write com.knollsoft.Rectangle screensOrderedByX -int 1
+```
+
+## Keep window size when moving a maximized window to another display
+
+By default, moving a maximized window to the next or previous display re-maximizes it to fill the destination display. Disable this to keep the window's size and center it on the destination display instead (so a window maximized on a smaller display won't grow to fill a larger one). This can also be toggled from Settings via the "Maximize window when moved to another display" checkbox.
+
+```bash
+defaults write com.knollsoft.Rectangle autoMaximize -int 2
+```
+
+To restore the default behavior:
+
+```bash
+defaults write com.knollsoft.Rectangle autoMaximize -int 0
 ```
 
 ## Offset cycling position when overlapping another window


### PR DESCRIPTION
## Summary

Moving a maximized window to the next/previous display currently re-maximizes it to fill the destination display. This is already toggleable via the hidden `autoMaximize` default, but there's no UI for it, so most users don't know it exists.

This PR exposes it as a **"Maximize window when moved to another display"** checkbox in Settings, **checked by default so existing behavior is unchanged**. Unchecking it keeps the window's size and centers it on the destination display — preferable when displays differ in size (e.g. a window maximized on a laptop screen shouldn't grow to fill a larger external monitor). This restores the behavior Spectacle had.

## Changes

- `SettingsViewController`: add the checkbox + description, mirroring the existing `greenButtonOverride` / `combinedDisplayMode` programmatic checkboxes (property, toggle action, initializer, config-import refresh).
- `Main.xcstrings`: register the two new strings.
- `TerminalCommands.md`: document the `autoMaximize` default.

## Testing

Built and ran locally on a dual-monitor setup:

- **Unchecked:** a window maximized on the smaller display keeps its size and centers when moved to the larger display.
- **Checked (default):** the window re-maximizes to fill the larger display, as before.
