### PR TITLE
Honor defaults-write customizations for JSONDefault keys

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		944F25CD2CE5A144004B2FD2 /* PrefsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944F25CC2CE5A144004B2FD2 /* PrefsViewController.swift */; };
 		944F25CF2CE5A144004B2FD2 /* ShortcutRecordingObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944F25CE2CE5A144004B2FD2 /* ShortcutRecordingObserver.swift */; };
 		944F25D12CE5A144004B2FD2 /* ShortcutRecordingObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944F25D02CE5A144004B2FD2 /* ShortcutRecordingObserverTests.swift */; };
+		01f52cab9bce43359775bdd7 /* JSONDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = de0950b8b00f40308934a523 /* JSONDefaultTests.swift */; };
 		94E9B08E2C3B8D97004C7F41 /* MacTilingDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E9B08D2C3B8D97004C7F41 /* MacTilingDefaults.swift */; };
 		94E9B0902C3E4578004C7F41 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E9B08F2C3E4578004C7F41 /* StringExtension.swift */; };
 		9818E00D28B59205004AA524 /* CompoundSnapArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9818E00C28B59205004AA524 /* CompoundSnapArea.swift */; };
@@ -260,6 +261,7 @@
 		944F25CC2CE5A144004B2FD2 /* PrefsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefsViewController.swift; sourceTree = "<group>"; };
 		944F25CE2CE5A144004B2FD2 /* ShortcutRecordingObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecordingObserver.swift; sourceTree = "<group>"; };
 		944F25D02CE5A144004B2FD2 /* ShortcutRecordingObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecordingObserverTests.swift; sourceTree = "<group>"; };
+		de0950b8b00f40308934a523 /* JSONDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDefaultTests.swift; sourceTree = "<group>"; };
 		94E9B08D2C3B8D97004C7F41 /* MacTilingDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacTilingDefaults.swift; sourceTree = "<group>"; };
 		94E9B08F2C3E4578004C7F41 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		9698D1D9EE0180D7C4468304 /* TopCenterLeftTwelfthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCenterLeftTwelfthCalculation.swift; sourceTree = "<group>"; };
@@ -729,6 +731,7 @@
 			children = (
 				9824701F22AF9B7E0037B409 /* RectangleTests.swift */,
 				944F25D02CE5A144004B2FD2 /* ShortcutRecordingObserverTests.swift */,
+				de0950b8b00f40308934a523 /* JSONDefaultTests.swift */,
 				9824702122AF9B7E0037B409 /* Info.plist */,
 			);
 			path = RectangleTests;
@@ -1182,6 +1185,7 @@
 			files = (
 				9824702022AF9B7E0037B409 /* RectangleTests.swift in Sources */,
 				944F25D12CE5A144004B2FD2 /* ShortcutRecordingObserverTests.swift in Sources */,
+				01f52cab9bce43359775bdd7 /* JSONDefaultTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -455,10 +455,11 @@ class JSONDefault<T: Codable>: StringDefault {
     }
     
     init(key: String, defaultValue: T) {
+        super.init(key: key)
+        loadFromJSON()
         if typedValue == nil {
             typedValue = defaultValue
         }
-        super.init(key: key)
     }
     
     override func load(from codable: CodableDefault) {

--- a/RectangleTests/JSONDefaultTests.swift
+++ b/RectangleTests/JSONDefaultTests.swift
@@ -1,0 +1,53 @@
+/// JSONDefaultTests.swift
+
+import XCTest
+@testable import Rectangle
+
+class JSONDefaultTests: XCTestCase {
+
+    /// `systemWideMouseDownApps` / `doubleClickToolBarIgnoredApps` are only customizable via
+    /// `defaults write` (there is no in-app UI). They are declared through
+    /// `JSONDefault.init(key:defaultValue:)`, which must honor a value the user persisted for the
+    /// key and fall back to the default only when nothing is stored. These tests guard that contract
+    /// using a dedicated test key against the real `UserDefaults.standard` suite `JSONDefault` reads.
+    private static let testKey = "testJSONDefaultStoredValueRoundTrip"
+
+    private func writeJSON<T: Encodable>(_ value: T, forKey key: String) throws {
+        let data = try JSONEncoder().encode(value)
+        UserDefaults.standard.set(String(data: data, encoding: .utf8), forKey: key)
+    }
+
+    func testStoredValueIsHonoredOverDefault() throws {
+        let key = Self.testKey
+        let storedValue: Set<String> = ["com.example.customApp", "org.something.other"]
+        let defaultValue: Set<String> = ["org.languagetool.desktop", "com.microsoft.teams2"]
+
+        try writeJSON(storedValue, forKey: key)
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+
+        let jsonDefault = JSONDefault<Set<String>>(key: key, defaultValue: defaultValue)
+        XCTAssertEqual(jsonDefault.typedValue, storedValue)
+    }
+
+    func testMissingValueFallsBackToDefault() throws {
+        let key = Self.testKey
+        let defaultValue: Set<String> = ["org.languagetool.desktop", "com.microsoft.teams2"]
+
+        UserDefaults.standard.removeObject(forKey: key)
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+
+        let jsonDefault = JSONDefault<Set<String>>(key: key, defaultValue: defaultValue)
+        XCTAssertEqual(jsonDefault.typedValue, defaultValue)
+    }
+
+    func testInvalidJSONFallsBackToDefault() throws {
+        let key = Self.testKey
+        let defaultValue: Set<String> = ["org.languagetool.desktop", "com.microsoft.teams2"]
+
+        UserDefaults.standard.set("not valid json", forKey: key)
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+
+        let jsonDefault = JSONDefault<Set<String>>(key: key, defaultValue: defaultValue)
+        XCTAssertEqual(jsonDefault.typedValue, defaultValue)
+    }
+}


### PR DESCRIPTION
## Summary
`defaults write` customizations to `systemWideMouseDownApps` and `doubleClickToolBarIgnoredApps` — the only two settings with no in-app UI — are now honored. Today they are silently ignored.

## Root cause
`JSONDefault.init(key:defaultValue:)` (`Defaults.swift`) set `typedValue = defaultValue` before `super.init(key:)` and never called `loadFromJSON()`, unlike the already-correct `override init(key:)`. So whatever the user persisted for that key was never decoded back; `typedValue` stayed at the default forever. The two keys above are the only consumers of this initializer, so the bug was invisible everywhere else.

## Changes
- `Rectangle/Defaults.swift` — `init(key:defaultValue:)` now mirrors `override init(key:)`: call `super.init(key:)` first, then `loadFromJSON()` (which decodes the stored UserDefaults JSON into `typedValue`, falling back to the default when the stored value is absent or invalid). `override init(key:)` is unchanged.
- `RectangleTests/JSONDefaultTests.swift` (new) — three pure-logic tests: a stored JSON value is honored over the default (RED before / GREEN after), a missing value falls back to the default, and invalid JSON falls back to the default. Each writes to the same `UserDefaults.standard` suite `JSONDefault` reads from and cleans up via `defer`.

## Testing
`xcodebuild test -project Rectangle.xcodeproj -scheme Rectangle -destination 'platform=macOS'` — **208 tests, 21 failures (0 unexpected)**. The 21 failures are the pre-existing red baseline on `main` (cooperative-resize / corner-calculation suites, tracked in issues #1804–#1806); this change adds **zero** new failures, and the three new `JSONDefaultTests` pass.

## AI assistance
This change was developed with AI assistance (Claude Code). Every changed line was reviewed and understood by the contributor.
