### PR TITLE
Allow zero to disable minimum window size limits

### DIFF
--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -28,8 +28,8 @@ class Defaults {
     static let ignoredSnapAreas = IntDefault(key: "ignoredSnapAreas")
     static let traverseSingleScreen = OptionalBoolDefault(key: "traverseSingleScreen")
     static let useCursorScreenDetection = BoolDefault(key: "useCursorScreenDetection")
-    static let minimumWindowWidth = FloatDefault(key: "minimumWindowWidth")
-    static let minimumWindowHeight = FloatDefault(key: "minimumWindowHeight")
+    static let minimumWindowWidth = MinimumWindowFractionDefault(key: "minimumWindowWidth")
+    static let minimumWindowHeight = MinimumWindowFractionDefault(key: "minimumWindowHeight")
     static let sizeOffset = FloatDefault(key: "sizeOffset")
     static let widthStepSize = FloatDefault(key: "widthStepSize", defaultValue: 30)
     static let unsnapRestore = OptionalBoolDefault(key: "unsnapRestore")
@@ -341,10 +341,11 @@ class FloatDefault: Default {
     
     var cgFloat: CGFloat { CGFloat(value) }
 
-    init(key: String, defaultValue: Float = 0) {
+    init(key: String, defaultValue: Float = 0, zeroValueIsValid: Bool = false) {
         self.key = key
         value = UserDefaults.standard.float(forKey: key)
-        if(defaultValue != 0 && value == 0) {
+        let hasStoredValue = UserDefaults.standard.object(forKey: key) != nil
+        if defaultValue != 0, value == 0, !zeroValueIsValid || !hasStoredValue {
             value = defaultValue
         }
         initialized = true
@@ -358,6 +359,33 @@ class FloatDefault: Default {
     
     func toCodable() -> CodableDefault {
         return CodableDefault(float: value)
+    }
+}
+
+class MinimumWindowFractionDefault: FloatDefault {
+    // Legacy configs serialized the implicit 25% default as zero. Use a sentinel
+    // so newly disabled limits can round-trip without changing old config imports.
+    private static let disabledConfigValue: Float = -1
+
+    init(key: String) {
+        super.init(key: key, defaultValue: 0.25, zeroValueIsValid: true)
+    }
+
+    override func load(from codable: CodableDefault) {
+        guard let value = codable.float else { return }
+        switch value {
+        case Self.disabledConfigValue:
+            self.value = 0
+        case 0:
+            // Older configs exported an unset preference as zero, which meant 25%.
+            self.value = 0.25
+        default:
+            self.value = value
+        }
+    }
+
+    override func toCodable() -> CodableDefault {
+        CodableDefault(float: value == 0 ? Self.disabledConfigValue : value)
     }
 }
 

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -28,8 +28,8 @@ class Defaults {
     static let ignoredSnapAreas = IntDefault(key: "ignoredSnapAreas")
     static let traverseSingleScreen = OptionalBoolDefault(key: "traverseSingleScreen")
     static let useCursorScreenDetection = BoolDefault(key: "useCursorScreenDetection")
-    static let minimumWindowWidth = MinimumWindowFractionDefault(key: "minimumWindowWidth")
-    static let minimumWindowHeight = MinimumWindowFractionDefault(key: "minimumWindowHeight")
+    static let minimumWindowWidth = DoubleDefault(key: "minimumWindowWidth", defaultValue: 0.25)
+    static let minimumWindowHeight = DoubleDefault(key: "minimumWindowHeight", defaultValue: 0.25)
     static let sizeOffset = FloatDefault(key: "sizeOffset")
     static let widthStepSize = FloatDefault(key: "widthStepSize", defaultValue: 30)
     static let unsnapRestore = OptionalBoolDefault(key: "unsnapRestore")
@@ -204,12 +204,14 @@ struct CodableDefault: Codable {
     let bool: Bool?
     let int: Int?
     let float: Float?
+    let double: Double?
     let string: String?
     
-    init(bool: Bool? = nil, int: Int? = nil, float: Float? = nil, string: String? = nil) {
+    init(bool: Bool? = nil, int: Int? = nil, float: Float? = nil, double: Double? = nil, string: String? = nil) {
         self.bool = bool
         self.int = int
         self.float = float
+        self.double = double
         self.string = string
     }
 }
@@ -341,11 +343,10 @@ class FloatDefault: Default {
     
     var cgFloat: CGFloat { CGFloat(value) }
 
-    init(key: String, defaultValue: Float = 0, zeroValueIsValid: Bool = false) {
+    init(key: String, defaultValue: Float = 0) {
         self.key = key
         value = UserDefaults.standard.float(forKey: key)
-        let hasStoredValue = UserDefaults.standard.object(forKey: key) != nil
-        if defaultValue != 0, value == 0, !zeroValueIsValid || !hasStoredValue {
+        if(defaultValue != 0 && value == 0) {
             value = defaultValue
         }
         initialized = true
@@ -362,30 +363,42 @@ class FloatDefault: Default {
     }
 }
 
-class MinimumWindowFractionDefault: FloatDefault {
-    // Legacy configs serialized the implicit 25% default as zero. Use a sentinel
-    // so newly disabled limits can round-trip without changing old config imports.
-    private static let disabledConfigValue: Float = -1
+class DoubleDefault: Default {
+    public private(set) var key: String
+    private var initialized = false
+    private let defaultValue: Double
 
-    init(key: String) {
-        super.init(key: key, defaultValue: 0.25, zeroValueIsValid: true)
-    }
-
-    override func load(from codable: CodableDefault) {
-        guard let value = codable.float else { return }
-        switch value {
-        case Self.disabledConfigValue:
-            self.value = 0
-        case 0:
-            // Older configs exported an unset preference as zero, which meant 25%.
-            self.value = 0.25
-        default:
-            self.value = value
+    var value: Double {
+        didSet {
+            if initialized {
+                UserDefaults.standard.set(value, forKey: key)
+            }
         }
     }
 
-    override func toCodable() -> CodableDefault {
-        CodableDefault(float: value == 0 ? Self.disabledConfigValue : value)
+    init(key: String, defaultValue: Double = 0) {
+        self.key = key
+        self.defaultValue = defaultValue
+        if UserDefaults.standard.object(forKey: key) == nil {
+            value = defaultValue
+        } else {
+            value = UserDefaults.standard.double(forKey: key)
+        }
+        initialized = true
+    }
+
+    func load(from codable: CodableDefault) {
+        if let double = codable.double {
+            value = double
+        } else if let float = codable.float {
+            // Legacy float-backed defaults could not distinguish an absent value
+            // from zero; preserve their effective default when migrating.
+            value = float == 0 && defaultValue != 0 ? defaultValue : Double(float)
+        }
+    }
+
+    func toCodable() -> CodableDefault {
+        CodableDefault(double: value)
     }
 }
 

--- a/Rectangle/WindowCalculation/ChangeWindowDimensionCalculation.swift
+++ b/Rectangle/WindowCalculation/ChangeWindowDimensionCalculation.swift
@@ -8,22 +8,24 @@ protocol ChangeWindowDimensionCalculation {
 
 extension ChangeWindowDimensionCalculation {
     private func minimumWindowWidth() -> CGFloat {
-        let defaultWidth = Defaults.minimumWindowWidth.value
-        return (defaultWidth <= 0 || defaultWidth > 1)
-            ? 0.25
-            : CGFloat(defaultWidth)
+        minimumWindowFraction(Defaults.minimumWindowWidth)
     }
-    
+
     private func minimumWindowHeight() -> CGFloat {
-        let defaultHeight = Defaults.minimumWindowHeight.value
-        return (defaultHeight <= 0 || defaultHeight > 1)
+        minimumWindowFraction(Defaults.minimumWindowHeight)
+    }
+
+    private func minimumWindowFraction(_ preference: FloatDefault) -> CGFloat {
+        let value = preference.value
+        return (!value.isFinite || value < 0 || value > 1)
             ? 0.25
-            : CGFloat(defaultHeight)
+            : CGFloat(value)
     }
     
     func resizedWindowRectIsTooSmall(windowRect: CGRect, visibleFrameOfScreen: CGRect) -> Bool {
-        let minimumWindowRectWidth = floor(visibleFrameOfScreen.width * minimumWindowWidth())
-        let minimumWindowRectHeight = floor(visibleFrameOfScreen.height * minimumWindowHeight())
-        return (windowRect.width <= minimumWindowRectWidth) || (windowRect.height <= minimumWindowRectHeight)
+        let minimumWindowRectWidth = max(1, floor(visibleFrameOfScreen.width * minimumWindowWidth()))
+        let minimumWindowRectHeight = max(1, floor(visibleFrameOfScreen.height * minimumWindowHeight()))
+        return (windowRect.size.width < minimumWindowRectWidth)
+            || (windowRect.size.height < minimumWindowRectHeight)
     }
 }

--- a/Rectangle/WindowCalculation/ChangeWindowDimensionCalculation.swift
+++ b/Rectangle/WindowCalculation/ChangeWindowDimensionCalculation.swift
@@ -15,11 +15,11 @@ extension ChangeWindowDimensionCalculation {
         minimumWindowFraction(Defaults.minimumWindowHeight)
     }
 
-    private func minimumWindowFraction(_ preference: FloatDefault) -> CGFloat {
+    private func minimumWindowFraction(_ preference: DoubleDefault) -> CGFloat {
         let value = preference.value
         return (!value.isFinite || value < 0 || value > 1)
             ? 0.25
-            : CGFloat(value)
+            : value
     }
     
     func resizedWindowRectIsTooSmall(windowRect: CGRect, visibleFrameOfScreen: CGRect) -> Bool {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -150,6 +150,118 @@ class DefaultsExportTests: XCTestCase {
     }
 }
 
+class ChangeSizeCalculationTests: XCTestCase {
+    private let visibleFrame = CGRect(x: 0, y: 0, width: 2560, height: 1415)
+    private let issueWindowRect = CGRect(x: 1895, y: 0, width: 665, height: 1415)
+    private var minimumWindowWidth: Float = 0
+    private var minimumWindowHeight: Float = 0
+    private var sizeOffset: Float = 0
+    private var gapSize: Float = 0
+    private var curtainChangeSize: Bool?
+    private var storedMinimumWindowWidth: Any?
+    private var storedMinimumWindowHeight: Any?
+
+    override func setUp() {
+        super.setUp()
+
+        minimumWindowWidth = Defaults.minimumWindowWidth.value
+        minimumWindowHeight = Defaults.minimumWindowHeight.value
+        sizeOffset = Defaults.sizeOffset.value
+        gapSize = Defaults.gapSize.value
+        curtainChangeSize = Defaults.curtainChangeSize.enabled
+        storedMinimumWindowWidth = UserDefaults.standard.object(forKey: Defaults.minimumWindowWidth.key)
+        storedMinimumWindowHeight = UserDefaults.standard.object(forKey: Defaults.minimumWindowHeight.key)
+
+        Defaults.minimumWindowWidth.value = 0
+        Defaults.minimumWindowHeight.value = 0
+        Defaults.sizeOffset.value = 30
+        Defaults.gapSize.value = 0
+        Defaults.curtainChangeSize.enabled = true
+    }
+
+    override func tearDown() {
+        Defaults.minimumWindowWidth.value = minimumWindowWidth
+        Defaults.minimumWindowHeight.value = minimumWindowHeight
+        restoreStoredValue(storedMinimumWindowWidth, for: Defaults.minimumWindowWidth.key)
+        restoreStoredValue(storedMinimumWindowHeight, for: Defaults.minimumWindowHeight.key)
+        Defaults.sizeOffset.value = sizeOffset
+        Defaults.gapSize.value = gapSize
+        Defaults.curtainChangeSize.enabled = curtainChangeSize
+
+        super.tearDown()
+    }
+
+    func testExplicitZeroDisablesScreenFractionMinimum() {
+        XCTAssertEqual(smallerResult(for: issueWindowRect),
+                       CGRect(x: 1925, y: 0, width: 635, height: 1415))
+    }
+
+    func testMinimumFractionDefaultDistinguishesAbsentFromExplicitZero() {
+        let key = "ChangeSizeCalculationTests.minimumWindowWidth"
+        UserDefaults.standard.removeObject(forKey: key)
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+
+        let absentPreference = MinimumWindowFractionDefault(key: key)
+        XCTAssertEqual(absentPreference.value, 0.25)
+        XCTAssertEqual(absentPreference.toCodable().float, 0.25)
+
+        absentPreference.value = 0
+        let explicitZeroPreference = MinimumWindowFractionDefault(key: key)
+        XCTAssertEqual(explicitZeroPreference.value, 0)
+        XCTAssertEqual(explicitZeroPreference.toCodable().float, -1)
+
+        explicitZeroPreference.load(from: CodableDefault(float: 0))
+        XCTAssertEqual(explicitZeroPreference.value, 0.25)
+
+        explicitZeroPreference.load(from: CodableDefault(float: -1))
+        XCTAssertEqual(explicitZeroPreference.value, 0)
+    }
+
+    func testSmallerCanReachExactConfiguredMinimum() {
+        Defaults.minimumWindowWidth.value = 0.25
+        let windowRect = CGRect(x: 1890, y: 0, width: 670, height: 1415)
+
+        XCTAssertEqual(smallerResult(for: windowRect),
+                       CGRect(x: 1920, y: 0, width: 640, height: 1415))
+    }
+
+    func testSmallerHonorsConfiguredScreenFractionMinimum() {
+        Defaults.minimumWindowWidth.value = 0.25
+
+        XCTAssertEqual(smallerResult(for: issueWindowRect), issueWindowRect)
+    }
+
+    func testSmallConfiguredScreenFractionAllowsIssueRegressionStep() {
+        Defaults.minimumWindowWidth.value = 0.01
+
+        XCTAssertEqual(smallerResult(for: issueWindowRect),
+                       CGRect(x: 1925, y: 0, width: 635, height: 1415))
+    }
+
+    func testExplicitZeroStillRejectsNonpositiveSize() {
+        let narrowWindow = CGRect(x: 100, y: 100, width: 20, height: 100)
+
+        XCTAssertEqual(smallerResult(for: narrowWindow), narrowWindow)
+    }
+
+    private func smallerResult(for windowRect: CGRect) -> CGRect {
+        ChangeSizeCalculation().calculateRect(
+            RectCalculationParameters(window: Window(id: 1, rect: windowRect),
+                                      visibleFrameOfScreen: visibleFrame,
+                                      action: .smaller,
+                                      lastAction: nil)
+        ).rect
+    }
+
+    private func restoreStoredValue(_ value: Any?, for key: String) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+}
+
 class CooperativeCornerResizeTests: XCTestCase {
     private let screenFrame = CGRect(x: 0, y: 0, width: 1200, height: 900)
     private let minimumSize = CGSize(width: 100, height: 100)

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -153,8 +153,8 @@ class DefaultsExportTests: XCTestCase {
 class ChangeSizeCalculationTests: XCTestCase {
     private let visibleFrame = CGRect(x: 0, y: 0, width: 2560, height: 1415)
     private let issueWindowRect = CGRect(x: 1895, y: 0, width: 665, height: 1415)
-    private var minimumWindowWidth: Float = 0
-    private var minimumWindowHeight: Float = 0
+    private var minimumWindowWidth: Double = 0
+    private var minimumWindowHeight: Double = 0
     private var sizeOffset: Float = 0
     private var gapSize: Float = 0
     private var curtainChangeSize: Bool?
@@ -196,25 +196,57 @@ class ChangeSizeCalculationTests: XCTestCase {
                        CGRect(x: 1925, y: 0, width: 635, height: 1415))
     }
 
-    func testMinimumFractionDefaultDistinguishesAbsentFromExplicitZero() {
+    func testDoubleDefaultDistinguishesAbsentFromExplicitZero() {
         let key = "ChangeSizeCalculationTests.minimumWindowWidth"
         UserDefaults.standard.removeObject(forKey: key)
         defer { UserDefaults.standard.removeObject(forKey: key) }
 
-        let absentPreference = MinimumWindowFractionDefault(key: key)
+        let absentPreference = DoubleDefault(key: key, defaultValue: 0.25)
         XCTAssertEqual(absentPreference.value, 0.25)
-        XCTAssertEqual(absentPreference.toCodable().float, 0.25)
+        XCTAssertEqual(absentPreference.toCodable().double, 0.25)
+        XCTAssertNil(absentPreference.toCodable().float)
 
         absentPreference.value = 0
-        let explicitZeroPreference = MinimumWindowFractionDefault(key: key)
+        let explicitZeroPreference = DoubleDefault(key: key, defaultValue: 0.25)
         XCTAssertEqual(explicitZeroPreference.value, 0)
-        XCTAssertEqual(explicitZeroPreference.toCodable().float, -1)
+        XCTAssertEqual(explicitZeroPreference.toCodable().double, 0)
+        XCTAssertNil(explicitZeroPreference.toCodable().float)
+    }
 
-        explicitZeroPreference.load(from: CodableDefault(float: 0))
-        XCTAssertEqual(explicitZeroPreference.value, 0.25)
+    func testDoubleDefaultLoadsLegacyFloatAndNewDoubleConfigValues() throws {
+        let key = "ChangeSizeCalculationTests.minimumWindowWidthConfig"
+        UserDefaults.standard.removeObject(forKey: key)
+        defer { UserDefaults.standard.removeObject(forKey: key) }
 
-        explicitZeroPreference.load(from: CodableDefault(float: -1))
-        XCTAssertEqual(explicitZeroPreference.value, 0)
+        let preference = DoubleDefault(key: key, defaultValue: 0.25)
+        let legacyZero = try JSONDecoder().decode(
+            CodableDefault.self,
+            from: Data(#"{"float":0}"#.utf8)
+        )
+        let legacyFraction = try JSONDecoder().decode(
+            CodableDefault.self,
+            from: Data(#"{"float":0.01}"#.utf8)
+        )
+        let currentZero = try JSONDecoder().decode(
+            CodableDefault.self,
+            from: Data(#"{"double":0}"#.utf8)
+        )
+        let currentFraction = try JSONDecoder().decode(
+            CodableDefault.self,
+            from: Data(#"{"double":0.123456789012345}"#.utf8)
+        )
+
+        preference.load(from: legacyZero)
+        XCTAssertEqual(preference.value, 0.25)
+
+        preference.load(from: legacyFraction)
+        XCTAssertEqual(preference.value, Double(Float(0.01)))
+
+        preference.load(from: currentFraction)
+        XCTAssertEqual(preference.value, 0.123456789012345)
+
+        preference.load(from: currentZero)
+        XCTAssertEqual(preference.value, 0)
     }
 
     func testSmallerCanReachExactConfiguredMinimum() {

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -318,6 +318,8 @@ defaults write com.knollsoft.Rectangle centeredDirectionalMove -int 2
 
 By default, "Make Smaller" will decrease the window until it reaches 25% of the screen (width & height).
 
+Set either value to `0` to disable Rectangle's screen-relative limit for that dimension and rely on the application's native minimum size.
+
 ```bash
 defaults write com.knollsoft.Rectangle minimumWindowWidth -float <VALUE_BETWEEN_0_&_1>
 ```


### PR DESCRIPTION
## Summary

- allow an explicit zero minimum-window fraction to disable Rectangle's screen-relative limit
- use a reusable `DoubleDefault` for minimum-window fractions while importing legacy float-backed configs
- preserve the existing 25% default when no preference is stored
- allow windows to reach an exact configured limit while retaining a one-point safety floor
- document the zero-value behavior

## Root cause

The minimum-size calculation treated zero as invalid and substituted the 25% default. On the reported 2560-point display, the next 30-point resize step from 665 to 635 points was rejected against a 640-point floor before any accessibility resize was attempted.

## User impact

Setting `minimumWindowWidth` or `minimumWindowHeight` to `0` now lets the application enforce its native minimum size. Existing installations without an explicit setting continue to use Rectangle's 25% default.

## Testing

- `ChangeSizeCalculationTests`: 7 passed
- all tests outside the two existing cooperative-resize test classes: 128 passed
- full scheme: 171 passed; the 10 failing cooperative-resize test cases reproduce unchanged on `upstream/main`
- `git diff --check`

Fixes #388
