### PR TITLE
Restore shortcuts after user session switches

### DIFF
--- a/Rectangle/ShortcutManager.swift
+++ b/Rectangle/ShortcutManager.swift
@@ -1,20 +1,84 @@
 /// ShortcutManager.swift
 
-import Foundation
+import Cocoa
+import CoreGraphics
 import MASShortcut
+
+protocol ShortcutBindingStore {
+    func configure()
+    func registerDefaultShortcuts(_ shortcuts: [String: MASShortcut])
+    func bindShortcut(withDefaultsKey defaultsKey: String, toAction action: @escaping () -> Void)
+    func breakBinding(withDefaultsKey defaultsKey: String)
+}
+
+struct MASShortcutBindingStore: ShortcutBindingStore {
+    func configure() {
+        MASShortcutBinder.shared()?.bindingOptions = [NSBindingOption.valueTransformerName: MASDictionaryTransformerName]
+    }
+
+    func registerDefaultShortcuts(_ shortcuts: [String: MASShortcut]) {
+        MASShortcutBinder.shared()?.registerDefaultShortcuts(shortcuts)
+    }
+
+    func bindShortcut(withDefaultsKey defaultsKey: String, toAction action: @escaping () -> Void) {
+        MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: defaultsKey, toAction: action)
+    }
+
+    func breakBinding(withDefaultsKey defaultsKey: String) {
+        MASShortcutBinder.shared()?.breakBinding(withDefaultsKey: defaultsKey)
+    }
+}
+
+typealias ShortcutRebindScheduler = (@escaping () -> Void) -> Void
 
 class ShortcutManager {
 
     let windowManager: WindowManager
+    private let bindingStore: ShortcutBindingStore
+    private let notificationCenter: NotificationCenter
+    private let workspaceNotificationCenter: NotificationCenter
+    private let shortcutsProvider: () -> [WindowAction: MASShortcut]
+    private let appDisabledProvider: () -> Bool
+    private let scheduler: ShortcutRebindScheduler
+    private let todoSessionStateChanged: (Bool) -> Void
     private var boundShortcutActions = Set<WindowAction>()
     private var shortcutIdentities = [WindowAction: ShortcutCycle.ShortcutIdentity]()
     private var isUpdatingShortcutBindings = false
     private var shortcutsSuspendedForRecording = false
+    private var sessionIsActive: Bool
+    private var sessionRebindPending = false
+    private var sessionGeneration = 0
 
-    init(windowManager: WindowManager) {
+    init(
+        windowManager: WindowManager,
+        bindingStore: ShortcutBindingStore = MASShortcutBindingStore(),
+        notificationCenter: NotificationCenter = .default,
+        workspaceNotificationCenter: NotificationCenter = NSWorkspace.shared.notificationCenter,
+        shortcutsProvider: @escaping () -> [WindowAction: MASShortcut] = { ShortcutCycle.shortcutsByAction() },
+        activeStateProvider: () -> Bool = {
+            let session = CGSessionCopyCurrentDictionary() as? [String: Any]
+            return session?[kCGSessionOnConsoleKey] as? Bool ?? true
+        },
+        appDisabledProvider: @escaping () -> Bool = { ApplicationToggle.shortcutsDisabled },
+        scheduler: @escaping ShortcutRebindScheduler = { action in
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100), execute: action)
+        },
+        todoSessionStateChanged: @escaping (Bool) -> Void = { isActive in
+            TodoManager.setShortcutBindingsSessionActive(isActive)
+        }
+    ) {
         self.windowManager = windowManager
+        self.bindingStore = bindingStore
+        self.notificationCenter = notificationCenter
+        self.workspaceNotificationCenter = workspaceNotificationCenter
+        self.shortcutsProvider = shortcutsProvider
+        self.appDisabledProvider = appDisabledProvider
+        self.scheduler = scheduler
+        self.todoSessionStateChanged = todoSessionStateChanged
+        self.sessionIsActive = activeStateProvider()
 
-        MASShortcutBinder.shared()?.bindingOptions = [NSBindingOption.valueTransformerName: MASDictionaryTransformerName]
+        bindingStore.configure()
+        todoSessionStateChanged(sessionIsActive)
 
         registerDefaults()
 
@@ -22,9 +86,11 @@ class ShortcutManager {
 
         subscribeAll(selector: #selector(windowActionTriggered))
 
-        NotificationCenter.default.addObserver(self, selector: #selector(defaultShortcutsChanged), name: .changeDefaults, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(userDefaultsChanged), name: UserDefaults.didChangeNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(shortcutRecordingChanged), name: .shortcutRecording, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(defaultShortcutsChanged), name: .changeDefaults, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(userDefaultsChanged), name: UserDefaults.didChangeNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(shortcutRecordingChanged), name: .shortcutRecording, object: nil)
+        workspaceNotificationCenter.addObserver(self, selector: #selector(sessionDidResignActive), name: NSWorkspace.sessionDidResignActiveNotification, object: nil)
+        workspaceNotificationCenter.addObserver(self, selector: #selector(sessionDidBecomeActive), name: NSWorkspace.sessionDidBecomeActiveNotification, object: nil)
     }
 
     public func reloadFromDefaults() {
@@ -36,9 +102,13 @@ class ShortcutManager {
     }
 
     public func bindShortcuts() {
-        guard !shortcutsSuspendedForRecording else { return }
+        guard sessionIsActive,
+              !sessionRebindPending,
+              !shortcutsSuspendedForRecording,
+              !appDisabledProvider()
+        else { return }
 
-        let shortcutsByAction = ShortcutCycle.shortcutsByAction()
+        let shortcutsByAction = shortcutsProvider()
         let groups = ShortcutCycle.groups(shortcutsByAction: shortcutsByAction)
 
         shortcutIdentities = ShortcutCycle.shortcutIdentities(shortcutsByAction: shortcutsByAction)
@@ -48,11 +118,11 @@ class ShortcutManager {
             boundShortcutActions.insert(representativeAction)
 
             if group.isCycle {
-                MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: representativeAction.name, toAction: { [weak self] in
+                bindingStore.bindShortcut(withDefaultsKey: representativeAction.name, toAction: { [weak self] in
                     self?.executeCycle(group)
                 })
             } else {
-                MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: representativeAction.name, toAction: representativeAction.post)
+                bindingStore.bindShortcut(withDefaultsKey: representativeAction.name, toAction: representativeAction.post)
             }
         }
     }
@@ -62,7 +132,7 @@ class ShortcutManager {
         defer { isUpdatingShortcutBindings = false }
 
         for action in Set(WindowAction.active).union(boundShortcutActions) {
-            MASShortcutBinder.shared()?.breakBinding(withDefaultsKey: action.name)
+            bindingStore.breakBinding(withDefaultsKey: action.name)
         }
 
         boundShortcutActions.removeAll()
@@ -74,7 +144,8 @@ class ShortcutManager {
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        notificationCenter.removeObserver(self)
+        workspaceNotificationCenter.removeObserver(self)
     }
 
     private func registerDefaults() {
@@ -88,7 +159,39 @@ class ShortcutManager {
             dict[windowAction.name] = shortcut
         }
 
-        MASShortcutBinder.shared()?.registerDefaultShortcuts(defaultShortcuts)
+        bindingStore.registerDefaultShortcuts(defaultShortcuts)
+    }
+
+    @objc private func sessionDidResignActive(_ notification: Notification) {
+        guard sessionIsActive else { return }
+
+        sessionIsActive = false
+        sessionRebindPending = false
+        sessionGeneration &+= 1
+        unbindShortcuts()
+        todoSessionStateChanged(false)
+    }
+
+    @objc private func sessionDidBecomeActive(_ notification: Notification) {
+        guard !sessionIsActive else { return }
+
+        sessionIsActive = true
+        sessionRebindPending = true
+        sessionGeneration &+= 1
+        let generation = sessionGeneration
+
+        scheduler { [weak self] in
+            guard let self,
+                  self.sessionIsActive,
+                  self.sessionRebindPending,
+                  self.sessionGeneration == generation
+            else { return }
+
+            self.sessionRebindPending = false
+            self.unbindShortcuts()
+            self.bindShortcuts()
+            self.todoSessionStateChanged(true)
+        }
     }
 
     @objc func windowActionTriggered(notification: NSNotification) {
@@ -164,12 +267,12 @@ class ShortcutManager {
         guard !isUpdatingShortcutBindings && !shortcutsSuspendedForRecording else { return }
 
         MASShortcutMigration.syncRenamedSideShortcutAliases()
-        let currentShortcuts = ShortcutCycle.shortcutsByAction()
+        let currentShortcuts = shortcutsProvider()
         let currentIdentities = ShortcutCycle.shortcutIdentities(shortcutsByAction: currentShortcuts)
         guard currentIdentities != shortcutIdentities else { return }
 
         unbindShortcuts()
-        if !ApplicationToggle.shortcutsDisabled {
+        if !appDisabledProvider() {
             bindShortcuts()
         } else {
             shortcutIdentities = currentIdentities
@@ -186,10 +289,10 @@ class ShortcutManager {
         } else {
             guard shortcutsSuspendedForRecording else { return }
             shortcutsSuspendedForRecording = false
-            if !ApplicationToggle.shortcutsDisabled {
+            if !appDisabledProvider() {
                 bindShortcuts()
             } else {
-                let currentShortcuts = ShortcutCycle.shortcutsByAction()
+                let currentShortcuts = shortcutsProvider()
                 shortcutIdentities = ShortcutCycle.shortcutIdentities(shortcutsByAction: currentShortcuts)
             }
         }
@@ -209,12 +312,12 @@ class ShortcutManager {
     }
 
     private func subscribe(notification: WindowAction, selector: Selector) {
-        NotificationCenter.default.addObserver(self, selector: selector, name: notification.notificationName, object: nil)
+        notificationCenter.addObserver(self, selector: selector, name: notification.notificationName, object: nil)
     }
 
     private func unsubscribeWindowActions() {
         for windowAction in WindowAction.active {
-            NotificationCenter.default.removeObserver(self, name: windowAction.notificationName, object: nil)
+            notificationCenter.removeObserver(self, name: windowAction.notificationName, object: nil)
         }
     }
 

--- a/Rectangle/TodoMode/TodoManager.swift
+++ b/Rectangle/TodoMode/TodoManager.swift
@@ -5,6 +5,7 @@ import MASShortcut
 
 class TodoManager {
     private static var todoWindowId: CGWindowID?
+    private static var shortcutBindingsSessionActive = true
 
     static var todoScreen : NSScreen?
     static let toggleDefaultsKey = "toggleTodo"
@@ -71,7 +72,7 @@ class TodoManager {
     }
     
     static func registerUnregisterToggleShortcut() {
-        if Defaults.todo.userEnabled {
+        if Defaults.todo.userEnabled && shortcutBindingsSessionActive {
             registerToggleShortcut()
         } else {
             unregisterToggleShortcut()
@@ -79,10 +80,23 @@ class TodoManager {
     }
     
     static func registerUnregisterReflowShortcut() {
-        if Defaults.todo.userEnabled && Defaults.todoMode.enabled {
+        if Defaults.todo.userEnabled && Defaults.todoMode.enabled && shortcutBindingsSessionActive {
             registerReflowShortcut()
         } else {
             unregisterReflowShortcut()
+        }
+    }
+
+    static func setShortcutBindingsSessionActive(_ isActive: Bool) {
+        guard shortcutBindingsSessionActive != isActive else { return }
+
+        shortcutBindingsSessionActive = isActive
+        unregisterToggleShortcut()
+        unregisterReflowShortcut()
+
+        if isActive {
+            registerUnregisterToggleShortcut()
+            registerUnregisterReflowShortcut()
         }
     }
 

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -2713,6 +2713,255 @@ class SnappingManagerSessionTests: XCTestCase {
     }
 }
 
+class ShortcutManagerSessionTests: XCTestCase {
+
+    private final class ValueBox<Value> {
+        var value: Value
+
+        init(_ value: Value) {
+            self.value = value
+        }
+    }
+
+    private final class BindingStoreSpy: ShortcutBindingStore {
+        private(set) var configureCallCount = 0
+        private(set) var registeredDefaultKeys = Set<String>()
+        private(set) var boundKeys = Set<String>()
+        private(set) var bindCallCount = 0
+        private(set) var breakBindingCallCount = 0
+
+        func configure() {
+            configureCallCount += 1
+        }
+
+        func registerDefaultShortcuts(_ shortcuts: [String: MASShortcut]) {
+            registeredDefaultKeys.formUnion(shortcuts.keys)
+        }
+
+        func bindShortcut(withDefaultsKey defaultsKey: String, toAction action: @escaping () -> Void) {
+            bindCallCount += 1
+            boundKeys.insert(defaultsKey)
+        }
+
+        func breakBinding(withDefaultsKey defaultsKey: String) {
+            breakBindingCallCount += 1
+            boundKeys.remove(defaultsKey)
+        }
+    }
+
+    private final class SchedulerSpy {
+        private var scheduledActions = [() -> Void]()
+
+        var pendingCount: Int {
+            scheduledActions.count
+        }
+
+        func schedule(_ action: @escaping () -> Void) {
+            scheduledActions.append(action)
+        }
+
+        func runNext() {
+            guard !scheduledActions.isEmpty else {
+                XCTFail("Expected a scheduled shortcut rebind")
+                return
+            }
+            scheduledActions.removeFirst()()
+        }
+    }
+
+    private struct Harness {
+        let manager: ShortcutManager
+        let bindingStore: BindingStoreSpy
+        let notificationCenter: NotificationCenter
+        let workspaceNotificationCenter: NotificationCenter
+        let shortcuts: ValueBox<[WindowAction: MASShortcut]>
+        let appDisabled: ValueBox<Bool>
+        let scheduler: SchedulerSpy
+        let todoSessionStates: ValueBox<[Bool]>
+    }
+
+    private func shortcut(_ keyCode: Int) -> MASShortcut {
+        MASShortcut(keyCode: keyCode, modifierFlags: [.command, .option])
+    }
+
+    private func makeHarness(
+        initiallyActive: Bool = true,
+        appDisabled: Bool = false,
+        shortcuts: [WindowAction: MASShortcut]? = nil
+    ) -> Harness {
+        let bindingStore = BindingStoreSpy()
+        let notificationCenter = NotificationCenter()
+        let workspaceNotificationCenter = NotificationCenter()
+        let shortcuts = ValueBox(shortcuts ?? [.leftHalf: shortcut(1)])
+        let appDisabled = ValueBox(appDisabled)
+        let scheduler = SchedulerSpy()
+        let todoSessionStates = ValueBox<[Bool]>([])
+        let manager = ShortcutManager(
+            windowManager: WindowManager(),
+            bindingStore: bindingStore,
+            notificationCenter: notificationCenter,
+            workspaceNotificationCenter: workspaceNotificationCenter,
+            shortcutsProvider: { shortcuts.value },
+            activeStateProvider: { initiallyActive },
+            appDisabledProvider: { appDisabled.value },
+            scheduler: { scheduler.schedule($0) },
+            todoSessionStateChanged: { todoSessionStates.value.append($0) }
+        )
+
+        return Harness(
+            manager: manager,
+            bindingStore: bindingStore,
+            notificationCenter: notificationCenter,
+            workspaceNotificationCenter: workspaceNotificationCenter,
+            shortcuts: shortcuts,
+            appDisabled: appDisabled,
+            scheduler: scheduler,
+            todoSessionStates: todoSessionStates
+        )
+    }
+
+    private func resignSession(_ harness: Harness) {
+        harness.workspaceNotificationCenter.post(
+            name: NSWorkspace.sessionDidResignActiveNotification,
+            object: nil
+        )
+    }
+
+    private func activateSession(_ harness: Harness) {
+        harness.workspaceNotificationCenter.post(
+            name: NSWorkspace.sessionDidBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    func testActiveSessionResignThenDelayedActivationRestoresBindings() {
+        let harness = makeHarness()
+        let expectedKeys: Set<String> = [WindowAction.leftHalf.name]
+
+        XCTAssertEqual(harness.bindingStore.boundKeys, expectedKeys)
+        XCTAssertEqual(harness.todoSessionStates.value, [true])
+
+        resignSession(harness)
+
+        XCTAssertTrue(harness.bindingStore.boundKeys.isEmpty)
+        XCTAssertEqual(harness.scheduler.pendingCount, 0)
+        XCTAssertEqual(harness.todoSessionStates.value, [true, false])
+
+        activateSession(harness)
+
+        XCTAssertTrue(harness.bindingStore.boundKeys.isEmpty)
+        XCTAssertEqual(harness.scheduler.pendingCount, 1)
+        XCTAssertEqual(harness.todoSessionStates.value, [true, false])
+
+        harness.scheduler.runNext()
+
+        XCTAssertEqual(harness.bindingStore.boundKeys, expectedKeys)
+        XCTAssertEqual(harness.scheduler.pendingCount, 0)
+        XCTAssertEqual(harness.todoSessionStates.value, [true, false, true])
+    }
+
+    func testDuplicateSessionNotificationsAreIdempotent() {
+        let harness = makeHarness()
+
+        resignSession(harness)
+        let breakCallsAfterFirstResign = harness.bindingStore.breakBindingCallCount
+
+        resignSession(harness)
+
+        XCTAssertEqual(harness.bindingStore.breakBindingCallCount, breakCallsAfterFirstResign)
+
+        activateSession(harness)
+        activateSession(harness)
+
+        XCTAssertEqual(harness.scheduler.pendingCount, 1)
+
+        harness.scheduler.runNext()
+        let bindCallsAfterActivation = harness.bindingStore.bindCallCount
+
+        activateSession(harness)
+
+        XCTAssertEqual(harness.scheduler.pendingCount, 0)
+        XCTAssertEqual(harness.bindingStore.bindCallCount, bindCallsAfterActivation)
+        XCTAssertEqual(harness.bindingStore.boundKeys, [WindowAction.leftHalf.name])
+    }
+
+    func testActivationRestoresCurrentLogicalShortcutsAfterTheyChangeWhileInactive() {
+        let harness = makeHarness()
+
+        resignSession(harness)
+        harness.shortcuts.value = [.rightHalf: shortcut(2)]
+
+        activateSession(harness)
+        harness.scheduler.runNext()
+
+        XCTAssertEqual(harness.bindingStore.boundKeys, [WindowAction.rightHalf.name])
+        XCTAssertFalse(harness.bindingStore.boundKeys.contains(WindowAction.leftHalf.name))
+    }
+
+    func testDisabledApplicationBlocksSessionRestore() {
+        let harness = makeHarness()
+
+        resignSession(harness)
+        harness.appDisabled.value = true
+
+        activateSession(harness)
+        harness.scheduler.runNext()
+
+        XCTAssertTrue(harness.bindingStore.boundKeys.isEmpty)
+    }
+
+    func testRecordingBlocksSessionRestoreUntilRecordingEnds() {
+        let harness = makeHarness()
+
+        harness.notificationCenter.post(name: .shortcutRecording, object: true)
+        XCTAssertTrue(harness.bindingStore.boundKeys.isEmpty)
+
+        resignSession(harness)
+        activateSession(harness)
+        harness.scheduler.runNext()
+
+        XCTAssertTrue(harness.bindingStore.boundKeys.isEmpty)
+
+        harness.notificationCenter.post(name: .shortcutRecording, object: false)
+
+        XCTAssertEqual(harness.bindingStore.boundKeys, [WindowAction.leftHalf.name])
+    }
+
+    func testInitiallyInactiveSessionDoesNotBindUntilActivationCompletes() {
+        let harness = makeHarness(initiallyActive: false)
+
+        XCTAssertTrue(harness.bindingStore.boundKeys.isEmpty)
+        XCTAssertEqual(harness.scheduler.pendingCount, 0)
+        XCTAssertEqual(harness.todoSessionStates.value, [false])
+
+        activateSession(harness)
+
+        XCTAssertTrue(harness.bindingStore.boundKeys.isEmpty)
+        XCTAssertEqual(harness.scheduler.pendingCount, 1)
+        XCTAssertEqual(harness.todoSessionStates.value, [false])
+
+        harness.scheduler.runNext()
+
+        XCTAssertEqual(harness.bindingStore.boundKeys, [WindowAction.leftHalf.name])
+        XCTAssertEqual(harness.todoSessionStates.value, [false, true])
+    }
+
+    func testResignBeforeQueuedActivationCompletesCancelsRestore() {
+        let harness = makeHarness()
+
+        resignSession(harness)
+        activateSession(harness)
+        XCTAssertEqual(harness.scheduler.pendingCount, 1)
+
+        resignSession(harness)
+        harness.scheduler.runNext()
+
+        XCTAssertTrue(harness.bindingStore.boundKeys.isEmpty)
+        XCTAssertEqual(harness.scheduler.pendingCount, 0)
+        XCTAssertEqual(harness.todoSessionStates.value, [true, false, false])
+    }
+}
+
 class ShortcutCycleTests: XCTestCase {
 
     private func shortcut(_ keyCode: Int, _ flags: NSEvent.ModifierFlags) -> MASShortcut {


### PR DESCRIPTION
## Summary

- release global shortcut bindings when the macOS user session becomes inactive
- restore current WindowAction and Todo shortcut bindings after the session becomes active again
- preserve inactive-session, ignored-app, and shortcut-recording guards across rebinding
- add regression coverage for session transitions, duplicate notifications, delayed restoration, and state changes while inactive
- keep Todo shortcuts unbound until both the user session is active and shortcut recording has ended

## Root cause

MASShortcut retains the configured shortcut even when Carbon cannot register the corresponding global hotkey. With multiple logged-in user sessions, an inactive Rectangle process could keep those hotkeys registered, leaving the active user's shortcuts configured but nonfunctional.

## Testing

- `xcodebuild test -quiet -project Rectangle.xcodeproj -scheme Rectangle -destination 'platform=macOS' -derivedDataPath /private/tmp/RectangleIssue351Conflict.X4sF3k -only-testing:RectangleTests/ShortcutManagerSessionTests -only-testing:RectangleTests/ShortcutRecordingObserverTests CODE_SIGNING_ALLOWED=NO` (15 tests passed)
- the remaining full-suite cooperative-resize failures reproduce unchanged on clean upstream `8db3e8e`

Fixes #351
