### PR TITLE
Add a hover badge and switcher for stacked windows

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		9824704F22B189250037B409 /* BestEffortWindowMover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9824704A22B189250037B409 /* BestEffortWindowMover.swift */; };
 		9824705122B28D7A0037B409 /* LeftRightHalfCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9824705022B28D7A0037B409 /* LeftRightHalfCalculation.swift */; };
 		983BBD6F253B609D000D223E /* FootprintWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983BBD6E253B609D000D223E /* FootprintWindow.swift */; };
+		F1AC0DE000000000000000A2 /* StackBadgeGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A1 /* StackBadgeGeometry.swift */; };
+		F1AC0DE000000000000000A4 /* StackBadgeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A3 /* StackBadgeManager.swift */; };
 		983DD04028A844BE00BF1EEE /* SnapAreaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */; };
 		983DD04428B0639E00BF1EEE /* SnapAreaModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD04328B0639E00BF1EEE /* SnapAreaModel.swift */; };
 		984EDB0F29A42ED200D119D2 /* LaunchOnLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */; };
@@ -317,6 +319,8 @@
 		9824704A22B189250037B409 /* BestEffortWindowMover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BestEffortWindowMover.swift; sourceTree = "<group>"; };
 		9824705022B28D7A0037B409 /* LeftRightHalfCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftRightHalfCalculation.swift; sourceTree = "<group>"; };
 		983BBD6E253B609D000D223E /* FootprintWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FootprintWindow.swift; sourceTree = "<group>"; };
+		F1AC0DE000000000000000A1 /* StackBadgeGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeGeometry.swift; sourceTree = "<group>"; };
+		F1AC0DE000000000000000A3 /* StackBadgeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeManager.swift; sourceTree = "<group>"; };
 		983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaViewController.swift; sourceTree = "<group>"; };
 		983DD04328B0639E00BF1EEE /* SnapAreaModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaModel.swift; sourceTree = "<group>"; };
 		984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOnLogin.swift; sourceTree = "<group>"; };
@@ -708,6 +712,7 @@
 				98910B3C2311304D0066EC23 /* PrefsWindow */,
 				989DA30C243FC0C3008C7AA4 /* WelcomeWindow */,
 				98C2755F231FF6AE009B9292 /* Snapping */,
+				F1AC0DE000000000000000A5 /* StackBadge */,
 				98D4B6C925B625B6009C7BF6 /* TodoMode */,
 				985B9BFA22BE218C00A2E8F0 /* Popover */,
 				982140EA22B7DB0400ABFB3F /* WindowMover */,
@@ -784,6 +789,15 @@
 				98D4B6C425B6256C009C7BF6 /* TodoManager.swift */,
 			);
 			path = TodoMode;
+			sourceTree = "<group>";
+		};
+		F1AC0DE000000000000000A5 /* StackBadge */ = {
+			isa = PBXGroup;
+			children = (
+				F1AC0DE000000000000000A1 /* StackBadgeGeometry.swift */,
+				F1AC0DE000000000000000A3 /* StackBadgeManager.swift */,
+			);
+			path = StackBadge;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1081,6 +1095,8 @@
 				9824702C22AFA22E0037B409 /* AccessibilityWindowController.swift in Sources */,
 				988D066122EB4C7C004EABD7 /* FirstThirdCalculation.swift in Sources */,
 				983BBD6F253B609D000D223E /* FootprintWindow.swift in Sources */,
+				F1AC0DE000000000000000A2 /* StackBadgeGeometry.swift in Sources */,
+				F1AC0DE000000000000000A4 /* StackBadgeManager.swift in Sources */,
 				988D067F22EB4EDE004EABD7 /* MoveLeftRightCalculation.swift in Sources */,
 				AA3A9E8B29230A82004EB8E5 /* CFExtension.swift in Sources */,
 				98C6DEF023CE191700CC0C1E /* GapCalculation.swift in Sources */,

--- a/Rectangle/AccessibilityElement.swift
+++ b/Rectangle/AccessibilityElement.swift
@@ -250,6 +250,16 @@ class AccessibilityElement {
     var isMinimized: Bool? {
         windowElement?.wrappedElement.getValue(.minimized) as? Bool
     }
+
+    var title: String? {
+        wrappedElement.getValue(.title) as? String
+    }
+
+    /// Caps how long AX calls through this element can block on an
+    /// unresponsive app (the systemwide default is several seconds).
+    func setMessagingTimeout(_ seconds: Float) {
+        AXUIElementSetMessagingTimeout(wrappedElement, seconds)
+    }
     
     var isFullScreen: Bool? {
         guard let subrole = windowElement?.getElementValue(.fullScreenButton)?.subrole else { return nil }

--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -25,6 +25,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var applicationToggle: ApplicationToggle!
     private var windowCalculationFactory: WindowCalculationFactory!
     private var snappingManager: SnappingManager!
+    private var stackBadgeManager: StackBadgeManager!
     private var titleBarManager: TitleBarManager!
     private var greenButtonManager: GreenButtonManager!
     
@@ -153,6 +154,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.shortcutManager = ShortcutManager(windowManager: windowManager)
         self.applicationToggle = ApplicationToggle(shortcutManager: shortcutManager)
         self.snappingManager = SnappingManager()
+        self.stackBadgeManager = StackBadgeManager()
         self.titleBarManager = TitleBarManager()
         self.greenButtonManager = GreenButtonManager()
         self.initializeTodo()

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -66,6 +66,7 @@ class Defaults {
     static let cyclingOverlapOffset = OptionalBoolDefault(key: "cyclingOverlapOffset")
     static let cyclingOverlapOffsetSize = FloatDefault(key: "cyclingOverlapOffsetSize", defaultValue: 11)
     static let cyclingOverlapMaxCascade = IntDefault(key: "cyclingOverlapMaxCascade", defaultValue: 1)
+    static let stackBadge = OptionalBoolDefault(key: "stackBadge")
     static let fullIgnoreBundleIds = JSONDefault<[String]>(key: "fullIgnoreBundleIds")
     static let notifiedOfProblemApps = BoolDefault(key: "notifiedOfProblemApps")
     static let specifiedHeight = FloatDefault(key: "specifiedHeight", defaultValue: 1050)
@@ -194,6 +195,7 @@ class Defaults {
         cyclingOverlapOffset,
         cyclingOverlapOffsetSize,
         cyclingOverlapMaxCascade,
+        stackBadge,
         moveFixedSizeToEdge,
         greenButtonOverride
     ]

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -117,6 +117,11 @@ class SettingsViewController: NSViewController {
         Notification.Name.showAdditionalSizesInMenuChanged.post()
     }
 
+    @objc func toggleStackBadge(_ sender: NSButton) {
+        Defaults.stackBadge.enabled = sender.state == .on
+        Notification.Name.stackBadgeChanged.post()
+    }
+
     @objc func toggleCyclingOverlapOffset(_ sender: NSButton) {
         Defaults.cyclingOverlapOffset.enabled = sender.state == .on
     }
@@ -901,11 +906,17 @@ class SettingsViewController: NSViewController {
             overlapOffsetCheckbox.translatesAutoresizingMaskIntoConstraints = false
             overlapOffsetCheckbox.alignment = .left
 
+            let stackBadgeCheckbox = NSButton(checkboxWithTitle: NSLocalizedString("Show stacked window badge on hover", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleStackBadge(_:)))
+            stackBadgeCheckbox.state = Defaults.stackBadge.userEnabled ? .on : .off
+            stackBadgeCheckbox.translatesAutoresizingMaskIntoConstraints = false
+            stackBadgeCheckbox.alignment = .left
+
             mainStackView.addArrangedSubview(gridHeaderLabel)
             mainStackView.setCustomSpacing(4, after: gridHeaderLabel)
             mainStackView.addArrangedSubview(showAdditionalSizesCheckbox)
             mainStackView.addArrangedSubview(overlapOffsetCheckbox)
-            mainStackView.setCustomSpacing(8, after: overlapOffsetCheckbox)
+            mainStackView.addArrangedSubview(stackBadgeCheckbox)
+            mainStackView.setCustomSpacing(8, after: stackBadgeCheckbox)
             mainStackView.addArrangedSubview(cyclingHintLabel)
             mainStackView.setCustomSpacing(8, after: cyclingHintLabel)
             mainStackView.addArrangedSubview(topLeftEighthRow)

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -989,6 +989,7 @@ class SettingsViewController: NSViewController {
                 widthStepField.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor),
                 showAdditionalSizesCheckbox.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 overlapOffsetCheckbox.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
+                stackBadgeCheckbox.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 smallerWidthShortcutView.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 topVerticalThirdShortcutView.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 middleVerticalThirdShortcutView.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),

--- a/Rectangle/StackBadge/StackBadgeGeometry.swift
+++ b/Rectangle/StackBadge/StackBadgeGeometry.swift
@@ -47,10 +47,26 @@ enum StackBadgeGeometry {
         return points
     }
 
+    /// The indices of the window origins (AX coordinates) that form a
+    /// cascade stack, anchored on the leftmost origin. The overlap offset
+    /// cascades diagonally: +x always, but y can run either way (the offset
+    /// is applied in AppKit coordinates, where +y converts to an upward move
+    /// in AX space), so the y window is symmetric. Anchoring on the leftmost
+    /// origin keeps unrelated neighbors out of a gap-widened candidate box.
+    static func stackIndices(among origins: [CGPoint], cascadeRange: CGFloat, tolerance: CGFloat) -> [Int] {
+        guard let anchor = (origins.min { $0.x < $1.x }) else { return [] }
+        return origins.indices.filter { index in
+            let dx = origins[index].x - anchor.x
+            let dy = origins[index].y - anchor.y
+            return dx >= -tolerance && dx <= cascadeRange
+                && dy >= -cascadeRange && dy <= cascadeRange
+        }
+    }
+
     /// The corner whose hover zone contains the point, or nil. The zone is a
-    /// square extending right and DOWN from the corner (AppKit y-down means
-    /// minus y), because the peek revealed by the overlap offset hangs
-    /// down-right of the buried window's top-left corner.
+    /// square extending right and down from the corner (down in AppKit means
+    /// minus y), covering where gap-shifted windows and their title bars sit
+    /// relative to the geometric corner.
     static func corner(near point: CGPoint, in corners: [CGPoint], zone: CGFloat) -> CGPoint? {
         var best: (corner: CGPoint, distance: CGFloat)?
         for corner in corners {

--- a/Rectangle/StackBadge/StackBadgeGeometry.swift
+++ b/Rectangle/StackBadge/StackBadgeGeometry.swift
@@ -48,19 +48,26 @@ enum StackBadgeGeometry {
     }
 
     /// The indices of the window origins (AX coordinates) that form a
-    /// cascade stack, anchored on the leftmost origin. The overlap offset
-    /// cascades diagonally: +x always, but y can run either way (the offset
-    /// is applied in AppKit coordinates, where +y converts to an upward move
-    /// in AX space), so the y window is symmetric. Anchoring on the leftmost
-    /// origin keeps unrelated neighbors out of a gap-widened candidate box.
+    /// cascade stack. The overlap offset cascades diagonally: +x always, but
+    /// y can run either way (the offset is applied in AppKit coordinates,
+    /// where +y converts to an upward move in AX space), so the y window is
+    /// symmetric. Every origin is tried as the stack's left anchor and the
+    /// densest cluster wins, so neither unrelated neighbors in a gap-widened
+    /// candidate box nor an unrelated leftmost outlier can distort the count.
     static func stackIndices(among origins: [CGPoint], cascadeRange: CGFloat, tolerance: CGFloat) -> [Int] {
-        guard let anchor = (origins.min { $0.x < $1.x }) else { return [] }
-        return origins.indices.filter { index in
-            let dx = origins[index].x - anchor.x
-            let dy = origins[index].y - anchor.y
-            return dx >= -tolerance && dx <= cascadeRange
-                && dy >= -cascadeRange && dy <= cascadeRange
+        var best = [Int]()
+        for anchor in origins {
+            let cluster = origins.indices.filter { index in
+                let dx = origins[index].x - anchor.x
+                let dy = origins[index].y - anchor.y
+                return dx >= -tolerance && dx <= cascadeRange
+                    && dy >= -cascadeRange && dy <= cascadeRange
+            }
+            if cluster.count > best.count {
+                best = cluster
+            }
         }
+        return best
     }
 
     /// The corner whose hover zone contains the point, or nil. The zone is a

--- a/Rectangle/StackBadge/StackBadgeGeometry.swift
+++ b/Rectangle/StackBadge/StackBadgeGeometry.swift
@@ -1,0 +1,67 @@
+//
+//  StackBadgeGeometry.swift
+//  Rectangle
+//
+//  Copyright © 2026 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+/// Pure geometry for the stack badge: where on a screen a grid cell's
+/// top-left corner can be, and whether the cursor is resting near one.
+/// No AX, no window state - computable from screen frames alone.
+enum StackBadgeGeometry {
+
+    /// Every grid layout Rectangle can place windows into, as (columns, rows).
+    /// Cell corners from these are where stacked windows can share an origin.
+    static let gridDimensions: [(cols: Int, rows: Int)] = [
+        (2, 1), (1, 2),         // halves
+        (3, 1), (1, 3),         // thirds
+        (2, 2),                 // quarters
+        (4, 1), (1, 4),         // fourths
+        (3, 2), (2, 3),         // sixths
+        (4, 2),                 // eighths
+        (3, 3),                 // ninths
+        (4, 3), (3, 4),         // twelfths
+        (4, 4)                  // sixteenths
+    ]
+
+    /// Top-left corners (AppKit coordinates, y up) of every grid cell across
+    /// all supported grids, deduplicated. ~30 points for a typical screen.
+    static func cornerPoints(in screenFrame: CGRect) -> [CGPoint] {
+        guard screenFrame.width > 0, screenFrame.height > 0 else { return [] }
+        var points = [CGPoint]()
+        for grid in gridDimensions {
+            for col in 0..<grid.cols {
+                for row in 0..<grid.rows {
+                    let point = CGPoint(
+                        x: screenFrame.minX + CGFloat(col) * screenFrame.width / CGFloat(grid.cols),
+                        y: screenFrame.maxY - CGFloat(row) * screenFrame.height / CGFloat(grid.rows)
+                    )
+                    if !points.contains(where: { abs($0.x - point.x) < 1 && abs($0.y - point.y) < 1 }) {
+                        points.append(point)
+                    }
+                }
+            }
+        }
+        return points
+    }
+
+    /// The corner whose hover zone contains the point, or nil. The zone is a
+    /// square extending right and DOWN from the corner (AppKit y-down means
+    /// minus y), because the peek revealed by the overlap offset hangs
+    /// down-right of the buried window's top-left corner.
+    static func corner(near point: CGPoint, in corners: [CGPoint], zone: CGFloat) -> CGPoint? {
+        var best: (corner: CGPoint, distance: CGFloat)?
+        for corner in corners {
+            let dx = point.x - corner.x
+            let dy = corner.y - point.y
+            guard dx >= -4, dx <= zone, dy >= -4, dy <= zone else { continue }
+            let distance = dx * dx + dy * dy
+            if best == nil || distance < best!.distance {
+                best = (corner, distance)
+            }
+        }
+        return best?.corner
+    }
+}

--- a/Rectangle/StackBadge/StackBadgeManager.swift
+++ b/Rectangle/StackBadge/StackBadgeManager.swift
@@ -30,7 +30,7 @@ class StackBadgeManager {
     private static let axTimeout: Float = 0.25
     // Clears the standard title-bar band (and its traffic lights) so the
     // badge and list sit below it in the window body.
-    private static let titleBarClearance: CGFloat = 30
+    private static let titleBarClearance: CGFloat = 35
 
     // A Timer polling NSEvent.mouseLocation is deliberate: a global
     // mouse-moved event monitor stops delivering events after sleep/wake,
@@ -240,7 +240,10 @@ class StackBadgeManager {
         badge.orderFrontRegardless()
         badgeWindow = badge
 
-        let list = Self.makeListWindow(windows: windows, corner: anchor, screenFrame: screenFrame) { [weak self] window in
+        // Open the list just below the badge (indented to sit under the peek)
+        // with a real gap, so the badge never overlaps the list's top.
+        let listTop = CGPoint(x: anchor.x + 12, y: badge.frame.minY - 6)
+        let list = Self.makeListWindow(windows: windows, listTop: listTop, screenFrame: screenFrame) { [weak self] window in
             self?.focus(window)
         }
         list.orderFrontRegardless()
@@ -291,32 +294,67 @@ class StackBadgeManager {
         }
     }
 
-    /// Click-through count pill sitting at the stack's top-left. Sized to fit
-    /// its contents so multi-digit counts never clip. Click-through
+    /// Click-through count pill sitting at the stack's top-left. A vibrancy
+    /// capsule with an SF Symbol stack glyph, matching the list's material so
+    /// badge and list read as one native element. Click-through
     /// (ignoresMouseEvents) since the list, not the badge, takes clicks.
     private static func makeBadgeWindow(count: Int, corner: CGPoint) -> NSWindow {
-        let label = NSTextField(labelWithString: "⧉ \(count)")
-        label.font = NSFont.monospacedDigitSystemFont(ofSize: 14, weight: .semibold)
-        label.textColor = .white
-        label.alignment = .center
+        let label = NSTextField(labelWithString: "\(count)")
+        label.font = NSFont.systemFont(ofSize: 13, weight: .semibold)
+        // Semantic color adapts with the (appearance-following) hudWindow
+        // material: dark on the light material in Light Mode, light on the
+        // dark material in Dark Mode. Hardcoded white washes out in Light.
+        label.textColor = .labelColor
         label.sizeToFit()
+        let labelW = ceil(label.frame.width)
+        let labelH = ceil(label.frame.height)
 
-        let size = NSSize(width: ceil(label.frame.width) + 16, height: 24)
+        // SF Symbol stack glyph on macOS 11+ (guarded exactly like the menu
+        // icons); pre-11 the pill is just the count.
+        var symbolView: NSImageView?
+        if #available(macOS 11, *),
+           let symbol = NSImage(systemSymbolName: "rectangle.stack.fill", accessibilityDescription: "stacked windows")?
+            .withSymbolConfiguration(.init(pointSize: 11, weight: .semibold)) {
+            let iv = NSImageView(image: symbol)
+            iv.contentTintColor = .labelColor
+            symbolView = iv
+        }
+        let symbolW: CGFloat = symbolView == nil ? 0 : 16
+        let gap: CGFloat = symbolView == nil ? 0 : 6
+
+        let hPad: CGFloat = 10
+        let height: CGFloat = 22
+        let size = NSSize(width: symbolW + gap + labelW + hPad * 2, height: height)
         let frame = NSRect(x: corner.x, y: corner.y - size.height, width: size.width, height: size.height)
+
         let window = NSWindow(contentRect: frame, styleMask: .borderless, backing: .buffered, defer: false)
         window.isOpaque = false
         window.backgroundColor = .clear
         window.level = .floating
-        window.hasShadow = false
+        window.hasShadow = true
         window.isReleasedWhenClosed = false
         window.collectionBehavior = [.transient, .ignoresCycle]
         window.ignoresMouseEvents = true
 
-        label.frame = NSRect(origin: .zero, size: size)
-        label.wantsLayer = true
-        label.layer?.backgroundColor = NSColor(white: 0.15, alpha: 0.92).cgColor
-        label.layer?.cornerRadius = 6
-        window.contentView = label
+        let effect = NSVisualEffectView(frame: NSRect(origin: .zero, size: size))
+        effect.material = .hudWindow
+        effect.blendingMode = .behindWindow
+        effect.state = .active
+        effect.wantsLayer = true
+        effect.layer?.cornerRadius = height / 2
+        effect.layer?.cornerCurve = .continuous
+        effect.layer?.masksToBounds = true
+
+        var x = hPad
+        if let symbolView {
+            symbolView.frame = NSRect(x: x, y: (height - 13) / 2, width: symbolW, height: 13)
+            effect.addSubview(symbolView)
+            x += symbolW + gap
+        }
+        label.frame = NSRect(x: x, y: (height - labelH) / 2, width: labelW, height: labelH)
+        effect.addSubview(label)
+
+        window.contentView = effect
         return window
     }
 
@@ -325,15 +363,16 @@ class StackBadgeManager {
     /// A non-activating panel so clicking a name doesn't activate Rectangle
     /// itself.
     private static func makeListWindow(windows: [StackedWindow],
-                                       corner: CGPoint,
+                                       listTop: CGPoint,
                                        screenFrame: CGRect,
                                        onSelect: @escaping (StackedWindow) -> Void) -> NSPanel {
         let rowHeight: CGFloat = 22
         let width: CGFloat = 260
         let padding: CGFloat = 4
         let height = CGFloat(windows.count) * rowHeight + padding * 2
-        var frame = NSRect(x: corner.x + 12,
-                           y: corner.y - 18 - height,
+        // listTop is the desired top-left of the list; it grows downward.
+        var frame = NSRect(x: listTop.x,
+                           y: listTop.y - height,
                            width: width,
                            height: height)
         if frame.maxX > screenFrame.maxX { frame.origin.x = screenFrame.maxX - frame.width }
@@ -352,9 +391,12 @@ class StackBadgeManager {
 
         let container = NSVisualEffectView(frame: NSRect(origin: .zero, size: frame.size))
         container.material = .hudWindow
+        container.blendingMode = .behindWindow
         container.state = .active
         container.wantsLayer = true
         container.layer?.cornerRadius = 8
+        container.layer?.cornerCurve = .continuous
+        container.layer?.masksToBounds = true
 
         for (index, window) in windows.enumerated() {
             let row = StackBadgeRowView(title: window.title, icon: appIcon(pid: window.pid)) {
@@ -397,13 +439,14 @@ private class StackBadgeRowView: NSView {
         super.init(frame: .zero)
         wantsLayer = true
         layer?.cornerRadius = 5
+        layer?.cornerCurve = .continuous
 
         let iconView = NSImageView(frame: NSRect(x: 6, y: 3, width: 16, height: 16))
         iconView.image = icon
         iconView.imageScaling = .scaleProportionallyUpOrDown
         addSubview(iconView)
 
-        textField.font = NSFont.systemFont(ofSize: 12)
+        textField.font = NSFont.systemFont(ofSize: 13)
         textField.textColor = .labelColor
         textField.lineBreakMode = .byTruncatingTail
         textField.autoresizingMask = [.width]

--- a/Rectangle/StackBadge/StackBadgeManager.swift
+++ b/Rectangle/StackBadge/StackBadgeManager.swift
@@ -369,14 +369,18 @@ class StackBadgeManager {
         let rowHeight: CGFloat = 22
         let width: CGFloat = 260
         let padding: CGFloat = 4
-        let height = CGFloat(windows.count) * rowHeight + padding * 2
-        // listTop is the desired top-left of the list; it grows downward.
+        let fullHeight = CGFloat(windows.count) * rowHeight + padding * 2
+        // Pin the top at listTop and grow DOWN. If the full list won't fit
+        // above the screen bottom, cap its height rather than clamping the
+        // origin upward - clamping upward would push the top back into the
+        // badge. (Overflow rows clip via the container's masksToBounds; only
+        // possible for a very tall stack pinned near the screen bottom.)
+        let height = min(fullHeight, max(0, listTop.y - screenFrame.minY))
         var frame = NSRect(x: listTop.x,
                            y: listTop.y - height,
                            width: width,
                            height: height)
         if frame.maxX > screenFrame.maxX { frame.origin.x = screenFrame.maxX - frame.width }
-        if frame.origin.y < screenFrame.minY { frame.origin.y = screenFrame.minY }
 
         let panel = NSPanel(contentRect: frame,
                             styleMask: [.borderless, .nonactivatingPanel],

--- a/Rectangle/StackBadge/StackBadgeManager.swift
+++ b/Rectangle/StackBadge/StackBadgeManager.swift
@@ -285,8 +285,13 @@ class StackBadgeManager {
     /// Resolves the window by pid directly (no shared window-list cache off
     /// the main thread), with AX timeouts so an unresponsive app can't hang
     /// the focus attempt.
+    ///
+    /// The list is deliberately NOT dismissed here, so you can click through
+    /// several windows in the stack in a row without re-opening it. It
+    /// dismisses when the cursor leaves the overlay (see tick()). Clicks keep
+    /// working even though another app is now frontmost because the rows opt
+    /// into first-mouse and the panel is non-activating.
     private func focus(_ window: StackedWindow) {
-        dismiss()
         DispatchQueue.global(qos: .userInitiated).async {
             let appElement = AccessibilityElement(window.pid)
             appElement.setMessagingTimeout(Self.axTimeout)

--- a/Rectangle/StackBadge/StackBadgeManager.swift
+++ b/Rectangle/StackBadge/StackBadgeManager.swift
@@ -104,9 +104,13 @@ class StackBadgeManager {
         else { return }
         dwellFired = true
 
+        // Gaps shift window origins away from the geometric grid corner, so
+        // the hover zone has to reach across the gap to the shifted peek.
+        let zone = Self.hoverZone + CGFloat(Defaults.gapSize.value)
+
         guard visibleUIFrames.isEmpty,
               let entry = (cornersByScreenFrame.first { NSPointInRect(location, $0.screenFrame) }),
-              let corner = StackBadgeGeometry.corner(near: location, in: entry.corners, zone: Self.hoverZone)
+              let corner = StackBadgeGeometry.corner(near: location, in: entry.corners, zone: zone)
         else { return }
 
         query(corner: corner, screenFrame: entry.screenFrame)
@@ -128,18 +132,40 @@ class StackBadgeManager {
         let maxCascade = CGFloat(min(5, max(1, Defaults.cyclingOverlapMaxCascade.value)))
         let cascadeRange = max(offsetSize, 1) * maxCascade + tolerance
 
-        let stacked = WindowUtil.getWindowList().filter { info in
+        // Gaps place a cell's window up to a full gap away from the
+        // geometric corner, so candidates are gathered from a widened box...
+        let gap = CGFloat(Defaults.gapSize.value)
+        let candidateRange = gap + cascadeRange
+
+        // The cascade offset is diagonal in x but can run either way in y
+        // (the offset is applied in AppKit coords, where +y converts to an
+        // upward move in AX space), so the y window is symmetric.
+        let candidates = WindowUtil.getWindowList().filter { info in
             guard info.level == kCGNormalWindowLevel else { return false }
             let coversScreen = info.frame.width > screenFrameAX.width * 0.9
                 && info.frame.height > screenFrameAX.height * 0.9
             guard !coversScreen else { return false }
             let dx = info.frame.origin.x - cornerAX.x
             let dy = info.frame.origin.y - cornerAX.y
-            return dx >= -tolerance && dx <= cascadeRange
-                && dy >= -tolerance && dy <= cascadeRange
+            return dx >= -tolerance && dx <= candidateRange
+                && dy >= -candidateRange && dy <= candidateRange
         }
 
-        guard stacked.count >= 2 else { return }
+        // ...and the stack is then clustered around the leftmost candidate,
+        // so the widened box doesn't count unrelated neighbors.
+        let stacked = StackBadgeGeometry
+            .stackIndices(among: candidates.map { $0.frame.origin }, cascadeRange: cascadeRange, tolerance: tolerance)
+            .map { candidates[$0] }
+
+        guard stacked.count >= 2,
+              let leftMost = (stacked.min { $0.frame.origin.x < $1.frame.origin.x }),
+              let topMost = (stacked.min { $0.frame.origin.y < $1.frame.origin.y })
+        else { return }
+
+        // The badge sits at the stack's visual top-left extremity - where
+        // the title bars start - not the geometric corner the gaps shifted
+        // the windows away from.
+        let anchorTopLeft = CGPoint(x: leftMost.frame.origin.x, y: topMost.frame.origin.y).screenFlipped
 
         let requestGeneration = generation
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -151,7 +177,7 @@ class StackBadgeManager {
             }
             DispatchQueue.main.async {
                 guard let self, self.generation == requestGeneration else { return }
-                self.show(windows: windows, corner: corner)
+                self.show(windows: windows, corner: anchorTopLeft)
             }
         }
     }

--- a/Rectangle/StackBadge/StackBadgeManager.swift
+++ b/Rectangle/StackBadge/StackBadgeManager.swift
@@ -247,15 +247,21 @@ class StackBadgeManager {
         listWindow = list
 
         // Keep-alive corridor: the UI sits titleBarClearance BELOW the peek
-        // where the cursor triggered it, so without this the cursor crosses
-        // dead space travelling down to the list and it dismisses. The
-        // corridor spans the UI's width from the list bottom up to the peek,
-        // so moving from trigger to list stays inside a live region.
+        // where the cursor triggered it, so without a bridge the cursor
+        // crosses dead space travelling down to it and it dismisses. The
+        // corridor spans only the gap between the peek and the TOP of the UI
+        // (the badge/list frames themselves are already live). Bounding it to
+        // that gap - rather than down to the list bottom - avoids a tall
+        // sticky column when the list is clamped to the screen bottom.
         let uiMinX = min(badge.frame.minX, list.frame.minX)
         let uiMaxX = max(badge.frame.maxX, list.frame.maxX)
-        let uiMinY = min(badge.frame.minY, list.frame.minY)
-        let corridor = CGRect(x: uiMinX, y: uiMinY,
-                              width: uiMaxX - uiMinX, height: corner.y - uiMinY)
+        // Bridge from the list's top edge up to the peek. Because the list's
+        // top sits a fixed distance below the peek (the clamp only ever
+        // pushes it UP, never down), this height is bounded - it never grows
+        // with the stack size, so no sticky column.
+        let corridorBottom = list.frame.maxY
+        let corridor = CGRect(x: uiMinX, y: corridorBottom,
+                              width: uiMaxX - uiMinX, height: max(0, corner.y - corridorBottom))
 
         visibleUIFrames = [badge.frame, list.frame, corridor]
     }
@@ -441,5 +447,18 @@ private class StackBadgeRowView: NSView {
         if bounds.contains(convert(event.locationInWindow, from: nil)) {
             onClick()
         }
+    }
+
+    // Route clicks anywhere in the row - including on the icon and the label
+    // subviews - to the row itself, so the whole row is one click target.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        return bounds.contains(convert(point, from: superview)) ? self : nil
+    }
+
+    // The list is a non-activating background panel, so without this the
+    // first click on a row (while another app is active) is swallowed as an
+    // activation click instead of focusing the window.
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        return true
     }
 }

--- a/Rectangle/StackBadge/StackBadgeManager.swift
+++ b/Rectangle/StackBadge/StackBadgeManager.swift
@@ -11,10 +11,10 @@ import Cocoa
 /// grid corner where multiple windows are stacked. Clicking a name brings
 /// that window forward.
 ///
-/// Deliberately stateless: nothing about windows is retained between dwells.
-/// Every dwell asks the window server fresh, so windows moving, closing, or
-/// changing screens through paths Rectangle doesn't control cannot leave
-/// stale UI behind.
+/// Deliberately stateless: nothing about windows or screens is retained
+/// between dwells. Every dwell asks the window server fresh, so windows
+/// moving, closing, or changing screens through paths Rectangle doesn't
+/// control cannot leave stale UI behind.
 class StackBadgeManager {
 
     struct StackedWindow {
@@ -27,17 +27,17 @@ class StackBadgeManager {
     private static let dwellInterval: TimeInterval = 0.25
     private static let hoverZone: CGFloat = 30
     private static let moveTolerance: CGFloat = 2
+    private static let axTimeout: Float = 0.25
 
+    // A Timer polling NSEvent.mouseLocation is deliberate: a global
+    // mouse-moved event monitor stops delivering events after sleep/wake,
+    // while the synchronous location read cannot. The tick is a coordinate
+    // comparison and only runs while the feature is enabled.
     private var timer: Timer?
     private var lastMouseLocation = CGPoint.zero
     private var lastMoveTime: TimeInterval = 0
     private var dwellFired = false
     private var generation = 0
-
-    /// Grid corner points per screen, in AppKit coordinates. Cached because
-    /// screen geometry - unlike window state - has a reliable invalidation
-    /// signal (didChangeScreenParametersNotification).
-    private var cornersByScreenFrame = [(screenFrame: CGRect, corners: [CGPoint])]()
 
     private var badgeWindow: NSWindow?
     private var listWindow: NSPanel?
@@ -48,11 +48,16 @@ class StackBadgeManager {
             forName: NSApplication.didChangeScreenParametersNotification,
             object: nil, queue: .main
         ) { [weak self] _ in
-            self?.rebuildCorners()
             self?.dismiss()
         }
         NotificationCenter.default.addObserver(
             forName: .stackBadgeChanged,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.toggleListening()
+        }
+        NotificationCenter.default.addObserver(
+            forName: .configImported,
             object: nil, queue: .main
         ) { [weak self] _ in
             self?.toggleListening()
@@ -63,7 +68,6 @@ class StackBadgeManager {
     private func toggleListening() {
         if Defaults.stackBadge.userEnabled {
             guard timer == nil else { return }
-            rebuildCorners()
             let timer = Timer.scheduledTimer(withTimeInterval: Self.tickInterval, repeats: true) { [weak self] _ in
                 self?.tick()
             }
@@ -73,13 +77,6 @@ class StackBadgeManager {
             timer?.invalidate()
             timer = nil
             dismiss()
-        }
-    }
-
-    private func rebuildCorners() {
-        cornersByScreenFrame = NSScreen.screens.map { screen in
-            let frame = screen.adjustedVisibleFrame()
-            return (frame, StackBadgeGeometry.cornerPoints(in: frame))
         }
     }
 
@@ -108,12 +105,19 @@ class StackBadgeManager {
         // the hover zone has to reach across the gap to the shifted peek.
         let zone = Self.hoverZone + CGFloat(Defaults.gapSize.value)
 
+        // Corner points are recomputed per dwell (a few hundred additions)
+        // rather than cached: adjustedVisibleFrame depends on more inputs
+        // than post didChangeScreenParametersNotification (Todo mode, Stage
+        // Manager, edge-gap defaults), so a cache has no reliable
+        // invalidation signal - the same reason window state isn't cached.
         guard visibleUIFrames.isEmpty,
-              let entry = (cornersByScreenFrame.first { NSPointInRect(location, $0.screenFrame) }),
-              let corner = StackBadgeGeometry.corner(near: location, in: entry.corners, zone: zone)
+              let screen = (NSScreen.screens.first { NSPointInRect(location, $0.frame) })
         else { return }
+        let screenFrame = screen.adjustedVisibleFrame()
+        let corners = StackBadgeGeometry.cornerPoints(in: screenFrame)
+        guard let corner = StackBadgeGeometry.corner(near: location, in: corners, zone: zone) else { return }
 
-        query(corner: corner, screenFrame: entry.screenFrame)
+        query(corner: corner, screenFrame: screenFrame)
     }
 
     private func isInsideVisibleUI(_ location: CGPoint) -> Bool {
@@ -151,8 +155,9 @@ class StackBadgeManager {
                 && dy >= -candidateRange && dy <= candidateRange
         }
 
-        // ...and the stack is then clustered around the leftmost candidate,
-        // so the widened box doesn't count unrelated neighbors.
+        // ...and the stack is the densest cascade cluster among them, so
+        // the widened box doesn't count unrelated neighbors and an
+        // unrelated leftmost window doesn't mask a real stack.
         let stacked = StackBadgeGeometry
             .stackIndices(among: candidates.map { $0.frame.origin }, cascadeRange: cascadeRange, tolerance: tolerance)
             .map { candidates[$0] }
@@ -169,24 +174,42 @@ class StackBadgeManager {
 
         let requestGeneration = generation
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let titles = Self.titlesByWindowId(for: stacked)
             // CGWindowList order is front to back; keep it for the list.
             let windows = stacked.map { info in
                 StackedWindow(windowId: info.id,
                               pid: info.pid,
-                              title: Self.title(for: info))
+                              title: Self.displayTitle(for: info, axTitle: titles[info.id]))
             }
             DispatchQueue.main.async {
-                guard let self, self.generation == requestGeneration else { return }
-                self.show(windows: windows, corner: anchorTopLeft)
+                guard let self,
+                      self.generation == requestGeneration,
+                      self.timer != nil
+                else { return }
+                self.show(windows: windows, corner: anchorTopLeft, screenFrame: screenFrame)
             }
         }
     }
 
-    private static func title(for info: WindowInfo) -> String {
-        let appElement = AccessibilityElement(info.pid)
-        appElement.setMessagingTimeout(0.25)
-        let windowElement = appElement.windowElements?.first { $0.windowId == info.id }
-        let title = windowElement?.title ?? ""
+    /// One AX window enumeration per application, however many of its
+    /// windows are in the stack.
+    private static func titlesByWindowId(for stacked: [WindowInfo]) -> [CGWindowID: String] {
+        var titles = [CGWindowID: String]()
+        for pid in Set(stacked.map { $0.pid }) {
+            let appElement = AccessibilityElement(pid)
+            appElement.setMessagingTimeout(axTimeout)
+            let stackedIds = Set(stacked.filter { $0.pid == pid }.map { $0.id })
+            for element in appElement.windowElements ?? [] {
+                if let id = element.windowId, stackedIds.contains(id) {
+                    titles[id] = element.title
+                }
+            }
+        }
+        return titles
+    }
+
+    private static func displayTitle(for info: WindowInfo, axTitle: String?) -> String {
+        let title = axTitle ?? ""
         let processName = info.processName ?? ""
         if title.isEmpty { return processName }
         if processName.isEmpty || title.hasPrefix(processName) { return title }
@@ -195,15 +218,15 @@ class StackBadgeManager {
 
     // MARK: - UI
 
-    private func show(windows: [StackedWindow], corner: CGPoint) {
+    private func show(windows: [StackedWindow], corner: CGPoint, screenFrame: CGRect) {
         dismiss()
 
         let badge = Self.makeBadgeWindow(count: windows.count, corner: corner)
         badge.orderFrontRegardless()
         badgeWindow = badge
 
-        let list = Self.makeListWindow(windows: windows, corner: corner) { [weak self] windowId in
-            self?.focus(windowId: windowId)
+        let list = Self.makeListWindow(windows: windows, corner: corner, screenFrame: screenFrame) { [weak self] window in
+            self?.focus(window)
         }
         list.orderFrontRegardless()
         listWindow = list
@@ -212,6 +235,9 @@ class StackBadgeManager {
     }
 
     private func dismiss() {
+        // Invalidate any in-flight title fetch so a stale result can't
+        // resurrect the UI after a dismissal.
+        generation += 1
         badgeWindow?.orderOut(nil)
         badgeWindow = nil
         listWindow?.orderOut(nil)
@@ -219,16 +245,23 @@ class StackBadgeManager {
         visibleUIFrames = []
     }
 
-    private func focus(windowId: CGWindowID) {
+    /// Resolves the window by pid directly (no shared window-list cache off
+    /// the main thread), with AX timeouts so an unresponsive app can't hang
+    /// the focus attempt.
+    private func focus(_ window: StackedWindow) {
         dismiss()
         DispatchQueue.global(qos: .userInitiated).async {
-            AccessibilityElement.getWindowElement(windowId)?.bringToFront(force: true)
+            let appElement = AccessibilityElement(window.pid)
+            appElement.setMessagingTimeout(Self.axTimeout)
+            guard let windowElement = (appElement.windowElements?.first { $0.windowId == window.windowId }) else { return }
+            windowElement.setMessagingTimeout(Self.axTimeout)
+            windowElement.bringToFront(force: true)
         }
     }
 
     /// Small click-through count pill sitting in the peek. Kept under 16pt
-    /// tall so it clears the front window's traffic lights, which the +11
-    /// offset pushes below the peek strip.
+    /// tall so it clears the front window's traffic lights, which the
+    /// offset pushes out of the peek strip.
     private static func makeBadgeWindow(count: Int, corner: CGPoint) -> NSWindow {
         let size = NSSize(width: 26, height: 15)
         let frame = NSRect(x: corner.x, y: corner.y - size.height, width: size.width, height: size.height)
@@ -254,19 +287,23 @@ class StackBadgeManager {
     }
 
     /// Clickable window-name list, opening downward from the peek into the
-    /// window body. A non-activating panel so clicking a name doesn't
-    /// activate Rectangle itself.
+    /// window body and clamped to the screen so every row stays reachable.
+    /// A non-activating panel so clicking a name doesn't activate Rectangle
+    /// itself.
     private static func makeListWindow(windows: [StackedWindow],
                                        corner: CGPoint,
-                                       onSelect: @escaping (CGWindowID) -> Void) -> NSPanel {
+                                       screenFrame: CGRect,
+                                       onSelect: @escaping (StackedWindow) -> Void) -> NSPanel {
         let rowHeight: CGFloat = 22
         let width: CGFloat = 260
         let padding: CGFloat = 4
         let height = CGFloat(windows.count) * rowHeight + padding * 2
-        let frame = NSRect(x: corner.x + 12,
+        var frame = NSRect(x: corner.x + 12,
                            y: corner.y - 18 - height,
                            width: width,
                            height: height)
+        if frame.maxX > screenFrame.maxX { frame.origin.x = screenFrame.maxX - frame.width }
+        if frame.origin.y < screenFrame.minY { frame.origin.y = screenFrame.minY }
 
         let panel = NSPanel(contentRect: frame,
                             styleMask: [.borderless, .nonactivatingPanel],
@@ -287,7 +324,7 @@ class StackBadgeManager {
 
         for (index, window) in windows.enumerated() {
             let button = StackBadgeRowButton(title: window.title) {
-                onSelect(window.windowId)
+                onSelect(window)
             }
             button.frame = NSRect(x: padding,
                                   y: frame.height - padding - CGFloat(index + 1) * rowHeight,

--- a/Rectangle/StackBadge/StackBadgeManager.swift
+++ b/Rectangle/StackBadge/StackBadgeManager.swift
@@ -23,11 +23,14 @@ class StackBadgeManager {
         let title: String
     }
 
-    private static let tickInterval: TimeInterval = 0.2
-    private static let dwellInterval: TimeInterval = 0.25
-    private static let hoverZone: CGFloat = 30
+    private static let tickInterval: TimeInterval = 0.1
+    private static let dwellInterval: TimeInterval = 0.15
+    private static let hoverZone: CGFloat = 48
     private static let moveTolerance: CGFloat = 2
     private static let axTimeout: Float = 0.25
+    // Clears the standard title-bar band (and its traffic lights) so the
+    // badge and list sit below it in the window body.
+    private static let titleBarClearance: CGFloat = 30
 
     // A Timer polling NSEvent.mouseLocation is deliberate: a global
     // mouse-moved event monitor stops delivering events after sleep/wake,
@@ -209,11 +212,18 @@ class StackBadgeManager {
     }
 
     private static func displayTitle(for info: WindowInfo, axTitle: String?) -> String {
-        let title = axTitle ?? ""
         let processName = info.processName ?? ""
-        if title.isEmpty { return processName }
-        if processName.isEmpty || title.hasPrefix(processName) { return title }
-        return "\(processName) — \(title)"
+        var title = axTitle ?? ""
+        // The row already shows the app's icon, so a leading app-name prefix
+        // ("Terminal — voice-bridge" -> "voice-bridge") is redundant. Strip it.
+        for separator in [" — ", " - ", ": "] where !processName.isEmpty {
+            let prefix = processName + separator
+            if title.hasPrefix(prefix) {
+                title = String(title.dropFirst(prefix.count))
+                break
+            }
+        }
+        return title.isEmpty ? processName : title
     }
 
     // MARK: - UI
@@ -221,17 +231,33 @@ class StackBadgeManager {
     private func show(windows: [StackedWindow], corner: CGPoint, screenFrame: CGRect) {
         dismiss()
 
-        let badge = Self.makeBadgeWindow(count: windows.count, corner: corner)
+        // Drop the badge and list below the window's title-bar band so the
+        // front window's traffic lights stay clickable. The buried windows'
+        // own lights are reached by clicking their name in the list.
+        let anchor = CGPoint(x: corner.x, y: corner.y - Self.titleBarClearance)
+
+        let badge = Self.makeBadgeWindow(count: windows.count, corner: anchor)
         badge.orderFrontRegardless()
         badgeWindow = badge
 
-        let list = Self.makeListWindow(windows: windows, corner: corner, screenFrame: screenFrame) { [weak self] window in
+        let list = Self.makeListWindow(windows: windows, corner: anchor, screenFrame: screenFrame) { [weak self] window in
             self?.focus(window)
         }
         list.orderFrontRegardless()
         listWindow = list
 
-        visibleUIFrames = [badge.frame, list.frame]
+        // Keep-alive corridor: the UI sits titleBarClearance BELOW the peek
+        // where the cursor triggered it, so without this the cursor crosses
+        // dead space travelling down to the list and it dismisses. The
+        // corridor spans the UI's width from the list bottom up to the peek,
+        // so moving from trigger to list stays inside a live region.
+        let uiMinX = min(badge.frame.minX, list.frame.minX)
+        let uiMaxX = max(badge.frame.maxX, list.frame.maxX)
+        let uiMinY = min(badge.frame.minY, list.frame.minY)
+        let corridor = CGRect(x: uiMinX, y: uiMinY,
+                              width: uiMaxX - uiMinX, height: corner.y - uiMinY)
+
+        visibleUIFrames = [badge.frame, list.frame, corridor]
     }
 
     private func dismiss() {
@@ -259,11 +285,17 @@ class StackBadgeManager {
         }
     }
 
-    /// Small click-through count pill sitting in the peek. Kept under 16pt
-    /// tall so it clears the front window's traffic lights, which the
-    /// offset pushes out of the peek strip.
+    /// Click-through count pill sitting at the stack's top-left. Sized to fit
+    /// its contents so multi-digit counts never clip. Click-through
+    /// (ignoresMouseEvents) since the list, not the badge, takes clicks.
     private static func makeBadgeWindow(count: Int, corner: CGPoint) -> NSWindow {
-        let size = NSSize(width: 26, height: 15)
+        let label = NSTextField(labelWithString: "⧉ \(count)")
+        label.font = NSFont.monospacedDigitSystemFont(ofSize: 14, weight: .semibold)
+        label.textColor = .white
+        label.alignment = .center
+        label.sizeToFit()
+
+        let size = NSSize(width: ceil(label.frame.width) + 16, height: 24)
         let frame = NSRect(x: corner.x, y: corner.y - size.height, width: size.width, height: size.height)
         let window = NSWindow(contentRect: frame, styleMask: .borderless, backing: .buffered, defer: false)
         window.isOpaque = false
@@ -274,14 +306,10 @@ class StackBadgeManager {
         window.collectionBehavior = [.transient, .ignoresCycle]
         window.ignoresMouseEvents = true
 
-        let label = NSTextField(labelWithString: "⧉ \(count)")
-        label.font = NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .semibold)
-        label.textColor = .white
-        label.alignment = .center
         label.frame = NSRect(origin: .zero, size: size)
         label.wantsLayer = true
         label.layer?.backgroundColor = NSColor(white: 0.15, alpha: 0.92).cgColor
-        label.layer?.cornerRadius = 5
+        label.layer?.cornerRadius = 6
         window.contentView = label
         return window
     }
@@ -323,42 +351,74 @@ class StackBadgeManager {
         container.layer?.cornerRadius = 8
 
         for (index, window) in windows.enumerated() {
-            let button = StackBadgeRowButton(title: window.title) {
+            let row = StackBadgeRowView(title: window.title, icon: appIcon(pid: window.pid)) {
                 onSelect(window)
             }
-            button.frame = NSRect(x: padding,
-                                  y: frame.height - padding - CGFloat(index + 1) * rowHeight,
-                                  width: width - padding * 2,
-                                  height: rowHeight)
-            container.addSubview(button)
+            row.frame = NSRect(x: padding,
+                               y: frame.height - padding - CGFloat(index + 1) * rowHeight,
+                               width: width - padding * 2,
+                               height: rowHeight)
+            container.addSubview(row)
         }
 
         panel.contentView = container
         return panel
     }
+
+    /// The running app's icon, drawn down to a crisp row-sized copy so the
+    /// shared full-resolution icon isn't mutated.
+    private static func appIcon(pid: pid_t) -> NSImage? {
+        guard let icon = NSRunningApplication(processIdentifier: pid)?.icon else { return nil }
+        let size = NSSize(width: 16, height: 16)
+        let resized = NSImage(size: size)
+        resized.lockFocus()
+        icon.draw(in: NSRect(origin: .zero, size: size))
+        resized.unlockFocus()
+        return resized
+    }
 }
 
-/// A flat, left-aligned row button with a hover highlight.
-private class StackBadgeRowButton: NSButton {
+/// A single window row: app icon, then the window name. Highlights like a
+/// native menu row - the system selection color with white text - when the
+/// cursor is over it, and invokes its action on click.
+private class StackBadgeRowView: NSView {
     private let onClick: () -> Void
+    private let textField: NSTextField
 
-    init(title: String, onClick: @escaping () -> Void) {
+    init(title: String, icon: NSImage?, onClick: @escaping () -> Void) {
         self.onClick = onClick
+        self.textField = NSTextField(labelWithString: title)
         super.init(frame: .zero)
-        self.title = title
-        isBordered = false
-        alignment = .left
-        lineBreakMode = .byTruncatingTail
-        font = NSFont.systemFont(ofSize: 12)
-        contentTintColor = .labelColor
         wantsLayer = true
         layer?.cornerRadius = 5
-        target = self
-        action = #selector(clicked)
+
+        let iconView = NSImageView(frame: NSRect(x: 6, y: 3, width: 16, height: 16))
+        iconView.image = icon
+        iconView.imageScaling = .scaleProportionallyUpOrDown
+        addSubview(iconView)
+
+        textField.font = NSFont.systemFont(ofSize: 12)
+        textField.textColor = .labelColor
+        textField.lineBreakMode = .byTruncatingTail
+        textField.autoresizingMask = [.width]
+        addSubview(textField)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layout() {
+        super.layout()
+        let x: CGFloat = 28
+        let height: CGFloat = 16
+        textField.frame = NSRect(x: x, y: (bounds.height - height) / 2,
+                                 width: bounds.width - x - 6, height: height)
+    }
+
+    private func setSelected(_ selected: Bool) {
+        layer?.backgroundColor = selected ? NSColor.selectedContentBackgroundColor.cgColor : nil
+        textField.textColor = selected ? .selectedMenuItemTextColor : .labelColor
     }
 
     override func updateTrackingAreas() {
@@ -370,14 +430,16 @@ private class StackBadgeRowButton: NSButton {
     }
 
     override func mouseEntered(with event: NSEvent) {
-        layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.15).cgColor
+        setSelected(true)
     }
 
     override func mouseExited(with event: NSEvent) {
-        layer?.backgroundColor = nil
+        setSelected(false)
     }
 
-    @objc private func clicked() {
-        onClick()
+    override func mouseUp(with event: NSEvent) {
+        if bounds.contains(convert(event.locationInWindow, from: nil)) {
+            onClick()
+        }
     }
 }

--- a/Rectangle/StackBadge/StackBadgeManager.swift
+++ b/Rectangle/StackBadge/StackBadgeManager.swift
@@ -1,0 +1,320 @@
+//
+//  StackBadgeManager.swift
+//  Rectangle
+//
+//  Copyright © 2026 Ryan Hanson. All rights reserved.
+//
+
+import Cocoa
+
+/// Shows a small badge and a window-name list when the cursor dwells on a
+/// grid corner where multiple windows are stacked. Clicking a name brings
+/// that window forward.
+///
+/// Deliberately stateless: nothing about windows is retained between dwells.
+/// Every dwell asks the window server fresh, so windows moving, closing, or
+/// changing screens through paths Rectangle doesn't control cannot leave
+/// stale UI behind.
+class StackBadgeManager {
+
+    struct StackedWindow {
+        let windowId: CGWindowID
+        let pid: pid_t
+        let title: String
+    }
+
+    private static let tickInterval: TimeInterval = 0.2
+    private static let dwellInterval: TimeInterval = 0.25
+    private static let hoverZone: CGFloat = 30
+    private static let moveTolerance: CGFloat = 2
+
+    private var timer: Timer?
+    private var lastMouseLocation = CGPoint.zero
+    private var lastMoveTime: TimeInterval = 0
+    private var dwellFired = false
+    private var generation = 0
+
+    /// Grid corner points per screen, in AppKit coordinates. Cached because
+    /// screen geometry - unlike window state - has a reliable invalidation
+    /// signal (didChangeScreenParametersNotification).
+    private var cornersByScreenFrame = [(screenFrame: CGRect, corners: [CGPoint])]()
+
+    private var badgeWindow: NSWindow?
+    private var listWindow: NSPanel?
+    private var visibleUIFrames = [CGRect]()
+
+    init() {
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.rebuildCorners()
+            self?.dismiss()
+        }
+        NotificationCenter.default.addObserver(
+            forName: .stackBadgeChanged,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.toggleListening()
+        }
+        toggleListening()
+    }
+
+    private func toggleListening() {
+        if Defaults.stackBadge.userEnabled {
+            guard timer == nil else { return }
+            rebuildCorners()
+            let timer = Timer.scheduledTimer(withTimeInterval: Self.tickInterval, repeats: true) { [weak self] _ in
+                self?.tick()
+            }
+            timer.tolerance = 0.05
+            self.timer = timer
+        } else {
+            timer?.invalidate()
+            timer = nil
+            dismiss()
+        }
+    }
+
+    private func rebuildCorners() {
+        cornersByScreenFrame = NSScreen.screens.map { screen in
+            let frame = screen.adjustedVisibleFrame()
+            return (frame, StackBadgeGeometry.cornerPoints(in: frame))
+        }
+    }
+
+    private func tick() {
+        let location = NSEvent.mouseLocation
+        let dx = location.x - lastMouseLocation.x
+        let dy = location.y - lastMouseLocation.y
+
+        if abs(dx) > Self.moveTolerance || abs(dy) > Self.moveTolerance {
+            lastMouseLocation = location
+            lastMoveTime = ProcessInfo.processInfo.systemUptime
+            dwellFired = false
+            generation += 1
+            if !visibleUIFrames.isEmpty, !isInsideVisibleUI(location) {
+                dismiss()
+            }
+            return
+        }
+
+        guard !dwellFired,
+              ProcessInfo.processInfo.systemUptime - lastMoveTime >= Self.dwellInterval
+        else { return }
+        dwellFired = true
+
+        guard visibleUIFrames.isEmpty,
+              let entry = (cornersByScreenFrame.first { NSPointInRect(location, $0.screenFrame) }),
+              let corner = StackBadgeGeometry.corner(near: location, in: entry.corners, zone: Self.hoverZone)
+        else { return }
+
+        query(corner: corner, screenFrame: entry.screenFrame)
+    }
+
+    private func isInsideVisibleUI(_ location: CGPoint) -> Bool {
+        visibleUIFrames.contains { $0.insetBy(dx: -8, dy: -8).contains(location) }
+    }
+
+    /// One fresh look at reality per dwell. The count comes from the window
+    /// server (CGWindowList - cannot block on an unresponsive app); AX is
+    /// touched only to read the titles of the few windows that matched, off
+    /// the main thread, discarded if the cursor has moved on.
+    private func query(corner: CGPoint, screenFrame: CGRect) {
+        let cornerAX = corner.screenFlipped
+        let screenFrameAX = screenFrame.screenFlipped
+        let tolerance: CGFloat = 4
+        let offsetSize = CGFloat(Defaults.cyclingOverlapOffsetSize.value)
+        let maxCascade = CGFloat(min(5, max(1, Defaults.cyclingOverlapMaxCascade.value)))
+        let cascadeRange = max(offsetSize, 1) * maxCascade + tolerance
+
+        let stacked = WindowUtil.getWindowList().filter { info in
+            guard info.level == kCGNormalWindowLevel else { return false }
+            let coversScreen = info.frame.width > screenFrameAX.width * 0.9
+                && info.frame.height > screenFrameAX.height * 0.9
+            guard !coversScreen else { return false }
+            let dx = info.frame.origin.x - cornerAX.x
+            let dy = info.frame.origin.y - cornerAX.y
+            return dx >= -tolerance && dx <= cascadeRange
+                && dy >= -tolerance && dy <= cascadeRange
+        }
+
+        guard stacked.count >= 2 else { return }
+
+        let requestGeneration = generation
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            // CGWindowList order is front to back; keep it for the list.
+            let windows = stacked.map { info in
+                StackedWindow(windowId: info.id,
+                              pid: info.pid,
+                              title: Self.title(for: info))
+            }
+            DispatchQueue.main.async {
+                guard let self, self.generation == requestGeneration else { return }
+                self.show(windows: windows, corner: corner)
+            }
+        }
+    }
+
+    private static func title(for info: WindowInfo) -> String {
+        let appElement = AccessibilityElement(info.pid)
+        appElement.setMessagingTimeout(0.25)
+        let windowElement = appElement.windowElements?.first { $0.windowId == info.id }
+        let title = windowElement?.title ?? ""
+        let processName = info.processName ?? ""
+        if title.isEmpty { return processName }
+        if processName.isEmpty || title.hasPrefix(processName) { return title }
+        return "\(processName) — \(title)"
+    }
+
+    // MARK: - UI
+
+    private func show(windows: [StackedWindow], corner: CGPoint) {
+        dismiss()
+
+        let badge = Self.makeBadgeWindow(count: windows.count, corner: corner)
+        badge.orderFrontRegardless()
+        badgeWindow = badge
+
+        let list = Self.makeListWindow(windows: windows, corner: corner) { [weak self] windowId in
+            self?.focus(windowId: windowId)
+        }
+        list.orderFrontRegardless()
+        listWindow = list
+
+        visibleUIFrames = [badge.frame, list.frame]
+    }
+
+    private func dismiss() {
+        badgeWindow?.orderOut(nil)
+        badgeWindow = nil
+        listWindow?.orderOut(nil)
+        listWindow = nil
+        visibleUIFrames = []
+    }
+
+    private func focus(windowId: CGWindowID) {
+        dismiss()
+        DispatchQueue.global(qos: .userInitiated).async {
+            AccessibilityElement.getWindowElement(windowId)?.bringToFront(force: true)
+        }
+    }
+
+    /// Small click-through count pill sitting in the peek. Kept under 16pt
+    /// tall so it clears the front window's traffic lights, which the +11
+    /// offset pushes below the peek strip.
+    private static func makeBadgeWindow(count: Int, corner: CGPoint) -> NSWindow {
+        let size = NSSize(width: 26, height: 15)
+        let frame = NSRect(x: corner.x, y: corner.y - size.height, width: size.width, height: size.height)
+        let window = NSWindow(contentRect: frame, styleMask: .borderless, backing: .buffered, defer: false)
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.level = .floating
+        window.hasShadow = false
+        window.isReleasedWhenClosed = false
+        window.collectionBehavior = [.transient, .ignoresCycle]
+        window.ignoresMouseEvents = true
+
+        let label = NSTextField(labelWithString: "⧉ \(count)")
+        label.font = NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .semibold)
+        label.textColor = .white
+        label.alignment = .center
+        label.frame = NSRect(origin: .zero, size: size)
+        label.wantsLayer = true
+        label.layer?.backgroundColor = NSColor(white: 0.15, alpha: 0.92).cgColor
+        label.layer?.cornerRadius = 5
+        window.contentView = label
+        return window
+    }
+
+    /// Clickable window-name list, opening downward from the peek into the
+    /// window body. A non-activating panel so clicking a name doesn't
+    /// activate Rectangle itself.
+    private static func makeListWindow(windows: [StackedWindow],
+                                       corner: CGPoint,
+                                       onSelect: @escaping (CGWindowID) -> Void) -> NSPanel {
+        let rowHeight: CGFloat = 22
+        let width: CGFloat = 260
+        let padding: CGFloat = 4
+        let height = CGFloat(windows.count) * rowHeight + padding * 2
+        let frame = NSRect(x: corner.x + 12,
+                           y: corner.y - 18 - height,
+                           width: width,
+                           height: height)
+
+        let panel = NSPanel(contentRect: frame,
+                            styleMask: [.borderless, .nonactivatingPanel],
+                            backing: .buffered,
+                            defer: false)
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.level = .floating
+        panel.hasShadow = true
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.transient, .ignoresCycle]
+
+        let container = NSVisualEffectView(frame: NSRect(origin: .zero, size: frame.size))
+        container.material = .hudWindow
+        container.state = .active
+        container.wantsLayer = true
+        container.layer?.cornerRadius = 8
+
+        for (index, window) in windows.enumerated() {
+            let button = StackBadgeRowButton(title: window.title) {
+                onSelect(window.windowId)
+            }
+            button.frame = NSRect(x: padding,
+                                  y: frame.height - padding - CGFloat(index + 1) * rowHeight,
+                                  width: width - padding * 2,
+                                  height: rowHeight)
+            container.addSubview(button)
+        }
+
+        panel.contentView = container
+        return panel
+    }
+}
+
+/// A flat, left-aligned row button with a hover highlight.
+private class StackBadgeRowButton: NSButton {
+    private let onClick: () -> Void
+
+    init(title: String, onClick: @escaping () -> Void) {
+        self.onClick = onClick
+        super.init(frame: .zero)
+        self.title = title
+        isBordered = false
+        alignment = .left
+        lineBreakMode = .byTruncatingTail
+        font = NSFont.systemFont(ofSize: 12)
+        contentTintColor = .labelColor
+        wantsLayer = true
+        layer?.cornerRadius = 5
+        target = self
+        action = #selector(clicked)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        trackingAreas.forEach(removeTrackingArea)
+        addTrackingArea(NSTrackingArea(rect: bounds,
+                                       options: [.mouseEnteredAndExited, .activeAlways],
+                                       owner: self))
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.15).cgColor
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        layer?.backgroundColor = nil
+    }
+
+    @objc private func clicked() {
+        onClick()
+    }
+}

--- a/Rectangle/StackBadge/StackBadgeManager.swift
+++ b/Rectangle/StackBadge/StackBadgeManager.swift
@@ -28,9 +28,11 @@ class StackBadgeManager {
     private static let hoverZone: CGFloat = 48
     private static let moveTolerance: CGFloat = 2
     private static let axTimeout: Float = 0.25
-    // Clears the standard title-bar band (and its traffic lights) so the
-    // badge and list sit below it in the window body.
-    private static let titleBarClearance: CGFloat = 35
+    // Drops the badge and list below the window's top chrome so the traffic
+    // lights stay clickable and the list clears typical toolbars (e.g. a
+    // browser's tab bar + URL bar). A fixed value since there's no general
+    // way to know an arbitrary app's toolbar height.
+    private static let titleBarClearance: CGFloat = 50
 
     // A Timer polling NSEvent.mouseLocation is deliberate: a global
     // mouse-moved event monitor stops delivering events after sleep/wake,
@@ -300,7 +302,7 @@ class StackBadgeManager {
     /// (ignoresMouseEvents) since the list, not the badge, takes clicks.
     private static func makeBadgeWindow(count: Int, corner: CGPoint) -> NSWindow {
         let label = NSTextField(labelWithString: "\(count)")
-        label.font = NSFont.systemFont(ofSize: 13, weight: .semibold)
+        label.font = NSFont.systemFont(ofSize: 15, weight: .semibold)
         // Semantic color adapts with the (appearance-following) hudWindow
         // material: dark on the light material in Light Mode, light on the
         // dark material in Dark Mode. Hardcoded white washes out in Light.
@@ -314,16 +316,17 @@ class StackBadgeManager {
         var symbolView: NSImageView?
         if #available(macOS 11, *),
            let symbol = NSImage(systemSymbolName: "rectangle.stack.fill", accessibilityDescription: "stacked windows")?
-            .withSymbolConfiguration(.init(pointSize: 11, weight: .semibold)) {
+            .withSymbolConfiguration(.init(pointSize: 14, weight: .semibold)) {
             let iv = NSImageView(image: symbol)
             iv.contentTintColor = .labelColor
             symbolView = iv
         }
-        let symbolW: CGFloat = symbolView == nil ? 0 : 16
-        let gap: CGFloat = symbolView == nil ? 0 : 6
+        let symbolW: CGFloat = symbolView == nil ? 0 : 19
+        let symbolH: CGFloat = 16
+        let gap: CGFloat = symbolView == nil ? 0 : 7
 
-        let hPad: CGFloat = 10
-        let height: CGFloat = 22
+        let hPad: CGFloat = 12
+        let height: CGFloat = 28
         let size = NSSize(width: symbolW + gap + labelW + hPad * 2, height: height)
         let frame = NSRect(x: corner.x, y: corner.y - size.height, width: size.width, height: size.height)
 
@@ -347,7 +350,7 @@ class StackBadgeManager {
 
         var x = hPad
         if let symbolView {
-            symbolView.frame = NSRect(x: x, y: (height - 13) / 2, width: symbolW, height: 13)
+            symbolView.frame = NSRect(x: x, y: (height - symbolH) / 2, width: symbolW, height: symbolH)
             effect.addSubview(symbolView)
             x += symbolW + gap
         }

--- a/Rectangle/StackBadge/StackBadgeManager.swift
+++ b/Rectangle/StackBadge/StackBadgeManager.swift
@@ -301,17 +301,17 @@ class StackBadgeManager {
         }
     }
 
-    /// Click-through count pill sitting at the stack's top-left. A vibrancy
-    /// capsule with an SF Symbol stack glyph, matching the list's material so
-    /// badge and list read as one native element. Click-through
-    /// (ignoresMouseEvents) since the list, not the badge, takes clicks.
+    /// Click-through count pill at the stack's top-left: a solid accent-color
+    /// capsule with an SF Symbol stack glyph, sized to fit its contents. The
+    /// accent fill makes it stand out against arbitrary window content.
+    /// Click-through (ignoresMouseEvents) since the list, not the badge,
+    /// takes clicks.
     private static func makeBadgeWindow(count: Int, corner: CGPoint) -> NSWindow {
         let label = NSTextField(labelWithString: "\(count)")
         label.font = NSFont.systemFont(ofSize: 15, weight: .semibold)
-        // Semantic color adapts with the (appearance-following) hudWindow
-        // material: dark on the light material in Light Mode, light on the
-        // dark material in Dark Mode. Hardcoded white washes out in Light.
-        label.textColor = .labelColor
+        // White reads on the saturated accent fill in both appearances - the
+        // standard pairing for accent-colored controls.
+        label.textColor = .white
         label.sizeToFit()
         let labelW = ceil(label.frame.width)
         let labelH = ceil(label.frame.height)
@@ -323,7 +323,7 @@ class StackBadgeManager {
            let symbol = NSImage(systemSymbolName: "rectangle.stack.fill", accessibilityDescription: "stacked windows")?
             .withSymbolConfiguration(.init(pointSize: 14, weight: .semibold)) {
             let iv = NSImageView(image: symbol)
-            iv.contentTintColor = .labelColor
+            iv.contentTintColor = .white
             symbolView = iv
         }
         let symbolW: CGFloat = symbolView == nil ? 0 : 19
@@ -344,25 +344,25 @@ class StackBadgeManager {
         window.collectionBehavior = [.transient, .ignoresCycle]
         window.ignoresMouseEvents = true
 
-        let effect = NSVisualEffectView(frame: NSRect(origin: .zero, size: size))
-        effect.material = .hudWindow
-        effect.blendingMode = .behindWindow
-        effect.state = .active
-        effect.wantsLayer = true
-        effect.layer?.cornerRadius = height / 2
-        effect.layer?.cornerCurve = .continuous
-        effect.layer?.masksToBounds = true
+        let container = NSView(frame: NSRect(origin: .zero, size: size))
+        container.wantsLayer = true
+        // Solid accent-color capsule (the user's chosen system accent) so the
+        // badge stands out against window content.
+        container.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
+        container.layer?.cornerRadius = height / 2
+        container.layer?.cornerCurve = .continuous
+        container.layer?.masksToBounds = true
 
         var x = hPad
         if let symbolView {
             symbolView.frame = NSRect(x: x, y: (height - symbolH) / 2, width: symbolW, height: symbolH)
-            effect.addSubview(symbolView)
+            container.addSubview(symbolView)
             x += symbolW + gap
         }
         label.frame = NSRect(x: x, y: (height - labelH) / 2, width: labelW, height: labelH)
-        effect.addSubview(label)
+        container.addSubview(label)
 
-        window.contentView = effect
+        window.contentView = container
         return window
     }
 

--- a/Rectangle/Utilities/NotificationExtension.swift
+++ b/Rectangle/Utilities/NotificationExtension.swift
@@ -19,6 +19,7 @@ extension Notification.Name {
     static let updateAvailability = Notification.Name("updateAvailability")
     static let showAdditionalSizesInMenuChanged = Notification.Name("showAdditionalSizesInMenuChanged")
     static let shortcutRecording = Notification.Name("shortcutRecording")
+    static let stackBadgeChanged = Notification.Name("stackBadgeChanged")
 
     func post(
         center: NotificationCenter = NotificationCenter.default,

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -38897,6 +38897,9 @@
         }
       }
     },
+    "Show stacked window badge on hover" : {
+
+    },
     "Side Split Ratio" : {
       "localizations" : {
         "ko" : {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -216,6 +216,47 @@ class StackBadgeGeometryTests: XCTestCase {
         let hit = StackBadgeGeometry.corner(near: CGPoint(x: 105, y: 495), in: [far, near], zone: 30)
         XCTAssertEqual(hit, near)
     }
+
+    // Regression: the cascade offset runs +x but UP in AX y (it's applied in
+    // AppKit coordinates and the y-axis flips), so clustering must accept
+    // origins above the anchor. Real-world origins from a two-window stack
+    // that the first implementation failed to count.
+    func testStackClusterAcceptsUpwardCascade() {
+        let origins = [CGPoint(x: 903, y: -2121), CGPoint(x: 892, y: -2110)]
+        let indices = StackBadgeGeometry.stackIndices(among: origins, cascadeRange: 15, tolerance: 4)
+        XCTAssertEqual(indices.count, 2)
+    }
+
+    // Regression: with maxCascade capped at 1, the second and third windows
+    // share an origin. All three belong to the stack.
+    func testStackClusterCountsCascadeCapSharedOrigins() {
+        let origins = [
+            CGPoint(x: 903, y: -2121),
+            CGPoint(x: 903, y: -2121),
+            CGPoint(x: 892, y: -2110)
+        ]
+        let indices = StackBadgeGeometry.stackIndices(among: origins, cascadeRange: 15, tolerance: 4)
+        XCTAssertEqual(indices.count, 3)
+    }
+
+    func testStackClusterExcludesUnrelatedNeighbor() {
+        // A window 30pt away from the anchor is a neighbor, not a stack member,
+        // even though a gap-widened candidate box may have caught it.
+        let origins = [CGPoint(x: 100, y: 100), CGPoint(x: 111, y: 89), CGPoint(x: 130, y: 130)]
+        let indices = StackBadgeGeometry.stackIndices(among: origins, cascadeRange: 15, tolerance: 4)
+        XCTAssertEqual(indices.sorted(), [0, 1])
+    }
+
+    func testStackClusterAcceptsDownwardCascade() {
+        // Edge clamping can flip the cascade direction locally; both must count.
+        let origins = [CGPoint(x: 100, y: 100), CGPoint(x: 111, y: 111)]
+        let indices = StackBadgeGeometry.stackIndices(among: origins, cascadeRange: 15, tolerance: 4)
+        XCTAssertEqual(indices.count, 2)
+    }
+
+    func testStackClusterEmptyInput() {
+        XCTAssertTrue(StackBadgeGeometry.stackIndices(among: [], cascadeRange: 15, tolerance: 4).isEmpty)
+    }
 }
 
 class CooperativeCornerResizeTests: XCTestCase {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -142,6 +142,79 @@ class DefaultsExportTests: XCTestCase {
         XCTAssertTrue(keys.contains("cyclingOverlapOffsetSize"), "cyclingOverlapOffsetSize missing from Defaults.array")
         XCTAssertTrue(keys.contains("cyclingOverlapMaxCascade"), "cyclingOverlapMaxCascade missing from Defaults.array")
         XCTAssertTrue(keys.contains("cooperativeCornerResize"), "cooperativeCornerResize missing from Defaults.array")
+        XCTAssertTrue(keys.contains("stackBadge"), "stackBadge missing from Defaults.array")
+    }
+}
+
+class StackBadgeGeometryTests: XCTestCase {
+
+    private let laptopFrame = CGRect(x: 0, y: 0, width: 2336, height: 1510)
+    // Real rig geometry: external 4K TVs with negative origins.
+    private let tvFrame = CGRect(x: -5212, y: 1510, width: 3840, height: 2160)
+
+    func testCornerCountMatchesUnionOfGridFractions() {
+        // Column fractions across all grids: 0, 1/4, 1/3, 1/2, 2/3, 3/4 (6 values).
+        // Row fractions are the same set. 6 x 6 = 36 unique corners.
+        let corners = StackBadgeGeometry.cornerPoints(in: laptopFrame)
+        XCTAssertEqual(corners.count, 36)
+    }
+
+    func testCoincidentCornersAreDeduplicated() {
+        // The half corner and the quarter corner at x = width/2 coincide;
+        // they must appear once, not once per grid.
+        let corners = StackBadgeGeometry.cornerPoints(in: laptopFrame)
+        let midTop = corners.filter { abs($0.x - 1168) < 1 && abs($0.y - 1510) < 1 }
+        XCTAssertEqual(midTop.count, 1)
+    }
+
+    func testScreenOriginIsACorner() {
+        let corners = StackBadgeGeometry.cornerPoints(in: laptopFrame)
+        XCTAssertTrue(corners.contains { abs($0.x - 0) < 1 && abs($0.y - 1510) < 1 },
+                      "top-left of the screen must be a corner")
+    }
+
+    func testFarEdgesAreNotCorners() {
+        // A cell's top-left can never sit on the right or bottom screen edge.
+        let corners = StackBadgeGeometry.cornerPoints(in: laptopFrame)
+        XCTAssertFalse(corners.contains { abs($0.x - laptopFrame.maxX) < 1 })
+        XCTAssertFalse(corners.contains { abs($0.y - laptopFrame.minY) < 1 })
+    }
+
+    func testNegativeOriginScreenCorners() {
+        let corners = StackBadgeGeometry.cornerPoints(in: tvFrame)
+        XCTAssertEqual(corners.count, 36)
+        XCTAssertTrue(corners.contains { abs($0.x - (-5212)) < 1 && abs($0.y - 3670) < 1 },
+                      "top-left corner of a negative-origin screen")
+        XCTAssertTrue(corners.contains { abs($0.x - (-5212 + 3840.0 / 3)) < 1 && abs($0.y - (3670 - 2160.0 / 3)) < 1 },
+                      "interior ninth corner on a negative-origin screen")
+    }
+
+    func testEmptyFrameYieldsNoCorners() {
+        XCTAssertTrue(StackBadgeGeometry.cornerPoints(in: .zero).isEmpty)
+        XCTAssertTrue(StackBadgeGeometry.cornerPoints(in: .null).isEmpty)
+    }
+
+    func testHoverZoneHitInsideZone() {
+        let corners = [CGPoint(x: 100, y: 500)]
+        // 20pt right, 20pt below (AppKit y down = minus y) - inside a 30pt zone.
+        let hit = StackBadgeGeometry.corner(near: CGPoint(x: 120, y: 480), in: corners, zone: 30)
+        XCTAssertEqual(hit, corners[0])
+    }
+
+    func testHoverZoneMissOutsideZone() {
+        let corners = [CGPoint(x: 100, y: 500)]
+        XCTAssertNil(StackBadgeGeometry.corner(near: CGPoint(x: 140, y: 480), in: corners, zone: 30))
+        // Above the corner is the neighboring cell - must not trigger.
+        XCTAssertNil(StackBadgeGeometry.corner(near: CGPoint(x: 110, y: 520), in: corners, zone: 30))
+        // Left of the corner is the neighboring cell - must not trigger.
+        XCTAssertNil(StackBadgeGeometry.corner(near: CGPoint(x: 80, y: 490), in: corners, zone: 30))
+    }
+
+    func testHoverZonePicksNearestOfTwoCandidates() {
+        let near = CGPoint(x: 100, y: 500)
+        let far = CGPoint(x: 90, y: 510)
+        let hit = StackBadgeGeometry.corner(near: CGPoint(x: 105, y: 495), in: [far, near], zone: 30)
+        XCTAssertEqual(hit, near)
     }
 }
 

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -257,6 +257,18 @@ class StackBadgeGeometryTests: XCTestCase {
     func testStackClusterEmptyInput() {
         XCTAssertTrue(StackBadgeGeometry.stackIndices(among: [], cascadeRange: 15, tolerance: 4).isEmpty)
     }
+
+    // Regression (review finding): an unrelated window that happens to be the
+    // leftmost candidate in the gap-widened box must not mask the real stack.
+    func testStackClusterLeftOutlierDoesNotMaskStack() {
+        let origins = [
+            CGPoint(x: 100, y: 105),   // unrelated leftmost outlier
+            CGPoint(x: 120, y: 100),   // buried
+            CGPoint(x: 131, y: 89)     // front (cascade +11, -11)
+        ]
+        let indices = StackBadgeGeometry.stackIndices(among: origins, cascadeRange: 15, tolerance: 4)
+        XCTAssertEqual(indices.sorted(), [1, 2])
+    }
 }
 
 class CooperativeCornerResizeTests: XCTestCase {

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -540,6 +540,14 @@ By default, only one cascade layer is shown (the original window plus one offset
 defaults write com.knollsoft.Rectangle cyclingOverlapMaxCascade -int 3
 ```
 
+## Show a badge with the stacked windows when hovering over a grid corner
+
+When multiple windows are stacked at the same grid position, resting the cursor on that position's top-left corner shows a small badge with the stack count and a list of the window names. Clicking a name brings that window forward.
+
+```bash
+defaults write com.knollsoft.Rectangle stackBadge -bool true
+```
+
 ## Move windows that can't fill the snap area to the edge
 
 Some windows can't be resized to fill a snap area — either because they're a fixed size, or because they're resizable but have a maximum size or a fixed aspect ratio (FaceTime is a common example). By default such a window aligns to the snap area's screen edge(s): a right-half snap anchors flush right, a corner snap anchors into the corner, and the window stays centered on any axis it can't fill. To choose a different behavior:


### PR DESCRIPTION
Follow-on to #1762 (grid-position overlap offset). On that PR you mentioned looking forward to the hover count badge idea as a follow-on — here it is.

## What it does

When the overlap offset stacks multiple windows at the same grid position, resting the cursor on the stack's top-left corner shows a small count badge and a list of the stacked windows — each with its app icon and title. Click a name to bring that window forward.

It turns overlap from something you can't see into a lightweight switcher for that grid slot. On a laptop or small screen where you can't spread windows out, a stack of tiles plus this becomes a de-facto tab bar for the spot.

## Opt-in and unobtrusive

- **Off by default**, behind a new `stackBadge` hidden default, with a checkbox ("Show stacked window badge on hover") in the General-tab additional-settings popover next to the overlap-offset toggle, and an entry in `TerminalCommands.md`.
- **Hover-only** — nothing on screen at rest.
- The badge is click-through and sits below the title-bar band, so the window's traffic lights stay clickable.

## How it works (stateless)

No window state is cached, so nothing can go stale across window moves, closes, Spaces, Stage Manager, or sleep/wake. A lightweight timer reads the cursor position; only a brief dwell on a grid corner (computed from screen geometry alone) triggers a single window-server query via `CGWindowListCopyWindowInfo`, which can't block on an unresponsive app. Accessibility is touched only to read the matched windows' titles, on a background queue with a messaging timeout.

## Testing

- Unit tests for the grid-corner geometry, including negative-origin (secondary-display) screens.
- Multi-model adversarial code review across correctness, concurrency, and view lifecycle.
- Manually verified in Light and Dark mode and across multiple displays; soak-tested over ~2 weeks of daily use on 2 separate Macs.

## Screenshots

### Light mode
<img width="1069" height="621" alt="Screenshot 2026-07-22 at 8 23 25 AM" src="https://github.com/user-attachments/assets/ceb71fc5-2bcf-4587-8da1-2e8e23e5276e" />


### Dark mode
<img width="1057" height="630" alt="Screenshot 2026-07-22 at 8 22 39 AM" src="https://github.com/user-attachments/assets/c100d691-7911-49fe-a1ce-632152c61bdd" />



### GIF

<img width="1100" height="651" alt="stack-badge-dark" src="https://github.com/user-attachments/assets/51d20916-555c-4fa3-aa1b-7e542c75089f" />


