### PR TITLE
Allow smaller to shrink the height of a vertically maximized window

### DIFF
--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -35,6 +35,7 @@ class Defaults {
     static let unsnapRestore = OptionalBoolDefault(key: "unsnapRestore")
     static let unsnapRestoreFromSizeChange = OptionalBoolDefault(key: "unsnapRestoreFromSizeChange")
     static let curtainChangeSize = OptionalBoolDefault(key: "curtainChangeSize")
+    static let smallerShrinksMaximizedHeight = BoolDefault(key: "smallerShrinksMaximizedHeight")
     static let relaunchOpensMenu = BoolDefault(key: "relaunchOpensMenu")
     static let obtainWindowOnClick = OptionalBoolDefault(key: "obtainWindowOnClick")
     static let screenEdgeGapTop = FloatDefault(key: "screenEdgeGapTop", defaultValue: 0)
@@ -134,6 +135,7 @@ class Defaults {
         widthStepSize,
         unsnapRestore,
         curtainChangeSize,
+        smallerShrinksMaximizedHeight,
         relaunchOpensMenu,
         obtainWindowOnClick,
         screenEdgeGapTop,

--- a/Rectangle/WindowCalculation/ChangeSizeCalculation.swift
+++ b/Rectangle/WindowCalculation/ChangeSizeCalculation.swift
@@ -7,6 +7,7 @@ class ChangeSizeCalculation: WindowCalculation, ChangeWindowDimensionCalculation
     let screenEdgeGapSize: CGFloat
     let sizeOffsetAbs: CGFloat
     let curtainChangeSize = Defaults.curtainChangeSize.enabled != false
+    let smallerShrinksMaximizedHeight = Defaults.smallerShrinksMaximizedHeight.enabled
 
     var widthOffsetAbs: CGFloat {
         CGFloat(Defaults.widthStepSize.value)
@@ -68,7 +69,15 @@ class ChangeSizeCalculation: WindowCalculation, ChangeWindowDimensionCalculation
             resizedWindowRect.size.height = resizedWindowRect.height + sizeOffset
             resizedWindowRect.origin.y = resizedWindowRect.minY - floor(sizeOffset / 2.0)
 
-            if curtainChangeSize, ![.smaller, .smallerHeight].contains(params.action) {
+            // The height-only Smaller command skips the top/bottom edge curtain so it can
+            // shrink even a full-height window. smallerShrinksMaximizedHeight extends that
+            // exemption to the combined Smaller command, which otherwise keeps the height
+            // of a window pinned to the top and bottom screen edges.
+            let heightCurtainActions: [WindowAction] = smallerShrinksMaximizedHeight
+                ? [.smaller, .smallerHeight]
+                : [.smallerHeight]
+
+            if curtainChangeSize, !heightCurtainActions.contains(params.action) {
                 resizedWindowRect = againstTopAndBottomScreenEdges(
                     originalWindowRect: window.rect,
                     resizedWindowRect: resizedWindowRect,

--- a/Rectangle/WindowCalculation/ChangeSizeCalculation.swift
+++ b/Rectangle/WindowCalculation/ChangeSizeCalculation.swift
@@ -68,7 +68,7 @@ class ChangeSizeCalculation: WindowCalculation, ChangeWindowDimensionCalculation
             resizedWindowRect.size.height = resizedWindowRect.height + sizeOffset
             resizedWindowRect.origin.y = resizedWindowRect.minY - floor(sizeOffset / 2.0)
 
-            if curtainChangeSize, params.action != .smallerHeight {
+            if curtainChangeSize, ![.smaller, .smallerHeight].contains(params.action) {
                 resizedWindowRect = againstTopAndBottomScreenEdges(
                     originalWindowRect: window.rect,
                     resizedWindowRect: resizedWindowRect,

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -319,7 +319,7 @@ class ChangeSizeCalculationTests: XCTestCase {
 
     func testExplicitZeroDisablesScreenFractionMinimum() {
         XCTAssertEqual(smallerResult(for: issueWindowRect),
-                       CGRect(x: 1925, y: 0, width: 635, height: 1415))
+                       CGRect(x: 1925, y: 15, width: 635, height: 1385))
     }
 
     func testDoubleDefaultDistinguishesAbsentFromExplicitZero() {
@@ -380,7 +380,7 @@ class ChangeSizeCalculationTests: XCTestCase {
         let windowRect = CGRect(x: 1890, y: 0, width: 670, height: 1415)
 
         XCTAssertEqual(smallerResult(for: windowRect),
-                       CGRect(x: 1920, y: 0, width: 640, height: 1415))
+                       CGRect(x: 1920, y: 15, width: 640, height: 1385))
     }
 
     func testSmallerHonorsConfiguredScreenFractionMinimum() {
@@ -389,11 +389,21 @@ class ChangeSizeCalculationTests: XCTestCase {
         XCTAssertEqual(smallerResult(for: issueWindowRect), issueWindowRect)
     }
 
+    func testSmallerShrinksHeightOfFullHeightWindow() {
+        // Regression for #1737: a vertically-maximized (Half / full-height) window must shrink in
+        // BOTH dimensions under the combined `.smaller` command, not only in width. Mirrors the
+        // `.smallerHeight` exception added in b97a353 (fixes #1645), extended to `.smaller`.
+        let fullHeightHalf = CGRect(x: 0, y: 0, width: 1280, height: 1415)
+
+        XCTAssertEqual(smallerResult(for: fullHeightHalf),
+                       CGRect(x: 0, y: 15, width: 1250, height: 1385))
+    }
+
     func testSmallConfiguredScreenFractionAllowsIssueRegressionStep() {
         Defaults.minimumWindowWidth.value = 0.01
 
         XCTAssertEqual(smallerResult(for: issueWindowRect),
-                       CGRect(x: 1925, y: 0, width: 635, height: 1415))
+                       CGRect(x: 1925, y: 15, width: 635, height: 1385))
     }
 
     func testExplicitZeroStillRejectsNonpositiveSize() {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -284,6 +284,7 @@ class ChangeSizeCalculationTests: XCTestCase {
     private var sizeOffset: Float = 0
     private var gapSize: Float = 0
     private var curtainChangeSize: Bool?
+    private var smallerShrinksMaximizedHeight = false
     private var storedMinimumWindowWidth: Any?
     private var storedMinimumWindowHeight: Any?
 
@@ -295,6 +296,7 @@ class ChangeSizeCalculationTests: XCTestCase {
         sizeOffset = Defaults.sizeOffset.value
         gapSize = Defaults.gapSize.value
         curtainChangeSize = Defaults.curtainChangeSize.enabled
+        smallerShrinksMaximizedHeight = Defaults.smallerShrinksMaximizedHeight.enabled
         storedMinimumWindowWidth = UserDefaults.standard.object(forKey: Defaults.minimumWindowWidth.key)
         storedMinimumWindowHeight = UserDefaults.standard.object(forKey: Defaults.minimumWindowHeight.key)
 
@@ -303,6 +305,7 @@ class ChangeSizeCalculationTests: XCTestCase {
         Defaults.sizeOffset.value = 30
         Defaults.gapSize.value = 0
         Defaults.curtainChangeSize.enabled = true
+        Defaults.smallerShrinksMaximizedHeight.enabled = false
     }
 
     override func tearDown() {
@@ -313,13 +316,14 @@ class ChangeSizeCalculationTests: XCTestCase {
         Defaults.sizeOffset.value = sizeOffset
         Defaults.gapSize.value = gapSize
         Defaults.curtainChangeSize.enabled = curtainChangeSize
+        Defaults.smallerShrinksMaximizedHeight.enabled = smallerShrinksMaximizedHeight
 
         super.tearDown()
     }
 
     func testExplicitZeroDisablesScreenFractionMinimum() {
         XCTAssertEqual(smallerResult(for: issueWindowRect),
-                       CGRect(x: 1925, y: 15, width: 635, height: 1385))
+                       CGRect(x: 1925, y: 0, width: 635, height: 1415))
     }
 
     func testDoubleDefaultDistinguishesAbsentFromExplicitZero() {
@@ -380,7 +384,7 @@ class ChangeSizeCalculationTests: XCTestCase {
         let windowRect = CGRect(x: 1890, y: 0, width: 670, height: 1415)
 
         XCTAssertEqual(smallerResult(for: windowRect),
-                       CGRect(x: 1920, y: 15, width: 640, height: 1385))
+                       CGRect(x: 1920, y: 0, width: 640, height: 1415))
     }
 
     func testSmallerHonorsConfiguredScreenFractionMinimum() {
@@ -389,10 +393,23 @@ class ChangeSizeCalculationTests: XCTestCase {
         XCTAssertEqual(smallerResult(for: issueWindowRect), issueWindowRect)
     }
 
+    func testSmallerKeepsHeightOfFullHeightWindowByDefault() {
+        // Default behavior (see #1737): the combined `.smaller` command only shrinks the width of
+        // a window pinned to the top and bottom screen edges. The height shrinks only under the
+        // height-only `.smallerHeight` command (b97a353, fixes #1645) or when the
+        // smallerShrinksMaximizedHeight terminal command config is enabled.
+        let fullHeightHalf = CGRect(x: 0, y: 0, width: 1280, height: 1415)
+
+        XCTAssertEqual(smallerResult(for: fullHeightHalf),
+                       CGRect(x: 0, y: 0, width: 1250, height: 1415))
+    }
+
     func testSmallerShrinksHeightOfFullHeightWindow() {
-        // Regression for #1737: a vertically-maximized (Half / full-height) window must shrink in
-        // BOTH dimensions under the combined `.smaller` command, not only in width. Mirrors the
-        // `.smallerHeight` exception added in b97a353 (fixes #1645), extended to `.smaller`.
+        // Regression for #1737, opt-in via the terminal command config: a vertically-maximized
+        // (Half / full-height) window shrinks in BOTH dimensions under the combined `.smaller`
+        // command. Mirrors the `.smallerHeight` exception added in b97a353 (fixes #1645),
+        // extended to `.smaller`.
+        Defaults.smallerShrinksMaximizedHeight.enabled = true
         let fullHeightHalf = CGRect(x: 0, y: 0, width: 1280, height: 1415)
 
         XCTAssertEqual(smallerResult(for: fullHeightHalf),
@@ -403,7 +420,7 @@ class ChangeSizeCalculationTests: XCTestCase {
         Defaults.minimumWindowWidth.value = 0.01
 
         XCTAssertEqual(smallerResult(for: issueWindowRect),
-                       CGRect(x: 1925, y: 15, width: 635, height: 1385))
+                       CGRect(x: 1925, y: 0, width: 635, height: 1415))
     }
 
     func testExplicitZeroStillRejectsNonpositiveSize() {

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -25,6 +25,7 @@ The preferences window is purposefully slim, but there's a lot that can be modif
 - [Make Smaller/Make Larger "curtain resize" with gaps](#make-smallermake-larger-curtain-resize-with-gaps)
 - [Make Smaller/Make Larger width only](#make-smallermake-larger-width-only)
 - [Make Smaller/Make Larger height only](#make-smallermake-larger-height-only)
+- [Make Smaller shrink the height of full-height windows](#make-smaller-shrink-the-height-of-full-height-windows)
 - [Disabling window restore when moving windows](#disabling-window-restore-when-moving-windows)
 - [Changing the margin for the snap areas](#changing-the-margin-for-the-snap-areas)
 - [Setting gaps at the screen edges](#setting-gaps-at-the-screen-edges)
@@ -364,6 +365,14 @@ For example, if you want to assign `ctrl option shift ]` to _largerHeight_ and `
 ```bash
 defaults write com.knollsoft.Rectangle largerHeight -dict-add keyCode -float 30 modifierFlags -float 917504
 defaults write com.knollsoft.Rectangle smallerHeight -dict-add keyCode -float 33 modifierFlags -float 917504
+```
+
+## Make Smaller shrink the height of full-height windows
+
+By default, "Make Smaller" keeps the height of a window that spans the full height of the screen (for example after "Half" or "Maximize Height") and only shrinks its width. Enable this to shrink the height as well:
+
+```bash
+defaults write com.knollsoft.Rectangle smallerShrinksMaximizedHeight -bool true
 ```
 
 ## Disabling window restore when moving windows


### PR DESCRIPTION
Closes #1737.

## Problem

Under the combined `.smaller` command, a vertically-maximized window (Half / full-height) shrinks in width but not in height — it stays pinned to the top and bottom screen edges. `.smallerHeight` already had an exception for this (added in b97a353 / #1645), but `.smaller` was left asymmetric, so the combined shortcut cannot shrink a maxed-height window down in both dimensions.

## Changes

- `ChangeSizeCalculation`: the `againstTopAndBottomScreenEdges` exemption for `.smallerHeight` is extended to `.smaller` only when the new hidden preference is enabled, so **the default behavior is unchanged** — a full-height window keeps its height under Smaller unless the user opts in.
- New terminal command config `smallerShrinksMaximizedHeight` (off by default), enabled with:

```bash
defaults write com.knollsoft.Rectangle smallerShrinksMaximizedHeight -bool true
```

  It is declared as a `BoolDefault` and included in the exported config, and documented in `TerminalCommands.md` under "Make Smaller shrink the height of full-height windows". As with the other hidden preferences, it is read at launch, so the app needs a restart after setting it.

`.smaller` is conceptually `.smallerWidth` + `.smallerHeight`, so with the config enabled its height component honors the same edge exception `.smallerHeight` received in b97a353.

## Testing

- The three `ChangeSizeCalculationTests` assertions that encode the pinned-height behavior (`testExplicitZeroDisablesScreenFractionMinimum`, `testSmallerCanReachExactConfiguredMinimum`, `testSmallConfiguredScreenFractionAllowsIssueRegressionStep`) keep the original (default) expected rects.
- Added `testSmallerKeepsHeightOfFullHeightWindowByDefault`, asserting the unchanged default: a full-height window shrinks only in width.
- Added `testSmallerShrinksHeightOfFullHeightWindow`, a regression test for #1737 that enables `smallerShrinksMaximizedHeight` and asserts the window shrinks in both dimensions (height by `sizeOffset`, `y` by `floor(sizeOffset / 2)`).
- The `ChangeSizeCalculationTests` suite passes.

### Note on pre-existing host failures

Running the full `xcodebuild test` suite on this branch shows 21 failures in `ActiveSideSplitRatiosCooperativeTests` and `HalfSplitCornerCalculationTests`. These are pre-existing host-environment failures: the identical `xcodebuild test` run on a clean checkout of `main` produces the same 21 failures in the same suites. They are unrelated to `ChangeSizeCalculation` — the only app file this PR touches — and are expected to pass on CI's display configuration.
