### PR TITLE
Invalidate the event tap CFMachPort in ActiveEventMonitor.stop()

### DIFF
--- a/Rectangle/Utilities/EventMonitor.swift
+++ b/Rectangle/Utilities/EventMonitor.swift
@@ -79,6 +79,13 @@ public class ActiveEventMonitor: EventMonitor {
             thread!.cancel()
             thread = nil
             CGEvent.tapEnable(tap: tap, enable: false)
+            // CoreGraphics holds internal references to the CFMachPort from tapCreate, so
+            // releasing ours never deallocates it; without an explicit invalidate, the
+            // WindowServer keeps the (disabled) tap registration until the process exits.
+            // stop()/start() cycles (app switches while snapping is active, and the
+            // tapDisabledByTimeout recovery above) would otherwise each leak one entry,
+            // degrading system-wide input latency once they accumulate.
+            CFMachPortInvalidate(tap)
         }
         tap = nil
     }


### PR DESCRIPTION
This PR fixes a resource leak in `ActiveEventMonitor`: its `stop()` disables the CGEventTap and drops the reference, but never calls `CFMachPortInvalidate`. CoreGraphics holds internal references to the `CFMachPort` returned by `CGEventTapCreate` (observed retain count 4 right after creation), so releasing the client reference never deallocates it — **the window server keeps the (disabled) event-tap registration until the process exits**. Each `stop()`/`start()` cycle therefore leaks one stale registration, and accumulated stale registrations measurably degrade system-wide input latency (the window server's per-event tap-table processing scales with table size).

The same bug class was recently root-caused across several projects: fixes have been submitted to Karabiner-Elements ([pqrs-org/Karabiner-Elements#4505](https://github.com/pqrs-org/Karabiner-Elements/pull/4505) — includes a video of the symptom and standalone repro scripts), Mos ([Caldis/Mos#999](https://github.com/Caldis/Mos/pull/999) — with a red/green regression test of exactly this fix pattern), pynput ([moses-palmer/pynput#684](https://github.com/moses-palmer/pynput/pull/684)), and deskflow ([deskflow/deskflow#10010](https://github.com/deskflow/deskflow/pull/10010)); Easydict found and fixed the identical leak independently ([tisfeng/Easydict#1170](https://github.com/tisfeng/Easydict/issues/1170), maintainer-confirmed and shipped in their 2.20.0). Long-lived tap-heavy projects (Hammerspoon, LinearMouse) all invalidate in their teardown paths.

This analysis and fix were prepared with AI assistance (Claude); the mechanism was verified on a real machine (macOS 26.5, Apple Silicon) and the change was human-reviewed.

## Scope in Rectangle

`ActiveEventMonitor` is only instantiated in two non-default configurations — `SnappingManager` when Mission-Control dragging is user-disabled, and `GreenButtonManager` when the green-button override is enabled — which is presumably why no lag reports have surfaced in this tracker yet. But when either is active, registrations leak on:

- every snapping/green-button toggle and config import (`stopEventMonitor()` / `toggleListening()` recreate the monitor), and
- **every `tapDisabledByTimeout` / `tapDisabledByUserInput` recovery**, since the tap callback handles those with `stop(); start()` (`EventMonitor.swift`) — this one can fire repeatedly under system load, silently.

## Mechanism verification (standalone)

On macOS 26.5: tearing a tap down with `tapEnable(false)` + run-loop-source removal + release leaves the mach receive right alive and the `CGGetEventTapList` entry present indefinitely; adding `CFMachPortInvalidate` reaps the entry immediately. Repeating the no-invalidate teardown in a loop grows the process's tap-table entry count by exactly 1 per cycle. Synthetically holding 1,000 such disabled registrations makes the whole Mac's input noticeably laggy within seconds; releasing them restores it. Repro scripts (`taplist.swift` to enumerate the table, `bloatgen.swift` to demonstrate impact) are in the Karabiner PR linked above.

## The fix

One line (+ comment) in `ActiveEventMonitor.stop()`: `CFMachPortInvalidate(tap)` after `tapEnable(false)`. `stop()` is the sole teardown path (`start()` always creates a fresh tap, and `deinit` calls `stop()`), so this covers all cases, including the timeout-recovery cycle. No behavior change on the event path — the tap is already disabled at that point.

## Validation

- Rectangle builds successfully with the change (`xcodebuild -project Rectangle.xcodeproj -scheme Rectangle build`, unsigned).
- Suggested check on a fixed build (with Mission-Control dragging disabled so the active monitor runs): toggle snapping a few times, or wait out a couple of tap-timeout recoveries, then enumerate `CGGetEventTapList` — Rectangle's disabled-entry count should stay at 0 instead of growing by 1 per cycle.
