### PR TITLE
Export Todo sidebar width units

### DIFF
--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -152,6 +152,7 @@ class Defaults {
         todoMode,
         todoApplication,
         todoSidebarWidth,
+        todoSidebarWidthUnit,
         todoSidebarSide,
         snapModifiers,
         attemptMatchOnNextPrevDisplay,

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -143,6 +143,11 @@ class DefaultsExportTests: XCTestCase {
         XCTAssertTrue(keys.contains("cyclingOverlapMaxCascade"), "cyclingOverlapMaxCascade missing from Defaults.array")
         XCTAssertTrue(keys.contains("cooperativeCornerResize"), "cooperativeCornerResize missing from Defaults.array")
     }
+
+    func testTodoSidebarWidthUnitInExportArray() {
+        let keys = Defaults.array.map { $0.key }
+        XCTAssertTrue(keys.contains("todoSidebarWidthUnit"), "todoSidebarWidthUnit missing from Defaults.array")
+    }
 }
 
 class CooperativeCornerResizeTests: XCTestCase {


### PR DESCRIPTION
When the Todo sidebar width unit is set to percent, exporting configuration and reimporting it silently reverts the unit to pixels, because Defaults.array includes todoSidebarWidth but not todoSidebarWidthUnit, so the unit is never written to or read from the config file.

This adds todoSidebarWidthUnit to Defaults.array immediately after todoSidebarWidth so the unit is exported and restored alongside the width. All other export behavior is unchanged.

Test: `xcodebuild test -project Rectangle.xcodeproj -scheme Rectangle -destination 'platform=macOS' -only-testing:RectangleTests/DefaultsExportTests` (testTodoSidebarWidthUnitInExportArray fails before the change and passes after).