### PR TITLE
Eliminate portrait eighth-snap gaps on displays whose height is not divisible by 4

### DIFF
--- a/Rectangle/WindowCalculation/BottomCenterLeftEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomCenterLeftEighthCalculation.swift
@@ -38,7 +38,7 @@ class BottomCenterLeftEighthCalculation: WindowCalculation, OrientationAware, Ei
         var rect = visibleFrameOfScreen
         rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
-        rect.origin.y = floor(visibleFrameOfScreen.maxY - (visibleFrameOfScreen.height * 0.75))
+        rect.origin.y = visibleFrameOfScreen.maxY - (rect.height * 3.0)
         rect.origin.x = visibleFrameOfScreen.minX + rect.width
         return RectResult(rect, subAction: .bottomCenterLeftEighth)
     }

--- a/Rectangle/WindowCalculation/BottomLeftEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomLeftEighthCalculation.swift
@@ -38,7 +38,7 @@ class BottomLeftEighthCalculation: WindowCalculation, OrientationAware, EighthsR
         var rect = visibleFrameOfScreen
         rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
-        rect.origin.y = floor(visibleFrameOfScreen.maxY - (visibleFrameOfScreen.height * 0.75))
+        rect.origin.y = visibleFrameOfScreen.maxY - (rect.height * 3.0)
         rect.origin.x = visibleFrameOfScreen.minX
         return RectResult(rect, subAction: .bottomLeftEighth)
     }

--- a/Rectangle/WindowCalculation/TopCenterRightEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopCenterRightEighthCalculation.swift
@@ -38,7 +38,7 @@ class TopCenterRightEighthCalculation: WindowCalculation, OrientationAware, Eigh
         var rect = visibleFrameOfScreen
         rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
-        rect.origin.y = visibleFrameOfScreen.maxY - (visibleFrameOfScreen.height / 2.0)
+        rect.origin.y = visibleFrameOfScreen.maxY - (rect.height * 2.0)
         rect.origin.x = visibleFrameOfScreen.minX
         return RectResult(rect, subAction: .topCenterRightEighth)
     }

--- a/Rectangle/WindowCalculation/TopRightEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/TopRightEighthCalculation.swift
@@ -38,7 +38,7 @@ class TopRightEighthCalculation: WindowCalculation, OrientationAware, EighthsRep
         var rect = visibleFrameOfScreen
         rect.size.width = floor(visibleFrameOfScreen.width / 2.0)
         rect.size.height = floor(visibleFrameOfScreen.height / 4.0)
-        rect.origin.y = visibleFrameOfScreen.maxY - (visibleFrameOfScreen.height / 2.0)
+        rect.origin.y = visibleFrameOfScreen.maxY - (rect.height * 2.0)
         rect.origin.x = visibleFrameOfScreen.minX + rect.width
         return RectResult(rect, subAction: .topRightEighth)
     }

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -3559,3 +3559,78 @@ class DerivedWindowIdTests: XCTestCase {
         XCTAssertEqual(Set(ids).count, ids.count)
     }
 }
+
+// Portrait eighth snapping tiles the screen into four rows. On a display whose
+// visible-frame height is not divisible by 4, the row origins must be expressed
+// as cell-height multiples (floor(height / 4)) so adjacent rows abut exactly
+// instead of drifting apart by the raw height fraction's sub-pixel remainder.
+class PortraitEighthAbutmentTests: XCTestCase {
+
+    // Portrait frame whose height is NOT divisible by 4 (1002 % 4 == 2): the case
+    // that used to leave 1-2px gaps between rows.
+    private static let nonDivisibleFrame = CGRect(x: 0, y: 0, width: 800, height: 1002)
+    // Portrait frame whose height IS divisible by 4: rows already tile seamlessly.
+    private static let divisibleFrame = CGRect(x: 0, y: 0, width: 800, height: 1000)
+
+    private func portraitEighths(_ frame: CGRect) -> [CGRect] {
+        return [
+            TopLeftEighthCalculation().portraitRect(frame).rect,
+            TopCenterLeftEighthCalculation().portraitRect(frame).rect,
+            TopCenterRightEighthCalculation().portraitRect(frame).rect,
+            TopRightEighthCalculation().portraitRect(frame).rect,
+            BottomLeftEighthCalculation().portraitRect(frame).rect,
+            BottomCenterLeftEighthCalculation().portraitRect(frame).rect,
+            BottomCenterRightEighthCalculation().portraitRect(frame).rect,
+            BottomRightEighthCalculation().portraitRect(frame).rect,
+        ]
+    }
+
+    private func rowOrigins(_ frame: CGRect) -> [CGFloat] {
+        return Set(portraitEighths(frame).map { $0.origin.y }).sorted(by: >)
+    }
+
+    func testAllPortraitEighthsAreOneCellTall() {
+        let cellHeight = floor(Self.nonDivisibleFrame.height / 4.0)
+        for rect in portraitEighths(Self.nonDivisibleFrame) {
+            XCTAssertEqual(rect.height, cellHeight, accuracy: 0.001)
+        }
+    }
+
+    func testPortraitEighthRowsAlignToCellHeightGridOnNonDivisibleHeight() {
+        let frame = Self.nonDivisibleFrame
+        let cellHeight = floor(frame.height / 4.0)
+        let origins = rowOrigins(frame)
+
+        XCTAssertEqual(origins.count, 4)
+        XCTAssertEqual(origins[0], frame.maxY - cellHeight, accuracy: 0.001)
+        XCTAssertEqual(origins[1], frame.maxY - cellHeight * 2.0, accuracy: 0.001)
+        XCTAssertEqual(origins[2], frame.maxY - cellHeight * 3.0, accuracy: 0.001)
+        XCTAssertEqual(origins[3], frame.minY, accuracy: 0.001)
+    }
+
+    func testPortraitEighthRowsAbutExactlyOnNonDivisibleHeight() {
+        // Before the fix, rows 2 and 3 used raw height fractions (height / 2 and
+        // height * 0.75), so rows 1-2 and 2-3 each drifted ~1px apart. The top
+        // three rows must abut exactly now: each row's minY equals the row
+        // above's maxY. (The height % 4 residual sits at the row3-row4 boundary
+        // and is zero only when height is divisible by 4 — see the divisible test.)
+        let frame = Self.nonDivisibleFrame
+        let cellHeight = floor(frame.height / 4.0)
+        let origins = rowOrigins(frame)
+
+        XCTAssertEqual(origins[0], origins[1] + cellHeight, accuracy: 0.001)
+        XCTAssertEqual(origins[1], origins[2] + cellHeight, accuracy: 0.001)
+    }
+
+    func testPortraitEighthRowsTileFullyWhenHeightDivisibleByFour() {
+        // When height % 4 == 0 the rounding residual is zero, so every row boundary
+        // abuts. Guards against regressing the already-seamless divisible case.
+        let frame = Self.divisibleFrame
+        let cellHeight = frame.height / 4.0
+        let origins = rowOrigins(frame)
+
+        XCTAssertEqual(origins[0], origins[1] + cellHeight, accuracy: 0.001)
+        XCTAssertEqual(origins[1], origins[2] + cellHeight, accuracy: 0.001)
+        XCTAssertEqual(origins[2], origins[3] + cellHeight, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Summary
Portrait-mode eighth snapping abuts cleanly: the middle row seams that previously left 1-2px gaps on displays whose height is not divisible by 4 now tile exactly. The unavoidable `floor(height/4)` remainder collects at the bottom edge instead of being split across the middle seams.

## Root cause
The four portrait eighth calculations set each row's height to `floor(visibleFrame.height / 4)` but derived two row origins from raw screen fractions (`height * 0.75`, `height / 2.0`). When `height % 4 != 0`, the raw-fraction boundaries did not land on the floored cell edges, so the middle seams (rows 1-2 and 2-3) left 1-2px gaps.

## Changes
- `Rectangle/WindowCalculation/{TopCenterRightEighth,TopRightEighth,BottomLeftEighth,BottomCenterLeftEighth}Calculation.swift` — express each of those two row origins as a cell-height multiple (`rect.height * 2`, `rect.height * 3`) so the top three rows share one consistent `floor(height/4)` basis and abut exactly against each other and against the top-anchored row 1.
- `RectangleTests/RectangleTests.swift` — a `PortraitEighthAbutmentTests` class: for a non-divisible height (1002) it asserts the row origins form the `maxY - cellH*k` grid and the two middle seams abut with no gap/overlap; for a divisible height (1000) it asserts all three seams abut (control).

## Behavior notes
- For heights divisible by 4 the math is numerically identical to before (`floor(h/4)*3 == h*0.75`, `floor(h/4)*2 == h/2`), so the already-seamless case is unchanged.
- For non-divisible heights the floor remainder is no longer scattered across the two middle seams; it collects as a single 1-2px step at the bottom edge (between the third row, anchored from `maxY`, and the bottom row, anchored at `minY`). This matches Rectangle's existing top/bottom anchoring convention; the test documents it explicitly. (A fully-seamless tile would require the bottom row to absorb the remainder with a non-uniform height, which is a separate design choice.)

## Testing
`xcodebuild test -project Rectangle.xcodeproj -scheme Rectangle -destination 'platform=macOS'` — 208 tests, **21 failures (0 unexpected)**. The 21 are the pre-existing red baseline on `main` (cooperative-resize / corner-calculation suites, issues #1804–#1806); this change adds **zero** new failures and the new abutment tests pass.

## AI assistance
This change was developed with AI assistance (Claude Code); every changed line was reviewed and understood by the contributor.
