### PR TITLE
Make snap area config export deterministic

### DIFF
--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -436,6 +436,18 @@ class IntDefault: Default {
     }
 }
 
+private struct SortedSnapAreaConfigs: Encodable {
+    let snapAreas: [Directional: SnapAreaConfig]
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        for (directional, snapAreaConfig) in snapAreas.sorted(by: { $0.key.rawValue < $1.key.rawValue }) {
+            try container.encode(directional)
+            try container.encode(snapAreaConfig)
+        }
+    }
+}
+
 class JSONDefault<T: Codable>: StringDefault {
     
     private var typeInitialized = false
@@ -478,14 +490,28 @@ class JSONDefault<T: Codable>: StringDefault {
     }
     
     private func saveToJSON(_ obj: T?) {
-        let encoder = JSONEncoder()
-        
-        if let jsonData = try? encoder.encode(obj) {
-            let jsonString = String(data: jsonData, encoding: .utf8)
-            if jsonString != value {
-                value = jsonString
-            }
+        if let jsonString = encodedString(obj), jsonString != value {
+            value = jsonString
         }
+    }
+
+    private func encodedString(_ obj: T?) -> String? {
+        let encoder = JSONEncoder()
+
+        let jsonData: Data?
+        if let snapAreas = obj as? [Directional: SnapAreaConfig] {
+            encoder.outputFormatting = .sortedKeys
+            jsonData = try? encoder.encode(SortedSnapAreaConfigs(snapAreas: snapAreas))
+        } else {
+            jsonData = try? encoder.encode(obj)
+        }
+        guard let jsonData = jsonData else { return nil }
+        return String(data: jsonData, encoding: .utf8)
+    }
+
+    override func toCodable() -> CodableDefault {
+        guard typedValue is [Directional: SnapAreaConfig] else { return super.toCodable() }
+        return CodableDefault(string: encodedString(typedValue))
     }
 }
 

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -146,6 +146,67 @@ class DefaultsExportTests: XCTestCase {
     }
 }
 
+class JSONDefaultSerializationTests: XCTestCase {
+
+    func testSnapAreaSerializationSortsDirectionalKeys() {
+        let key = "JSONDefaultSerializationTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+        let jsonDefault = JSONDefault<[Directional: SnapAreaConfig]>(key: key)
+
+        jsonDefault.typedValue = [
+            .bl: SnapAreaConfig(action: .bottomLeft),
+            .b: SnapAreaConfig(compound: .thirds),
+            .l: SnapAreaConfig(compound: .leftTopBottomHalf),
+            .tl: SnapAreaConfig(action: .topLeft),
+            .br: SnapAreaConfig(action: .bottomRight),
+            .tr: SnapAreaConfig(action: .topRight),
+            .r: SnapAreaConfig(compound: .rightTopBottomHalf)
+        ]
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: key), "[1,{\"action\":15},3,{\"action\":16},4,{\"compound\":-2},5,{\"compound\":-3},6,{\"action\":13},7,{\"compound\":-4},8,{\"action\":14}]")
+    }
+
+    func testSnapAreaExportCanonicalizesLoadedJSON() {
+        let key = "JSONDefaultSerializationTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+        UserDefaults.standard.set("[6,{\"action\":13},7,{\"compound\":-4},4,{\"compound\":-2},1,{\"action\":15},8,{\"action\":14},3,{\"action\":16},5,{\"compound\":-3}]", forKey: key)
+
+        let jsonDefault = JSONDefault<[Directional: SnapAreaConfig]>(key: key)
+
+        XCTAssertEqual(jsonDefault.toCodable().string, "[1,{\"action\":15},3,{\"action\":16},4,{\"compound\":-2},5,{\"compound\":-3},6,{\"action\":13},7,{\"compound\":-4},8,{\"action\":14}]")
+    }
+
+    func testNonSnapStoredJSONExportsRawValue() {
+        let key = "JSONDefaultSerializationTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+        let storedJSON = "{\"z\":1,\"a\":2}"
+        UserDefaults.standard.set(storedJSON, forKey: key)
+
+        let jsonDefault = JSONDefault<[String: Int]>(key: key)
+
+        XCTAssertEqual(jsonDefault.toCodable().string, storedJSON)
+    }
+
+    func testUnsetJSONDefaultExportsAsUnset() {
+        let key = "JSONDefaultSerializationTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+        let jsonDefault = JSONDefault<[String: Int]>(key: key)
+
+        XCTAssertNil(jsonDefault.toCodable().string)
+    }
+
+    func testInvalidStoredJSONExportsRawValue() {
+        let key = "JSONDefaultSerializationTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+        let invalidJSON = "not valid JSON"
+        UserDefaults.standard.set(invalidJSON, forKey: key)
+
+        let jsonDefault = JSONDefault<[String: Int]>(key: key)
+
+        XCTAssertEqual(jsonDefault.toCodable().string, invalidJSON)
+    }
+}
+
 class StackBadgeGeometryTests: XCTestCase {
 
     private let laptopFrame = CGRect(x: 0, y: 0, width: 2336, height: 1510)


### PR DESCRIPTION
## Summary

- serialize snap-area dictionaries in a stable `Directional.rawValue` order
- preserve Rectangle's existing alternating key/value JSON schema
- canonicalize previously persisted valid snap-area JSON during config export
- preserve raw export behavior for unset, malformed, and unrelated JSON defaults

Fixes #1468.

## Verification

- `JSONDefaultSerializationTests`: 5/5 passing
- full `RectangleTests`: 210 tests run; the same 22 pre-existing assertions fail as on `main`, confined to `ActiveSideSplitRatiosCooperativeTests`, `CooperativeCornerResizeTests`, and `HalfSplitCornerCalculationTests`
- `git diff --check origin/main...HEAD`

## AI assistance

AI tooling assisted with investigation, implementation, and test generation. The final diff was reviewed against the issue, independently code-reviewed twice, and verified locally.
