### PR TITLE
Bound the overlap-offset scan and offset maximized windows too

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		9824704F22B189250037B409 /* BestEffortWindowMover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9824704A22B189250037B409 /* BestEffortWindowMover.swift */; };
 		9824705122B28D7A0037B409 /* LeftRightHalfCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9824705022B28D7A0037B409 /* LeftRightHalfCalculation.swift */; };
 		983BBD6F253B609D000D223E /* FootprintWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983BBD6E253B609D000D223E /* FootprintWindow.swift */; };
+		F1AC0DE000000000000000C2 /* OverlapOffsetGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000C1 /* OverlapOffsetGeometry.swift */; };
 		F1AC0DE000000000000000A2 /* StackBadgeGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A1 /* StackBadgeGeometry.swift */; };
 		F1AC0DE000000000000000A4 /* StackBadgeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A3 /* StackBadgeManager.swift */; };
 		983DD04028A844BE00BF1EEE /* SnapAreaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */; };
@@ -319,6 +320,7 @@
 		9824704A22B189250037B409 /* BestEffortWindowMover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BestEffortWindowMover.swift; sourceTree = "<group>"; };
 		9824705022B28D7A0037B409 /* LeftRightHalfCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftRightHalfCalculation.swift; sourceTree = "<group>"; };
 		983BBD6E253B609D000D223E /* FootprintWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FootprintWindow.swift; sourceTree = "<group>"; };
+		F1AC0DE000000000000000C1 /* OverlapOffsetGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlapOffsetGeometry.swift; sourceTree = "<group>"; };
 		F1AC0DE000000000000000A1 /* StackBadgeGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeGeometry.swift; sourceTree = "<group>"; };
 		F1AC0DE000000000000000A3 /* StackBadgeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeManager.swift; sourceTree = "<group>"; };
 		983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaViewController.swift; sourceTree = "<group>"; };
@@ -652,6 +654,7 @@
 				AA0AC003291C48DE00D125D2 /* SequenceExtension.swift */,
 				AA3A9E8A29230A82004EB8E5 /* CFExtension.swift */,
 				98C2755D231FF6A9009B9292 /* EventMonitor.swift */,
+							F1AC0DE000000000000000C1 /* OverlapOffsetGeometry.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1095,6 +1098,7 @@
 				9824702C22AFA22E0037B409 /* AccessibilityWindowController.swift in Sources */,
 				988D066122EB4C7C004EABD7 /* FirstThirdCalculation.swift in Sources */,
 				983BBD6F253B609D000D223E /* FootprintWindow.swift in Sources */,
+				F1AC0DE000000000000000C2 /* OverlapOffsetGeometry.swift in Sources */,
 				F1AC0DE000000000000000A2 /* StackBadgeGeometry.swift in Sources */,
 				F1AC0DE000000000000000A4 /* StackBadgeManager.swift in Sources */,
 				988D067F22EB4EDE004EABD7 /* MoveLeftRightCalculation.swift in Sources */,

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -904,7 +904,7 @@ class SettingsViewController: NSViewController {
                 sixteenthsCyclingShortcutView
             ])
 
-            let overlapOffsetCheckbox = NSButton(checkboxWithTitle: NSLocalizedString("Offset cycling position on overlap", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleCyclingOverlapOffset(_:)))
+            let overlapOffsetCheckbox = NSButton(checkboxWithTitle: NSLocalizedString("Offset window position on overlap", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleCyclingOverlapOffset(_:)))
             overlapOffsetCheckbox.state = Defaults.cyclingOverlapOffset.userEnabled ? .on : .off
             overlapOffsetCheckbox.translatesAutoresizingMaskIntoConstraints = false
             overlapOffsetCheckbox.alignment = .left

--- a/Rectangle/Utilities/OverlapOffsetGeometry.swift
+++ b/Rectangle/Utilities/OverlapOffsetGeometry.swift
@@ -1,0 +1,69 @@
+//
+//  OverlapOffsetGeometry.swift
+//  Rectangle
+//
+//  Copyright © 2026 Ryan Hanson. All rights reserved.
+//
+
+import Foundation
+
+/// Pure geometry for the overlap offset: where a window lands when it arrives
+/// on a position other windows already occupy. Kept free of accessibility and
+/// screen lookups so the cascade math can be tested directly - every bug this
+/// feature has had lived here.
+enum OverlapOffsetGeometry {
+
+    /// Windows are matched by their top-left corner, so that a small window
+    /// landing on a larger one at the same corner still counts as an overlap.
+    static func topLeft(of rect: CGRect) -> CGPoint {
+        CGPoint(x: rect.minX, y: rect.maxY)
+    }
+
+    /// Whether a frame is large enough to count as covering the screen.
+    static func coversScreen(_ rect: CGRect, screenFrame: CGRect) -> Bool {
+        rect.width > screenFrame.width * 0.9 && rect.height > screenFrame.height * 0.9
+    }
+
+    /// How far the window can shift on each axis without crossing the far
+    /// edge of the visible frame. Zero on an axis that has no room: shifting
+    /// there anyway would push the window flush against that edge, which both
+    /// hides the window underneath again and eats any gap on that side.
+    static func offsetStep(for rect: CGRect, in screenFrame: CGRect, by offset: CGFloat) -> CGVector {
+        CGVector(dx: rect.maxX + offset <= screenFrame.maxX ? offset : 0,
+                 dy: rect.maxY + offset <= screenFrame.maxY ? offset : 0)
+    }
+
+    /// Whether the window has room to shift at all. A window sized to the
+    /// whole visible frame (a maximized window with no gaps) does not, so the
+    /// caller can skip scanning for overlaps entirely.
+    static func canOffset(_ rect: CGRect, in screenFrame: CGRect, by offset: CGFloat) -> Bool {
+        let step = offsetStep(for: rect, in: screenFrame, by: offset)
+        return step.dx != 0 || step.dy != 0
+    }
+
+    /// The rect to place, shifted clear of any window already at its top-left
+    /// corner, up to `maxCascade` times. Returns the rect unchanged when it
+    /// overlaps nothing or has nowhere left to go.
+    static func cascadedRect(_ rect: CGRect,
+                             occupiedTopLefts: [CGPoint],
+                             screenFrame: CGRect,
+                             offset: CGFloat,
+                             maxCascade: Int,
+                             tolerance: CGFloat = 4) -> CGRect {
+        guard offset > 0 else { return rect }
+        var candidate = rect
+        for _ in 0..<max(0, maxCascade) {
+            let corner = topLeft(of: candidate)
+            let overlaps = occupiedTopLefts.contains { occupied in
+                abs(occupied.x - corner.x) < tolerance && abs(occupied.y - corner.y) < tolerance
+            }
+            guard overlaps else { break }
+
+            let step = offsetStep(for: candidate, in: screenFrame, by: offset)
+            guard step.dx != 0 || step.dy != 0 else { break }
+            candidate.origin.x += step.dx
+            candidate.origin.y += step.dy
+        }
+        return candidate
+    }
+}

--- a/Rectangle/Utilities/OverlapOffsetGeometry.swift
+++ b/Rectangle/Utilities/OverlapOffsetGeometry.swift
@@ -1,26 +1,77 @@
-//
-//  OverlapOffsetGeometry.swift
-//  Rectangle
-//
-//  Copyright © 2026 Ryan Hanson. All rights reserved.
-//
+/// OverlapOffsetGeometry
 
 import Foundation
 
-/// Pure geometry for the overlap offset: where a window lands when it arrives
-/// on a position other windows already occupy. Kept free of accessibility and
-/// screen lookups so the cascade math can be tested directly - every bug this
-/// feature has had lived here.
+/// Geometry handling for the overlap offset: where a window lands when it arrives
+/// on a position other windows already occupy.
 enum OverlapOffsetGeometry {
+
+    /// Bounds how long a hung app can stall the overlap scan's accessibility calls.
+    /// Matches the badge's timeout for the same reason.
+    static let axScanTimeout: Float = 0.25
+
+    static func applyOverlapOffsetIfNeeded(_ rect: CGRect, windowId: CGWindowID?, screen: NSScreen) -> CGRect {
+        let overlapOffset = CGFloat(Defaults.cyclingOverlapOffsetSize.value)
+        guard overlapOffset > 0 else { return rect }
+
+        guard let windowId else { return rect }
+
+        let screenFrameNormalized = screen.adjustedVisibleFrame()
+
+        guard canOffset(rect, in: screenFrameNormalized, by: overlapOffset) else {
+            return rect
+        }
+
+        // Enumerates every window over the accessibility API on the main thread.
+        // Set timeout bounds to accessibility calls, so apps that are hanging or slow don't hang this.
+        AXUIElementSetMessagingTimeout(AXUIElement.systemWide, Self.axScanTimeout)
+        defer { AXUIElementSetMessagingTimeout(AXUIElement.systemWide, 0) }
+
+        let screenFrameAX = screenFrameNormalized.screenFlipped
+        let maxCascade = min(5, max(1, Defaults.cyclingOverlapMaxCascade.value))
+        let placedCoversScreen = coversScreen(rect, screenFrame: screenFrameNormalized)
+
+        // Each element.frame is a pair of accessibility round-trips, so the
+        // frames are read once here rather than on every cascade iteration.
+        let occupiedTopLefts: [CGPoint] = AccessibilityElement.getAllWindowElements().compactMap { element in
+            guard element.getWindowId() != windowId,
+                  element.isWindow == true,
+                  element.isMinimized != true,
+                  element.isHidden != true,
+                  element.isSheet != true
+            else { return nil }
+
+            let frameAX = element.frame
+            guard !frameAX.isNull, screenFrameAX.intersects(frameAX) else { return nil }
+
+            // Don't let maximized windows offset all other non-maximized windows.
+            let frame = frameAX.screenFlipped
+            guard placedCoversScreen
+                    || !coversScreen(frame, screenFrame: screenFrameNormalized)
+            else { return nil }
+
+            return topLeft(of: frame)
+        }
+
+        let offsetRect = cascadedRect(rect,
+                                                           occupiedTopLefts: occupiedTopLefts,
+                                                           screenFrame: screenFrameNormalized,
+                                                           offset: overlapOffset,
+                                                           maxCascade: maxCascade)
+        if offsetRect != rect {
+            Logger.log("Overlap detected, offset window to \(offsetRect.origin.debugDescription)")
+        }
+        return offsetRect
+    }
 
     /// Windows are matched by their top-left corner, so that a small window
     /// landing on a larger one at the same corner still counts as an overlap.
-    static func topLeft(of rect: CGRect) -> CGPoint {
+    private static func topLeft(of rect: CGRect) -> CGPoint {
         CGPoint(x: rect.minX, y: rect.maxY)
     }
 
     /// Whether a frame is large enough to count as covering the screen.
-    static func coversScreen(_ rect: CGRect, screenFrame: CGRect) -> Bool {
+    private static func coversScreen(_ rect: CGRect, screenFrame: CGRect) -> Bool {
         rect.width > screenFrame.width * 0.9 && rect.height > screenFrame.height * 0.9
     }
 
@@ -28,7 +79,7 @@ enum OverlapOffsetGeometry {
     /// edge of the visible frame. Zero on an axis that has no room: shifting
     /// there anyway would push the window flush against that edge, which both
     /// hides the window underneath again and eats any gap on that side.
-    static func offsetStep(for rect: CGRect, in screenFrame: CGRect, by offset: CGFloat) -> CGVector {
+    private static func offsetStep(for rect: CGRect, in screenFrame: CGRect, by offset: CGFloat) -> CGVector {
         CGVector(dx: rect.maxX + offset <= screenFrame.maxX ? offset : 0,
                  dy: rect.maxY + offset <= screenFrame.maxY ? offset : 0)
     }
@@ -36,7 +87,7 @@ enum OverlapOffsetGeometry {
     /// Whether the window has room to shift at all. A window sized to the
     /// whole visible frame (a maximized window with no gaps) does not, so the
     /// caller can skip scanning for overlaps entirely.
-    static func canOffset(_ rect: CGRect, in screenFrame: CGRect, by offset: CGFloat) -> Bool {
+    private static func canOffset(_ rect: CGRect, in screenFrame: CGRect, by offset: CGFloat) -> Bool {
         let step = offsetStep(for: rect, in: screenFrame, by: offset)
         return step.dx != 0 || step.dy != 0
     }
@@ -44,7 +95,7 @@ enum OverlapOffsetGeometry {
     /// The rect to place, shifted clear of any window already at its top-left
     /// corner, up to `maxCascade` times. Returns the rect unchanged when it
     /// overlaps nothing or has nowhere left to go.
-    static func cascadedRect(_ rect: CGRect,
+    private static func cascadedRect(_ rect: CGRect,
                              occupiedTopLefts: [CGPoint],
                              screenFrame: CGRect,
                              offset: CGFloat,
@@ -66,4 +117,5 @@ enum OverlapOffsetGeometry {
         }
         return candidate
     }
+    
 }

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -931,6 +931,14 @@ enum WindowAction: Int, Codable {
         }
     }
 
+    /// Whether landing on another window in this position should be offset so
+    /// the covered window stays visible. Cycling positions qualify, and so
+    /// does maximize: it doesn't cycle, but two maximized windows still land
+    /// exactly on top of each other.
+    var overlapOffsetApplies: Bool {
+        positionCycles || self == .maximize
+    }
+
     var category: WindowActionCategory? { // used to specify a submenu
         switch self {
         case .firstThird, .centerThird, .lastThird, .firstTwoThirds, .centerTwoThirds, .lastTwoThirds: return .thirds

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -4,10 +4,6 @@ import Cocoa
 
 class WindowManager {
 
-    /// Bounds how long a hung app can stall the overlap scan's accessibility
-    /// calls. Matches the badge's timeout for the same reason.
-    static let axScanTimeout: Float = 0.25
-
     private let screenDetection = ScreenDetection()
     private let standardWindowMoverChain: [WindowMover]
     private let fixedSizeWindowMoverChain: [WindowMover]
@@ -140,7 +136,7 @@ class WindowManager {
         }
 
         if Defaults.cyclingOverlapOffset.userEnabled, action.overlapOffsetApplies {
-            calcResult.rect = applyOverlapOffsetIfNeeded(calcResult.rect, windowId: windowId, screen: calcResult.screen)
+            calcResult.rect = OverlapOffsetGeometry.applyOverlapOffsetIfNeeded(calcResult.rect, windowId: windowId, screen: calcResult.screen)
         }
 
         let isFixedSize = (!frontmostWindowElement.isResizable() && action.resizes) || frontmostWindowElement.isSystemDialog == true
@@ -270,80 +266,6 @@ class WindowManager {
         if Defaults.moveCursorAcrossDisplays.userEnabled {
             CGWarpMouseCursorPosition(resultingRect.centerPoint)
         }
-    }
-    
-    private func applyOverlapOffsetIfNeeded(_ rect: CGRect, windowId: CGWindowID?, screen: NSScreen) -> CGRect {
-        let overlapOffset = CGFloat(Defaults.cyclingOverlapOffsetSize.value)
-        guard overlapOffset > 0 else { return rect }
-
-        // Without a window id the current window can't be excluded from the
-        // overlap scan, so skip the offset rather than cascade against itself.
-        guard let windowId else { return rect }
-
-        let screenFrameNormalized = screen.adjustedVisibleFrame()
-
-        // Nothing to do if the window can't move on either axis - a window
-        // sized to the whole visible frame has nowhere to shift. Checked
-        // before the scan below, which is far more expensive than this.
-        guard OverlapOffsetGeometry.canOffset(rect, in: screenFrameNormalized, by: overlapOffset) else {
-            return rect
-        }
-
-        // This scan enumerates every window over the accessibility API on the
-        // main thread. A hung or (under heavy system load) sluggish app can
-        // otherwise block that for the full default AX timeout - seconds -
-        // freezing the UI on each window move. Cap messaging system-wide for
-        // the scan and restore the process default immediately after; an app
-        // that can't answer in time is simply skipped (no offset), which is
-        // harmless.
-        //
-        // The cap is per request, not per scan, so this bounds what any one
-        // unresponsive app costs rather than the total: several hung apps
-        // still add up. That is a large improvement on the default and not a
-        // guarantee of a fixed ceiling.
-        AXUIElementSetMessagingTimeout(AXUIElement.systemWide, Self.axScanTimeout)
-        defer { AXUIElementSetMessagingTimeout(AXUIElement.systemWide, 0) }
-
-        let screenFrameAX = screenFrameNormalized.screenFlipped
-        let maxCascade = min(5, max(1, Defaults.cyclingOverlapMaxCascade.value))
-        let placedCoversScreen = OverlapOffsetGeometry.coversScreen(rect, screenFrame: screenFrameNormalized)
-
-        // Each element.frame is a pair of accessibility round-trips, so the
-        // frames are read once here rather than on every cascade iteration.
-        let occupiedTopLefts: [CGPoint] = AccessibilityElement.getAllWindowElements().compactMap { element in
-            guard element.getWindowId() != windowId,
-                  element.isWindow == true,
-                  element.isMinimized != true,
-                  element.isHidden != true,
-                  element.isSheet != true
-            else { return nil }
-
-            let frameAX = element.frame
-            guard !frameAX.isNull, screenFrameAX.intersects(frameAX) else { return nil }
-
-            // A window covering the screen shares its origin with every
-            // left/right half and corner placement, so matching one would
-            // offset all of them (#1766) - it's ignored. That only holds while
-            // the window being placed is smaller than it: when this window
-            // covers the screen too, a shared origin is a genuine stack of
-            // maximized windows, which is what the offset exists to reveal.
-            let frame = frameAX.screenFlipped
-            guard placedCoversScreen
-                    || !OverlapOffsetGeometry.coversScreen(frame, screenFrame: screenFrameNormalized)
-            else { return nil }
-
-            return OverlapOffsetGeometry.topLeft(of: frame)
-        }
-
-        let offsetRect = OverlapOffsetGeometry.cascadedRect(rect,
-                                                           occupiedTopLefts: occupiedTopLefts,
-                                                           screenFrame: screenFrameNormalized,
-                                                           offset: overlapOffset,
-                                                           maxCascade: maxCascade)
-        if offsetRect != rect {
-            Logger.log("Overlap detected, offset window to \(offsetRect.origin.debugDescription)")
-        }
-        return offsetRect
     }
 
     func postProcess(result: ResultParameters, resultingRect: CGRect) {

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -2,8 +2,73 @@
 
 import Cocoa
 
+/// Pure geometry for the overlap offset: where a window lands when it arrives
+/// on a position other windows already occupy. Kept free of accessibility and
+/// screen lookups so the cascade math can be tested directly - every bug this
+/// feature has had lived here.
+enum OverlapOffsetGeometry {
+
+    /// Windows are matched by their top-left corner, so that a small window
+    /// landing on a larger one at the same corner still counts as an overlap.
+    static func topLeft(of rect: CGRect) -> CGPoint {
+        CGPoint(x: rect.minX, y: rect.maxY)
+    }
+
+    /// Whether a frame is large enough to count as covering the screen.
+    static func coversScreen(_ rect: CGRect, screenFrame: CGRect) -> Bool {
+        rect.width > screenFrame.width * 0.9 && rect.height > screenFrame.height * 0.9
+    }
+
+    /// How far the window can shift on each axis without crossing the far
+    /// edge of the visible frame. Zero on an axis that has no room: shifting
+    /// there anyway would push the window flush against that edge, which both
+    /// hides the window underneath again and eats any gap on that side.
+    static func offsetStep(for rect: CGRect, in screenFrame: CGRect, by offset: CGFloat) -> CGVector {
+        CGVector(dx: rect.maxX + offset <= screenFrame.maxX ? offset : 0,
+                 dy: rect.maxY + offset <= screenFrame.maxY ? offset : 0)
+    }
+
+    /// Whether the window has room to shift at all. A window sized to the
+    /// whole visible frame (a maximized window with no gaps) does not, so the
+    /// caller can skip scanning for overlaps entirely.
+    static func canOffset(_ rect: CGRect, in screenFrame: CGRect, by offset: CGFloat) -> Bool {
+        let step = offsetStep(for: rect, in: screenFrame, by: offset)
+        return step.dx != 0 || step.dy != 0
+    }
+
+    /// The rect to place, shifted clear of any window already at its top-left
+    /// corner, up to `maxCascade` times. Returns the rect unchanged when it
+    /// overlaps nothing or has nowhere left to go.
+    static func cascadedRect(_ rect: CGRect,
+                             occupiedTopLefts: [CGPoint],
+                             screenFrame: CGRect,
+                             offset: CGFloat,
+                             maxCascade: Int,
+                             tolerance: CGFloat = 4) -> CGRect {
+        guard offset > 0 else { return rect }
+        var candidate = rect
+        for _ in 0..<max(0, maxCascade) {
+            let corner = topLeft(of: candidate)
+            let overlaps = occupiedTopLefts.contains { occupied in
+                abs(occupied.x - corner.x) < tolerance && abs(occupied.y - corner.y) < tolerance
+            }
+            guard overlaps else { break }
+
+            let step = offsetStep(for: candidate, in: screenFrame, by: offset)
+            guard step.dx != 0 || step.dy != 0 else { break }
+            candidate.origin.x += step.dx
+            candidate.origin.y += step.dy
+        }
+        return candidate
+    }
+}
+
 class WindowManager {
-    
+
+    /// Bounds how long a hung app can stall the overlap scan's accessibility
+    /// calls. Matches the badge's timeout for the same reason.
+    static let axScanTimeout: Float = 0.25
+
     private let screenDetection = ScreenDetection()
     private let standardWindowMoverChain: [WindowMover]
     private let fixedSizeWindowMoverChain: [WindowMover]
@@ -135,7 +200,7 @@ class WindowManager {
             calcResult.rect = GapCalculation.applyGaps(calcResult.rect, dimension: gapsApplicable, sharedEdges: gapSharedEdges, gapSize: Defaults.gapSize.value, skipTopGap: Defaults.skipGapTopEdge.enabled)
         }
 
-        if Defaults.cyclingOverlapOffset.userEnabled, action.positionCycles {
+        if Defaults.cyclingOverlapOffset.userEnabled, action.overlapOffsetApplies {
             calcResult.rect = applyOverlapOffsetIfNeeded(calcResult.rect, windowId: windowId, screen: calcResult.screen)
         }
 
@@ -276,61 +341,70 @@ class WindowManager {
         // overlap scan, so skip the offset rather than cascade against itself.
         guard let windowId else { return rect }
 
-        let screenFrameAX = screen.adjustedVisibleFrame().screenFlipped
-        let tolerance: CGFloat = 4
-        let maxCascade = min(5, max(1, Defaults.cyclingOverlapMaxCascade.value))
+        let screenFrameNormalized = screen.adjustedVisibleFrame()
 
-        let otherWindows = AccessibilityElement.getAllWindowElements().filter { element in
+        // Nothing to do if the window can't move on either axis - a window
+        // sized to the whole visible frame has nowhere to shift. Checked
+        // before the scan below, which is far more expensive than this.
+        guard OverlapOffsetGeometry.canOffset(rect, in: screenFrameNormalized, by: overlapOffset) else {
+            return rect
+        }
+
+        // This scan enumerates every window over the accessibility API on the
+        // main thread. A hung or (under heavy system load) sluggish app can
+        // otherwise block that for the full default AX timeout - seconds -
+        // freezing the UI on each window move. Cap messaging system-wide for
+        // the scan and restore the process default immediately after; an app
+        // that can't answer in time is simply skipped (no offset), which is
+        // harmless.
+        //
+        // The cap is per request, not per scan, so this bounds what any one
+        // unresponsive app costs rather than the total: several hung apps
+        // still add up. That is a large improvement on the default and not a
+        // guarantee of a fixed ceiling.
+        AXUIElementSetMessagingTimeout(AXUIElement.systemWide, Self.axScanTimeout)
+        defer { AXUIElementSetMessagingTimeout(AXUIElement.systemWide, 0) }
+
+        let screenFrameAX = screenFrameNormalized.screenFlipped
+        let maxCascade = min(5, max(1, Defaults.cyclingOverlapMaxCascade.value))
+        let placedCoversScreen = OverlapOffsetGeometry.coversScreen(rect, screenFrame: screenFrameNormalized)
+
+        // Each element.frame is a pair of accessibility round-trips, so the
+        // frames are read once here rather than on every cascade iteration.
+        let occupiedTopLefts: [CGPoint] = AccessibilityElement.getAllWindowElements().compactMap { element in
             guard element.getWindowId() != windowId,
                   element.isWindow == true,
                   element.isMinimized != true,
                   element.isHidden != true,
                   element.isSheet != true
-            else { return false }
+            else { return nil }
 
-            let frame = element.frame
-            return !frame.isNull && screenFrameAX.intersects(frame)
+            let frameAX = element.frame
+            guard !frameAX.isNull, screenFrameAX.intersects(frameAX) else { return nil }
+
+            // A window covering the screen shares its origin with every
+            // left/right half and corner placement, so matching one would
+            // offset all of them (#1766) - it's ignored. That only holds while
+            // the window being placed is smaller than it: when this window
+            // covers the screen too, a shared origin is a genuine stack of
+            // maximized windows, which is what the offset exists to reveal.
+            let frame = frameAX.screenFlipped
+            guard placedCoversScreen
+                    || !OverlapOffsetGeometry.coversScreen(frame, screenFrame: screenFrameNormalized)
+            else { return nil }
+
+            return OverlapOffsetGeometry.topLeft(of: frame)
         }
 
-        let screenFrameNormalized = screen.adjustedVisibleFrame()
-        var candidate = rect
-        var cascadeLevel = 0
-
-        while cascadeLevel < maxCascade {
-            let candidateAX = candidate.screenFlipped
-            let hasOverlap = otherWindows.contains { element in
-                let otherFrame = element.frame
-                let originsMatch = abs(otherFrame.origin.x - candidateAX.origin.x) < tolerance
-                    && abs(otherFrame.origin.y - candidateAX.origin.y) < tolerance
-                let otherCoversScreen = otherFrame.width > screenFrameAX.width * 0.9
-                    && otherFrame.height > screenFrameAX.height * 0.9
-                return originsMatch && !otherCoversScreen
-            }
-
-            guard hasOverlap else { break }
-
-            candidate.origin.x += overlapOffset
-            candidate.origin.y += overlapOffset
-            cascadeLevel += 1
-
-            if candidate.origin.x + candidate.width > screenFrameNormalized.maxX {
-                candidate.origin.x = screenFrameNormalized.maxX - candidate.width
-            }
-            if candidate.origin.y + candidate.height > screenFrameNormalized.maxY {
-                candidate.origin.y = screenFrameNormalized.maxY - candidate.height
-            }
-            if candidate.origin.x < screenFrameNormalized.origin.x {
-                candidate.origin.x = screenFrameNormalized.origin.x
-            }
-            if candidate.origin.y < screenFrameNormalized.origin.y {
-                candidate.origin.y = screenFrameNormalized.origin.y
-            }
+        let offsetRect = OverlapOffsetGeometry.cascadedRect(rect,
+                                                           occupiedTopLefts: occupiedTopLefts,
+                                                           screenFrame: screenFrameNormalized,
+                                                           offset: overlapOffset,
+                                                           maxCascade: maxCascade)
+        if offsetRect != rect {
+            Logger.log("Overlap detected, offset window to \(offsetRect.origin.debugDescription)")
         }
-
-        if cascadeLevel > 0 {
-            Logger.log("Cycling overlap detected, applied \(cascadeLevel) x \(overlapOffset)pt cascade offset")
-        }
-        return candidate
+        return offsetRect
     }
 
     func postProcess(result: ResultParameters, resultingRect: CGRect) {

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -2,67 +2,6 @@
 
 import Cocoa
 
-/// Pure geometry for the overlap offset: where a window lands when it arrives
-/// on a position other windows already occupy. Kept free of accessibility and
-/// screen lookups so the cascade math can be tested directly - every bug this
-/// feature has had lived here.
-enum OverlapOffsetGeometry {
-
-    /// Windows are matched by their top-left corner, so that a small window
-    /// landing on a larger one at the same corner still counts as an overlap.
-    static func topLeft(of rect: CGRect) -> CGPoint {
-        CGPoint(x: rect.minX, y: rect.maxY)
-    }
-
-    /// Whether a frame is large enough to count as covering the screen.
-    static func coversScreen(_ rect: CGRect, screenFrame: CGRect) -> Bool {
-        rect.width > screenFrame.width * 0.9 && rect.height > screenFrame.height * 0.9
-    }
-
-    /// How far the window can shift on each axis without crossing the far
-    /// edge of the visible frame. Zero on an axis that has no room: shifting
-    /// there anyway would push the window flush against that edge, which both
-    /// hides the window underneath again and eats any gap on that side.
-    static func offsetStep(for rect: CGRect, in screenFrame: CGRect, by offset: CGFloat) -> CGVector {
-        CGVector(dx: rect.maxX + offset <= screenFrame.maxX ? offset : 0,
-                 dy: rect.maxY + offset <= screenFrame.maxY ? offset : 0)
-    }
-
-    /// Whether the window has room to shift at all. A window sized to the
-    /// whole visible frame (a maximized window with no gaps) does not, so the
-    /// caller can skip scanning for overlaps entirely.
-    static func canOffset(_ rect: CGRect, in screenFrame: CGRect, by offset: CGFloat) -> Bool {
-        let step = offsetStep(for: rect, in: screenFrame, by: offset)
-        return step.dx != 0 || step.dy != 0
-    }
-
-    /// The rect to place, shifted clear of any window already at its top-left
-    /// corner, up to `maxCascade` times. Returns the rect unchanged when it
-    /// overlaps nothing or has nowhere left to go.
-    static func cascadedRect(_ rect: CGRect,
-                             occupiedTopLefts: [CGPoint],
-                             screenFrame: CGRect,
-                             offset: CGFloat,
-                             maxCascade: Int,
-                             tolerance: CGFloat = 4) -> CGRect {
-        guard offset > 0 else { return rect }
-        var candidate = rect
-        for _ in 0..<max(0, maxCascade) {
-            let corner = topLeft(of: candidate)
-            let overlaps = occupiedTopLefts.contains { occupied in
-                abs(occupied.x - corner.x) < tolerance && abs(occupied.y - corner.y) < tolerance
-            }
-            guard overlaps else { break }
-
-            let step = offsetStep(for: candidate, in: screenFrame, by: offset)
-            guard step.dx != 0 || step.dy != 0 else { break }
-            candidate.origin.x += step.dx
-            candidate.origin.y += step.dy
-        }
-        return candidate
-    }
-}
-
 class WindowManager {
 
     /// Bounds how long a hung app can stall the overlap scan's accessibility

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -32828,7 +32828,7 @@
         }
       }
     },
-    "Offset cycling position on overlap" : {
+    "Offset window position on overlap" : {
 
     },
     "ogc-rX-tC1.title" : {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -2788,6 +2788,125 @@ class HalfSplitCornerCalculationTests: XCTestCase {
     }
 }
 
+
+/// The cascade math itself. Asserting the resulting rect matters: an earlier
+/// version of this feature was certified by a test that only checked an
+/// eligibility flag, while the offset it enabled was a no-op for anyone
+/// running the default of no gaps.
+class OverlapOffsetGeometryTests: XCTestCase {
+
+    private let screen = CGRect(x: 0, y: 0, width: 1000, height: 800)
+    private let offset: CGFloat = 11
+
+    private func cascade(_ rect: CGRect, occupied: [CGPoint], maxCascade: Int = 1) -> CGRect {
+        OverlapOffsetGeometry.cascadedRect(rect,
+                                           occupiedTopLefts: occupied,
+                                           screenFrame: screen,
+                                           offset: offset,
+                                           maxCascade: maxCascade)
+    }
+
+    /// A maximized window with no gaps fills the visible frame, so there is
+    /// nowhere to shift it - and the caller skips the window scan entirely.
+    func testMaximizedWithoutGapsCannotOffset() {
+        let maximized = screen
+        XCTAssertFalse(OverlapOffsetGeometry.canOffset(maximized, in: screen, by: offset))
+        XCTAssertEqual(cascade(maximized, occupied: [OverlapOffsetGeometry.topLeft(of: maximized)]),
+                       maximized)
+    }
+
+    /// Gaps larger than the offset leave room, so maximized windows cascade.
+    func testMaximizedWithGapsOffsets() {
+        let maximized = CGRect(x: 22, y: 22, width: 956, height: 756)
+        XCTAssertTrue(OverlapOffsetGeometry.canOffset(maximized, in: screen, by: offset))
+        XCTAssertEqual(cascade(maximized, occupied: [OverlapOffsetGeometry.topLeft(of: maximized)]),
+                       CGRect(x: 33, y: 33, width: 956, height: 756))
+    }
+
+    /// Gaps smaller than the offset must not shift the window part way: it
+    /// would end up flush against the far edges, deleting the gaps there.
+    func testGapsSmallerThanOffsetDoNotOffset() {
+        let maximized = CGRect(x: 5, y: 5, width: 990, height: 790)
+        XCTAssertFalse(OverlapOffsetGeometry.canOffset(maximized, in: screen, by: offset))
+        XCTAssertEqual(cascade(maximized, occupied: [OverlapOffsetGeometry.topLeft(of: maximized)]),
+                       maximized)
+    }
+
+    /// A half with no gaps has room across but not up, and still offsets on
+    /// the axis that fits - the behavior shipped in v0.96.
+    func testHalfOffsetsOnTheAxisWithRoom() {
+        let leftHalf = CGRect(x: 0, y: 0, width: 500, height: 800)
+        XCTAssertEqual(cascade(leftHalf, occupied: [OverlapOffsetGeometry.topLeft(of: leftHalf)]),
+                       CGRect(x: 11, y: 0, width: 500, height: 800))
+    }
+
+    func testNoOverlapLeavesTheRectAlone() {
+        let leftHalf = CGRect(x: 0, y: 0, width: 500, height: 800)
+        XCTAssertEqual(cascade(leftHalf, occupied: [CGPoint(x: 500, y: 800)]), leftHalf)
+    }
+
+    func testCascadeStopsAtMaxCascade() {
+        let quarter = CGRect(x: 0, y: 0, width: 400, height: 400)
+        let occupied = [CGPoint(x: 0, y: 400), CGPoint(x: 11, y: 411), CGPoint(x: 22, y: 422)]
+        XCTAssertEqual(cascade(quarter, occupied: occupied, maxCascade: 1).origin,
+                       CGPoint(x: 11, y: 11))
+        XCTAssertEqual(cascade(quarter, occupied: occupied, maxCascade: 3).origin,
+                       CGPoint(x: 33, y: 33))
+    }
+
+    /// Matching is by top-left corner, so a smaller window landing on a larger
+    /// one at the same corner counts as an overlap - an eighth arriving on a
+    /// quarter. Both sit against the top of the screen here, so the window
+    /// offsets across but not up.
+    func testMatchesMixedSizesAtTheSameCorner() {
+        let eighth = CGRect(x: 0, y: 600, width: 250, height: 200)
+        let quarterTopLeft = OverlapOffsetGeometry.topLeft(of: CGRect(x: 0, y: 400, width: 500, height: 400))
+        XCTAssertEqual(quarterTopLeft, OverlapOffsetGeometry.topLeft(of: eighth))
+        XCTAssertEqual(cascade(eighth, occupied: [quarterTopLeft]),
+                       CGRect(x: 11, y: 600, width: 250, height: 200))
+    }
+
+    func testCoversScreen() {
+        XCTAssertTrue(OverlapOffsetGeometry.coversScreen(screen, screenFrame: screen))
+        XCTAssertTrue(OverlapOffsetGeometry.coversScreen(CGRect(x: 22, y: 22, width: 956, height: 756),
+                                                         screenFrame: screen))
+        XCTAssertFalse(OverlapOffsetGeometry.coversScreen(CGRect(x: 0, y: 0, width: 500, height: 800),
+                                                          screenFrame: screen))
+    }
+}
+
+/// Which actions are eligible for the overlap offset. `positionCycles` alone
+/// excluded maximize, so two maximized windows landed exactly on top of each
+/// other. Eligibility is only half of it - whether an eligible window actually
+/// moves is covered by OverlapOffsetGeometryTests.
+class OverlapOffsetEligibilityTests: XCTestCase {
+
+    func testMaximizeGetsTheOffset() {
+        XCTAssertTrue(WindowAction.maximize.overlapOffsetApplies)
+    }
+
+    func testGridPositionsGetTheOffset() {
+        for action in [WindowAction.leftHalf, .topLeft, .topLeftSixth,
+                       .topLeftNinth, .topLeftEighth, .topLeftTwelfth, .topLeftSixteenth] {
+            XCTAssertTrue(action.overlapOffsetApplies, "\(action) should get the overlap offset")
+        }
+    }
+
+    /// Actions that move or resize in place have no "landed on top of
+    /// something" notion, so offsetting them would just displace the window.
+    func testMovesAndResizesDoNotGetTheOffset() {
+        for action in [WindowAction.center, .restore, .moveLeft, .moveRight, .moveUp, .moveDown,
+                       .larger, .smaller, .nextDisplay, .previousDisplay,
+                       .almostMaximize, .maximizeHeight, .tileAll, .cascadeAll] {
+            XCTAssertFalse(action.overlapOffsetApplies, "\(action) should not get the overlap offset")
+        }
+    }
+}
+
+/// The stacked-window list is driven by an event tap, so it decides which
+/// keystrokes to take from the app underneath. Taking the wrong ones would
+/// break typing system-wide while the list is open.
+
 class OverlapOffsetGuardsTests: XCTestCase {
 
     func testMaxCascadeClampedToMinOne() {


### PR DESCRIPTION
Follow-on to the overlap offset shipped in v0.96. Three things, all in the same code path.

**The scan can no longer stall the UI on an unresponsive app.** `applyOverlapOffsetIfNeeded` enumerates windows over the accessibility API on the main thread, so a hung app — or any app under heavy system load — could block each window move for the full default AX timeout. The scan now caps messaging and restores the default immediately after. An app that can't answer in time is skipped, which just means it doesn't get an offset. To be precise about the guarantee: the cap is per request, so this bounds what any single unresponsive app costs rather than the total. Window frames are also read once per scan now, instead of once per cascade step.

**Maximize gets the offset.** It doesn't cycle, so `positionCycles` excluded it — but two maximized windows land exactly on top of each other, which is the case where the covered window is least visible. Eligibility is now its own property rather than a second meaning layered onto `positionCycles`.

**The cascade only shifts where there's room.** Previously the edge clamp could undo the shift entirely, which made the offset a silent no-op for a maximized window at the default of no gaps, and could eat the gap on the other side when gaps were smaller than the offset. Each axis is now checked for room separately: a window with nowhere to go is left alone, and a left-half window with room only horizontally still offsets horizontally.

The math moved to `OverlapOffsetGeometry`, a pure enum with no accessibility or screen lookups, because every bug this feature has had lived in that math and none of it was reachable by a test. The new tests assert resulting rects rather than the flags that gate them — an earlier version of this change was certified green by a test that only checked an eligibility boolean while the offset it enabled did nothing.

No behavior change for anyone who hasn't enabled the offset. This also supersedes #1813, which covered the maximized-window half; that half is here and the badge half is in #1808.
