### PR TITLE
Reapply shortcuts when restoring current defaults

### DIFF
--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -253,19 +253,14 @@ class SettingsViewController: NSViewController {
 
         //  Restore default shortcuts
         let rectangleDefaults = response == .alertFirstButtonReturn
-        Self.restoreShortcutDefaults(rectangleDefaults: rectangleDefaults)
+        WindowAction.active.forEach { UserDefaults.standard.removeObject(forKey: $0.name) }
+        Defaults.alternateDefaultShortcuts.enabled = rectangleDefaults
+        Notification.Name.changeDefaults.post()
         
         // Restore snap areas
         Defaults.portraitSnapAreas.typedValue = nil
         Defaults.landscapeSnapAreas.typedValue = nil
         Notification.Name.defaultSnapAreas.post()
-    }
-
-    static func restoreShortcutDefaults(rectangleDefaults: Bool,
-                                        notificationCenter: NotificationCenter = .default) {
-        WindowAction.active.forEach { UserDefaults.standard.removeObject(forKey: $0.name) }
-        Defaults.alternateDefaultShortcuts.enabled = rectangleDefaults
-        Notification.Name.changeDefaults.post(center: notificationCenter)
     }
     
     @IBAction func exportConfig(_ sender: NSButton) {

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -252,17 +252,20 @@ class SettingsViewController: NSViewController {
         if response == .alertThirdButtonReturn { return }
 
         //  Restore default shortcuts
-        WindowAction.active.forEach { UserDefaults.standard.removeObject(forKey: $0.name) }
         let rectangleDefaults = response == .alertFirstButtonReturn
-        if rectangleDefaults != Defaults.alternateDefaultShortcuts.enabled {
-            Defaults.alternateDefaultShortcuts.enabled = rectangleDefaults
-            Notification.Name.changeDefaults.post()
-        }
+        Self.restoreShortcutDefaults(rectangleDefaults: rectangleDefaults)
         
         // Restore snap areas
         Defaults.portraitSnapAreas.typedValue = nil
         Defaults.landscapeSnapAreas.typedValue = nil
         Notification.Name.defaultSnapAreas.post()
+    }
+
+    static func restoreShortcutDefaults(rectangleDefaults: Bool,
+                                        notificationCenter: NotificationCenter = .default) {
+        WindowAction.active.forEach { UserDefaults.standard.removeObject(forKey: $0.name) }
+        Defaults.alternateDefaultShortcuts.enabled = rectangleDefaults
+        Notification.Name.changeDefaults.post(center: notificationCenter)
     }
     
     @IBAction func exportConfig(_ sender: NSButton) {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -146,6 +146,83 @@ class DefaultsExportTests: XCTestCase {
     }
 }
 
+class ShortcutDefaultsRestoreTests: XCTestCase {
+
+    private static let defaultsKeys = WindowAction.active.map(\.name) + [Defaults.alternateDefaultShortcuts.key]
+    private var storedValues = [String: Any]()
+    private var absentKeys = Set<String>()
+    private var alternateDefaultShortcuts = false
+
+    override func setUp() {
+        super.setUp()
+        storedValues.removeAll()
+        absentKeys.removeAll()
+        alternateDefaultShortcuts = Defaults.alternateDefaultShortcuts.enabled
+
+        for key in Self.defaultsKeys {
+            if let value = UserDefaults.standard.object(forKey: key) {
+                storedValues[key] = value
+            } else {
+                absentKeys.insert(key)
+            }
+        }
+    }
+
+    override func tearDown() {
+        Defaults.alternateDefaultShortcuts.enabled = alternateDefaultShortcuts
+        for key in Self.defaultsKeys {
+            if let value = storedValues[key] {
+                UserDefaults.standard.set(value, forKey: key)
+            } else if absentKeys.contains(key) {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+        storedValues.removeAll()
+        absentKeys.removeAll()
+        super.tearDown()
+    }
+
+    func testRestoreSameSchemeClearsOverrideAndPostsChangeDefaultsOnce() {
+        let action = WindowAction.almostMaximize
+        let rectangleDefaults = Defaults.alternateDefaultShortcuts.enabled
+        UserDefaults.standard.set(["keyCode": 12, "modifierFlags": NSEvent.ModifierFlags.command.rawValue],
+                                  forKey: action.name)
+        let notificationCenter = NotificationCenter()
+        var notificationCount = 0
+        let observer = notificationCenter.addObserver(forName: .changeDefaults, object: nil, queue: nil) { _ in
+            notificationCount += 1
+        }
+        defer { notificationCenter.removeObserver(observer) }
+
+        SettingsViewController.restoreShortcutDefaults(rectangleDefaults: rectangleDefaults,
+                                                       notificationCenter: notificationCenter)
+
+        XCTAssertNil(UserDefaults.standard.object(forKey: action.name))
+        XCTAssertEqual(Defaults.alternateDefaultShortcuts.enabled, rectangleDefaults)
+        XCTAssertEqual(notificationCount, 1)
+    }
+
+    func testRestoreChangedSchemeClearsOverrideAndPostsChangeDefaultsOnce() {
+        let action = WindowAction.almostMaximize
+        let rectangleDefaults = !Defaults.alternateDefaultShortcuts.enabled
+        UserDefaults.standard.set(["keyCode": 13, "modifierFlags": NSEvent.ModifierFlags.option.rawValue],
+                                  forKey: action.name)
+        let notificationCenter = NotificationCenter()
+        var notificationCount = 0
+        let observer = notificationCenter.addObserver(forName: .changeDefaults, object: nil, queue: nil) { _ in
+            notificationCount += 1
+        }
+        defer { notificationCenter.removeObserver(observer) }
+
+        SettingsViewController.restoreShortcutDefaults(rectangleDefaults: rectangleDefaults,
+                                                       notificationCenter: notificationCenter)
+
+        XCTAssertNil(UserDefaults.standard.object(forKey: action.name))
+        XCTAssertEqual(Defaults.alternateDefaultShortcuts.enabled, rectangleDefaults)
+        XCTAssertEqual(notificationCount, 1)
+    }
+}
+
 class StackBadgeGeometryTests: XCTestCase {
 
     private let laptopFrame = CGRect(x: 0, y: 0, width: 2336, height: 1510)


### PR DESCRIPTION
## Summary

- always reload registered shortcuts after restoring a default shortcut scheme
- clear all active shortcut overrides before selecting the requested scheme
- preserve the existing cancel flow and snap-area reset behavior

Fixes #1119.

Previously, selecting the already-active scheme removed persisted overrides but skipped the `changeDefaults` notification. The shortcut binder therefore kept stale or conflicting bindings until Rectangle restarted.

## Verification

- `ShortcutDefaultsRestoreTests`: 2/2 passing for same-scheme and changed-scheme resets
- full `RectangleTests`: 207 tests run; the same 22 pre-existing assertions fail as on `main`, confined to `ActiveSideSplitRatiosCooperativeTests`, `CooperativeCornerResizeTests`, and `HalfSplitCornerCalculationTests`
- `git diff --check origin/main...HEAD`

## AI assistance

AI tooling assisted with investigation, implementation, and test generation. The final diff passed independent specification and code-quality reviews and was verified locally.
