### PR TITLE
Add presets — named, switchable configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ There are buttons for importing and exporting the config as a JSON file in the s
 
 Upon launch, Rectangle will load a config file at `~/Library/Application Support/Rectangle/RectangleConfig.json` if it is present and will rename that file with a time/date stamp so that it isn't read on subsequent launches.
 
+## Presets
+
+Presets are named configurations that you can switch between from the top right of the Shortcuts tab. They are useful when you move between keyboards: shortcuts that live on a numeric keypad are unusable on a tenkeyless or built-in keyboard, and a preset lets you swap the whole set in one step instead of re-recording shortcuts.
+
+A preset holds every shortcut plus the settings that describe window behavior — gaps, snap areas, size steps, cycling, and so on. Settings that describe the app itself, such as launching at login, checking for updates, and per-app exclusions, stay global and are not affected by switching.
+
+The active preset always mirrors your current settings, so anything you change is kept in it automatically. New presets can be created from Rectangle's built-in defaults or by duplicating the one you are using.
+
 ## Preferences Storage
 
 The configuration for Rectangle is stored using NSUserDefaults, meaning it is stored in the following location:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Upon launch, Rectangle will load a config file at `~/Library/Application Support
 
 ## Presets
 
-Presets are named configurations that you can switch between from the top right of the Shortcuts tab. They are useful when you move between keyboards: shortcuts that live on a numeric keypad are unusable on a tenkeyless or built-in keyboard, and a preset lets you swap the whole set in one step instead of re-recording shortcuts.
+Presets are named configurations that you can switch between from the Extras popover, reached from the “⋯” button at the bottom of the General tab. They are useful when you move between keyboards: shortcuts that live on a numeric keypad are unusable on a tenkeyless or built-in keyboard, and a preset lets you swap the whole set in one step instead of re-recording shortcuts.
 
 A preset holds every shortcut plus the settings that describe window behavior — gaps, snap areas, size steps, cycling, and so on. Settings that describe the app itself, such as launching at login, checking for updates, and per-app exclusions, stay global and are not affected by switching.
 

--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		983BBD6F253B609D000D223E /* FootprintWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983BBD6E253B609D000D223E /* FootprintWindow.swift */; };
 		F1AC0DE000000000000000A2 /* StackBadgeGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A1 /* StackBadgeGeometry.swift */; };
 		F1AC0DE000000000000000A4 /* StackBadgeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A3 /* StackBadgeManager.swift */; };
+		F1AC0DE000000000000000B2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000B1 /* Preset.swift */; };
 		983DD04028A844BE00BF1EEE /* SnapAreaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */; };
 		983DD04428B0639E00BF1EEE /* SnapAreaModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD04328B0639E00BF1EEE /* SnapAreaModel.swift */; };
 		984EDB0F29A42ED200D119D2 /* LaunchOnLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */; };
@@ -323,6 +324,7 @@
 		983BBD6E253B609D000D223E /* FootprintWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FootprintWindow.swift; sourceTree = "<group>"; };
 		F1AC0DE000000000000000A1 /* StackBadgeGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeGeometry.swift; sourceTree = "<group>"; };
 		F1AC0DE000000000000000A3 /* StackBadgeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeManager.swift; sourceTree = "<group>"; };
+		F1AC0DE000000000000000B1 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
 		983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaViewController.swift; sourceTree = "<group>"; };
 		983DD04328B0639E00BF1EEE /* SnapAreaModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaModel.swift; sourceTree = "<group>"; };
 		984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOnLogin.swift; sourceTree = "<group>"; };
@@ -715,6 +717,7 @@
 				989DA30C243FC0C3008C7AA4 /* WelcomeWindow */,
 				98C2755F231FF6AE009B9292 /* Snapping */,
 				F1AC0DE000000000000000A5 /* StackBadge */,
+				F1AC0DE000000000000000B5 /* Presets */,
 				98D4B6C925B625B6009C7BF6 /* TodoMode */,
 				985B9BFA22BE218C00A2E8F0 /* Popover */,
 				982140EA22B7DB0400ABFB3F /* WindowMover */,
@@ -801,6 +804,14 @@
 				F1AC0DE000000000000000A3 /* StackBadgeManager.swift */,
 			);
 			path = StackBadge;
+			sourceTree = "<group>";
+		};
+		F1AC0DE000000000000000B5 /* Presets */ = {
+			isa = PBXGroup;
+			children = (
+				F1AC0DE000000000000000B1 /* Preset.swift */,
+			);
+			path = Presets;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1100,6 +1111,7 @@
 				983BBD6F253B609D000D223E /* FootprintWindow.swift in Sources */,
 				F1AC0DE000000000000000A2 /* StackBadgeGeometry.swift in Sources */,
 				F1AC0DE000000000000000A4 /* StackBadgeManager.swift in Sources */,
+				F1AC0DE000000000000000B2 /* Preset.swift in Sources */,
 				988D067F22EB4EDE004EABD7 /* MoveLeftRightCalculation.swift in Sources */,
 				AA3A9E8B29230A82004EB8E5 /* CFExtension.swift in Sources */,
 				98C6DEF023CE191700CC0C1E /* GapCalculation.swift in Sources */,

--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		F1AC0DE000000000000000A2 /* StackBadgeGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A1 /* StackBadgeGeometry.swift */; };
 		F1AC0DE000000000000000A4 /* StackBadgeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A3 /* StackBadgeManager.swift */; };
 		F1AC0DE000000000000000B2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000B1 /* Preset.swift */; };
+		F1AC0DE000000000000000B4 /* PresetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000B3 /* PresetManager.swift */; };
 		983DD04028A844BE00BF1EEE /* SnapAreaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */; };
 		983DD04428B0639E00BF1EEE /* SnapAreaModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD04328B0639E00BF1EEE /* SnapAreaModel.swift */; };
 		984EDB0F29A42ED200D119D2 /* LaunchOnLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */; };
@@ -325,6 +326,7 @@
 		F1AC0DE000000000000000A1 /* StackBadgeGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeGeometry.swift; sourceTree = "<group>"; };
 		F1AC0DE000000000000000A3 /* StackBadgeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeManager.swift; sourceTree = "<group>"; };
 		F1AC0DE000000000000000B1 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
+		F1AC0DE000000000000000B3 /* PresetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetManager.swift; sourceTree = "<group>"; };
 		983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaViewController.swift; sourceTree = "<group>"; };
 		983DD04328B0639E00BF1EEE /* SnapAreaModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaModel.swift; sourceTree = "<group>"; };
 		984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOnLogin.swift; sourceTree = "<group>"; };
@@ -810,6 +812,7 @@
 			isa = PBXGroup;
 			children = (
 				F1AC0DE000000000000000B1 /* Preset.swift */,
+				F1AC0DE000000000000000B3 /* PresetManager.swift */,
 			);
 			path = Presets;
 			sourceTree = "<group>";
@@ -1112,6 +1115,7 @@
 				F1AC0DE000000000000000A2 /* StackBadgeGeometry.swift in Sources */,
 				F1AC0DE000000000000000A4 /* StackBadgeManager.swift in Sources */,
 				F1AC0DE000000000000000B2 /* Preset.swift in Sources */,
+				F1AC0DE000000000000000B4 /* PresetManager.swift in Sources */,
 				988D067F22EB4EDE004EABD7 /* MoveLeftRightCalculation.swift in Sources */,
 				AA3A9E8B29230A82004EB8E5 /* CFExtension.swift in Sources */,
 				98C6DEF023CE191700CC0C1E /* GapCalculation.swift in Sources */,

--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		F1AC0DE000000000000000A4 /* StackBadgeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A3 /* StackBadgeManager.swift */; };
 		F1AC0DE000000000000000A8 /* StackBadgeListPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A9 /* StackBadgeListPanel.swift */; };
 		F1AC0DE000000000000000AA /* StackBadgeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000AB /* StackBadgeRowView.swift */; };
+		F1AC0DE000000000000000B2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000B1 /* Preset.swift */; };
 		983DD04028A844BE00BF1EEE /* SnapAreaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */; };
 		983DD04428B0639E00BF1EEE /* SnapAreaModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD04328B0639E00BF1EEE /* SnapAreaModel.swift */; };
 		984EDB0F29A42ED200D119D2 /* LaunchOnLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */; };
@@ -329,6 +330,7 @@
 		F1AC0DE000000000000000A3 /* StackBadgeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeManager.swift; sourceTree = "<group>"; };
 		F1AC0DE000000000000000A9 /* StackBadgeListPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeListPanel.swift; sourceTree = "<group>"; };
 		F1AC0DE000000000000000AB /* StackBadgeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeRowView.swift; sourceTree = "<group>"; };
+		F1AC0DE000000000000000B1 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
 		983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaViewController.swift; sourceTree = "<group>"; };
 		983DD04328B0639E00BF1EEE /* SnapAreaModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaModel.swift; sourceTree = "<group>"; };
 		984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOnLogin.swift; sourceTree = "<group>"; };
@@ -725,6 +727,7 @@
 				989DA30C243FC0C3008C7AA4 /* WelcomeWindow */,
 				98C2755F231FF6AE009B9292 /* Snapping */,
 				F1AC0DE000000000000000A5 /* StackBadge */,
+				F1AC0DE000000000000000B5 /* Presets */,
 				98D4B6C925B625B6009C7BF6 /* TodoMode */,
 				985B9BFA22BE218C00A2E8F0 /* Popover */,
 				982140EA22B7DB0400ABFB3F /* WindowMover */,
@@ -813,6 +816,14 @@
 				F1AC0DE000000000000000AB /* StackBadgeRowView.swift */,
 			);
 			path = StackBadge;
+			sourceTree = "<group>";
+		};
+		F1AC0DE000000000000000B5 /* Presets */ = {
+			isa = PBXGroup;
+			children = (
+				F1AC0DE000000000000000B1 /* Preset.swift */,
+			);
+			path = Presets;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1116,6 +1127,7 @@
 				F1AC0DE000000000000000A4 /* StackBadgeManager.swift in Sources */,
 				F1AC0DE000000000000000A8 /* StackBadgeListPanel.swift in Sources */,
 				F1AC0DE000000000000000AA /* StackBadgeRowView.swift in Sources */,
+				F1AC0DE000000000000000B2 /* Preset.swift in Sources */,
 				988D067F22EB4EDE004EABD7 /* MoveLeftRightCalculation.swift in Sources */,
 				AA3A9E8B29230A82004EB8E5 /* CFExtension.swift in Sources */,
 				98C6DEF023CE191700CC0C1E /* GapCalculation.swift in Sources */,

--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		F1AC0DE000000000000000A8 /* StackBadgeListPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000A9 /* StackBadgeListPanel.swift */; };
 		F1AC0DE000000000000000AA /* StackBadgeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000AB /* StackBadgeRowView.swift */; };
 		F1AC0DE000000000000000B2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000B1 /* Preset.swift */; };
+		F1AC0DE000000000000000B4 /* PresetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AC0DE000000000000000B3 /* PresetManager.swift */; };
 		983DD04028A844BE00BF1EEE /* SnapAreaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */; };
 		983DD04428B0639E00BF1EEE /* SnapAreaModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DD04328B0639E00BF1EEE /* SnapAreaModel.swift */; };
 		984EDB0F29A42ED200D119D2 /* LaunchOnLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */; };
@@ -331,6 +332,7 @@
 		F1AC0DE000000000000000A9 /* StackBadgeListPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeListPanel.swift; sourceTree = "<group>"; };
 		F1AC0DE000000000000000AB /* StackBadgeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackBadgeRowView.swift; sourceTree = "<group>"; };
 		F1AC0DE000000000000000B1 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
+		F1AC0DE000000000000000B3 /* PresetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetManager.swift; sourceTree = "<group>"; };
 		983DD03F28A844BE00BF1EEE /* SnapAreaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaViewController.swift; sourceTree = "<group>"; };
 		983DD04328B0639E00BF1EEE /* SnapAreaModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapAreaModel.swift; sourceTree = "<group>"; };
 		984EDB0E29A42ED200D119D2 /* LaunchOnLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOnLogin.swift; sourceTree = "<group>"; };
@@ -822,6 +824,7 @@
 			isa = PBXGroup;
 			children = (
 				F1AC0DE000000000000000B1 /* Preset.swift */,
+				F1AC0DE000000000000000B3 /* PresetManager.swift */,
 			);
 			path = Presets;
 			sourceTree = "<group>";
@@ -1128,6 +1131,7 @@
 				F1AC0DE000000000000000A8 /* StackBadgeListPanel.swift in Sources */,
 				F1AC0DE000000000000000AA /* StackBadgeRowView.swift in Sources */,
 				F1AC0DE000000000000000B2 /* Preset.swift in Sources */,
+				F1AC0DE000000000000000B4 /* PresetManager.swift in Sources */,
 				988D067F22EB4EDE004EABD7 /* MoveLeftRightCalculation.swift in Sources */,
 				AA3A9E8B29230A82004EB8E5 /* CFExtension.swift in Sources */,
 				98C6DEF023CE191700CC0C1E /* GapCalculation.swift in Sources */,

--- a/Rectangle/AppDelegate.swift
+++ b/Rectangle/AppDelegate.swift
@@ -14,6 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let statusItem = RectangleStatusItem.instance
     static let windowHistory = WindowHistory()
     var updaterController: SPUStandardUpdaterController!
+    var presetManager: PresetManager!
     var hasPendingUpdate = false {
         didSet {
             Notification.Name.updateAvailability.post()
@@ -55,7 +56,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         mainStatusMenu.delegate = self
         statusItem.refreshVisibility()
         checkLaunchOnLogin()
-        
+        presetManager = PresetManager()
+
         let alreadyTrusted = accessibilityAuthorization.checkAccessibility {
             self.showWelcomeWindow()
             self.checkForConflictingApps()
@@ -99,7 +101,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self.prevActiveApp = change.oldValue ?? nil
         }
     }
-    
+
+    func applicationWillTerminate(_ notification: Notification) {
+        presetManager?.syncActivePreset()
+    }
+
     func checkVersion() {
         let currentVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
         if let lastVersion = Defaults.lastVersion.value,

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -131,4 +131,8 @@ class CycleSizesDefault: Default {
         return CodableDefault(int: value.toBits())
     }
 
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(int: 0)
+    }
+
 }

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -139,4 +139,8 @@ class CycleSizesDefault: Default {
         return CodableDefault(int: value.toBits())
     }
 
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(int: 0)
+    }
+
 }

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -105,6 +105,8 @@ class Defaults {
     static let screensOrderedByX = IntEnumDefault<ScreenOrdering>(key: "screensOrderedByX", defaultValue: .yThenMinX)
     static let combinedDisplayMode = OptionalBoolDefault(key: "combinedDisplayMode")
     static let greenButtonOverride = BoolDefault(key: "greenButtonOverride")
+    /// Deliberately not in `array`: presets are exported through `Config.presets`
+    /// rather than as an escaped JSON string among the individual settings.
     static let presets = JSONDefault<PresetStore>(key: "presets")
     static var array: [Default] = [
         launchOnLogin,
@@ -201,8 +203,7 @@ class Defaults {
         cyclingOverlapMaxCascade,
         stackBadge,
         moveFixedSizeToEdge,
-        greenButtonOverride,
-        presets
+        greenButtonOverride
     ]
 }
 

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -105,6 +105,7 @@ class Defaults {
     static let screensOrderedByX = IntEnumDefault<ScreenOrdering>(key: "screensOrderedByX", defaultValue: .yThenMinX)
     static let combinedDisplayMode = OptionalBoolDefault(key: "combinedDisplayMode")
     static let greenButtonOverride = BoolDefault(key: "greenButtonOverride")
+    static let presets = JSONDefault<PresetStore>(key: "presets")
     static var array: [Default] = [
         launchOnLogin,
         disabledApps,
@@ -200,7 +201,8 @@ class Defaults {
         cyclingOverlapMaxCascade,
         stackBadge,
         moveFixedSizeToEdge,
-        greenButtonOverride
+        greenButtonOverride,
+        presets
     ]
 }
 

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -224,6 +224,10 @@ protocol Default {
     var key: String { get }
     func load(from codable: CodableDefault)
     func toCodable() -> CodableDefault
+
+    /// The value this setting has when the user has never touched it. Used to build
+    /// a preset from Rectangle's built-in defaults without mutating live settings.
+    func defaultCodable() -> CodableDefault
 }
 
 class BoolDefault: Default {
@@ -252,6 +256,10 @@ class BoolDefault: Default {
     
     func toCodable() -> CodableDefault {
         return CodableDefault(bool: enabled)
+    }
+
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(bool: false)
     }
 }
 
@@ -304,6 +312,10 @@ class OptionalBoolDefault: Default {
         let intValue = enabled ? 1 : 2
         return CodableDefault(int: intValue)
     }
+
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(int: 0)
+    }
 }
 
 class StringDefault: Default {
@@ -331,12 +343,17 @@ class StringDefault: Default {
     func toCodable() -> CodableDefault {
         return CodableDefault(string: value)
     }
+
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(string: nil)
+    }
 }
 
 class FloatDefault: Default {
     public private(set) var key: String
     private var initialized = false
-    
+    private let defaultValue: Float
+
     var value: Float {
         didSet {
             if initialized {
@@ -344,26 +361,31 @@ class FloatDefault: Default {
             }
         }
     }
-    
+
     var cgFloat: CGFloat { CGFloat(value) }
 
     init(key: String, defaultValue: Float = 0) {
         self.key = key
+        self.defaultValue = defaultValue
         value = UserDefaults.standard.float(forKey: key)
         if(defaultValue != 0 && value == 0) {
             value = defaultValue
         }
         initialized = true
     }
-    
+
     func load(from codable: CodableDefault) {
         if let float = codable.float {
             value = float
         }
     }
-    
+
     func toCodable() -> CodableDefault {
         return CodableDefault(float: value)
+    }
+
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(float: defaultValue)
     }
 }
 
@@ -404,12 +426,17 @@ class DoubleDefault: Default {
     func toCodable() -> CodableDefault {
         CodableDefault(double: value)
     }
+
+    func defaultCodable() -> CodableDefault {
+        CodableDefault(double: defaultValue)
+    }
 }
 
 class IntDefault: Default {
     public private(set) var key: String
     private var initialized = false
-    
+    private let defaultValue: Int
+
     var value: Int {
         didSet {
             if initialized {
@@ -417,24 +444,29 @@ class IntDefault: Default {
             }
         }
     }
-    
+
     init(key: String, defaultValue: Int = 0) {
         self.key = key
+        self.defaultValue = defaultValue
         value = UserDefaults.standard.integer(forKey: key)
         if(defaultValue != 0 && value == 0) {
             value = defaultValue
         }
         initialized = true
     }
-    
+
     func load(from codable: CodableDefault) {
         if let int = codable.int {
             value = int
         }
     }
-    
+
     func toCodable() -> CodableDefault {
         return CodableDefault(int: value)
+    }
+
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(int: defaultValue)
     }
 }
 
@@ -474,9 +506,13 @@ class JSONDefault<T: Codable>: StringDefault {
     }
     
     private func loadFromJSON() {
-        guard let jsonString = value else { return }
+        guard let jsonString = value,
+              let jsonData = jsonString.data(using: .utf8)
+        else {
+            typedValue = nil
+            return
+        }
         let decoder = JSONDecoder()
-        guard let jsonData = jsonString.data(using: .utf8) else { return }
         typedValue = try? decoder.decode(T.self, from: jsonData)
     }
     
@@ -523,6 +559,10 @@ class IntEnumDefault<E: RawRepresentable>: Default where E.RawValue == Int {
     
     func toCodable() -> CodableDefault {
         CodableDefault(int: value.rawValue)
+    }
+
+    func defaultCodable() -> CodableDefault {
+        CodableDefault(int: defaultValue.rawValue)
     }
 }
 

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -110,6 +110,8 @@ class Defaults {
     static let screensOrderedByX = IntEnumDefault<ScreenOrdering>(key: "screensOrderedByX", defaultValue: .yThenMinX)
     static let combinedDisplayMode = OptionalBoolDefault(key: "combinedDisplayMode")
     static let greenButtonOverride = BoolDefault(key: "greenButtonOverride")
+    /// Deliberately not in `array`: presets are exported through `Config.presets`
+    /// rather than as an escaped JSON string among the individual settings.
     static let presets = JSONDefault<PresetStore>(key: "presets")
     static var array: [Default] = [
         launchOnLogin,
@@ -207,8 +209,7 @@ class Defaults {
         cyclingOverlapMaxCascade,
         stackBadge,
         moveFixedSizeToEdge,
-        greenButtonOverride,
-        presets
+        greenButtonOverride
     ]
 }
 

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -230,6 +230,10 @@ protocol Default {
     var key: String { get }
     func load(from codable: CodableDefault)
     func toCodable() -> CodableDefault
+
+    /// The value this setting has when the user has never touched it. Used to build
+    /// a preset from Rectangle's built-in defaults without mutating live settings.
+    func defaultCodable() -> CodableDefault
 }
 
 class BoolDefault: Default {
@@ -258,6 +262,10 @@ class BoolDefault: Default {
     
     func toCodable() -> CodableDefault {
         return CodableDefault(bool: enabled)
+    }
+
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(bool: false)
     }
 }
 
@@ -310,6 +318,10 @@ class OptionalBoolDefault: Default {
         let intValue = enabled ? 1 : 2
         return CodableDefault(int: intValue)
     }
+
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(int: 0)
+    }
 }
 
 class StringDefault: Default {
@@ -337,12 +349,17 @@ class StringDefault: Default {
     func toCodable() -> CodableDefault {
         return CodableDefault(string: value)
     }
+
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(string: nil)
+    }
 }
 
 class FloatDefault: Default {
     public private(set) var key: String
     private var initialized = false
-    
+    private let defaultValue: Float
+
     var value: Float {
         didSet {
             if initialized {
@@ -350,26 +367,31 @@ class FloatDefault: Default {
             }
         }
     }
-    
+
     var cgFloat: CGFloat { CGFloat(value) }
 
     init(key: String, defaultValue: Float = 0) {
         self.key = key
+        self.defaultValue = defaultValue
         value = UserDefaults.standard.float(forKey: key)
         if(defaultValue != 0 && value == 0) {
             value = defaultValue
         }
         initialized = true
     }
-    
+
     func load(from codable: CodableDefault) {
         if let float = codable.float {
             value = float
         }
     }
-    
+
     func toCodable() -> CodableDefault {
         return CodableDefault(float: value)
+    }
+
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(float: defaultValue)
     }
 }
 
@@ -410,12 +432,17 @@ class DoubleDefault: Default {
     func toCodable() -> CodableDefault {
         CodableDefault(double: value)
     }
+
+    func defaultCodable() -> CodableDefault {
+        CodableDefault(double: defaultValue)
+    }
 }
 
 class IntDefault: Default {
     public private(set) var key: String
     private var initialized = false
-    
+    private let defaultValue: Int
+
     var value: Int {
         didSet {
             if initialized {
@@ -423,24 +450,29 @@ class IntDefault: Default {
             }
         }
     }
-    
+
     init(key: String, defaultValue: Int = 0) {
         self.key = key
+        self.defaultValue = defaultValue
         value = UserDefaults.standard.integer(forKey: key)
         if(defaultValue != 0 && value == 0) {
             value = defaultValue
         }
         initialized = true
     }
-    
+
     func load(from codable: CodableDefault) {
         if let int = codable.int {
             value = int
         }
     }
-    
+
     func toCodable() -> CodableDefault {
         return CodableDefault(int: value)
+    }
+
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(int: defaultValue)
     }
 }
 
@@ -480,9 +512,13 @@ class JSONDefault<T: Codable>: StringDefault {
     }
     
     private func loadFromJSON() {
-        guard let jsonString = value else { return }
+        guard let jsonString = value,
+              let jsonData = jsonString.data(using: .utf8)
+        else {
+            typedValue = nil
+            return
+        }
         let decoder = JSONDecoder()
-        guard let jsonData = jsonString.data(using: .utf8) else { return }
         typedValue = try? decoder.decode(T.self, from: jsonData)
     }
     
@@ -501,6 +537,7 @@ class JSONDefault<T: Codable>: StringDefault {
 
 class IntEnumDefault<E: RawRepresentable>: Default where E.RawValue == Int {
     public private(set) var key: String
+    private let defaultValue: E
     private let invalidValueFallback: E
 
     var _value: E
@@ -516,6 +553,7 @@ class IntEnumDefault<E: RawRepresentable>: Default where E.RawValue == Int {
 
     init(key: String, defaultValue: E, invalidValueFallback: E? = nil) {
         self.key = key
+        self.defaultValue = defaultValue
         let invalidValueFallback = invalidValueFallback ?? defaultValue
         self.invalidValueFallback = invalidValueFallback
         if UserDefaults.standard.object(forKey: key) == nil {
@@ -535,6 +573,10 @@ class IntEnumDefault<E: RawRepresentable>: Default where E.RawValue == Int {
     
     func toCodable() -> CodableDefault {
         CodableDefault(int: value.rawValue)
+    }
+
+    func defaultCodable() -> CodableDefault {
+        CodableDefault(int: defaultValue.rawValue)
     }
 }
 

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -110,6 +110,7 @@ class Defaults {
     static let screensOrderedByX = IntEnumDefault<ScreenOrdering>(key: "screensOrderedByX", defaultValue: .yThenMinX)
     static let combinedDisplayMode = OptionalBoolDefault(key: "combinedDisplayMode")
     static let greenButtonOverride = BoolDefault(key: "greenButtonOverride")
+    static let presets = JSONDefault<PresetStore>(key: "presets")
     static var array: [Default] = [
         launchOnLogin,
         disabledApps,
@@ -206,7 +207,8 @@ class Defaults {
         cyclingOverlapMaxCascade,
         stackBadge,
         moveFixedSizeToEdge,
-        greenButtonOverride
+        greenButtonOverride,
+        presets
     ]
 }
 

--- a/Rectangle/PrefsWindow/Config.swift
+++ b/Rectangle/PrefsWindow/Config.swift
@@ -52,7 +52,17 @@ extension Defaults {
         let decoder = JSONDecoder()
         return try? decoder.decode(Config.self, from: jsonData)
     }
-    
+
+    /// Applies coded settings to the live defaults. Keys that are absent are left
+    /// alone. Shared by JSON import and by preset switching.
+    static func apply(defaults codableDefaults: [String: CodableDefault]) {
+        for availableDefault in Defaults.array {
+            if let codedDefault = codableDefaults[availableDefault.key] {
+                availableDefault.load(from: codedDefault)
+            }
+        }
+    }
+
     static func load(fileUrl: URL, notificationCenter: NotificationCenter = .default) {
         guard let dictTransformer = ValueTransformer(forName: NSValueTransformerName(rawValue: MASDictionaryTransformerName)) else { return }
         
@@ -66,12 +76,8 @@ extension Defaults {
         guard let jsonString = try? String(contentsOf: fileUrl, encoding: .utf8),
               let config = convert(jsonString: jsonString) else { return }
 
-        for availableDefault in Defaults.array {
-            if let codedDefault = config.defaults[availableDefault.key] {
-                availableDefault.load(from: codedDefault)
-            }
-        }
-        
+        apply(defaults: config.defaults)
+
         for action in WindowAction.active {
             let importedShortcut = config.shortcuts[action.name] ?? action.aliasName.flatMap { config.shortcuts[$0] }
             if let importedShortcut, importedShortcut.keyCode >= 0 {

--- a/Rectangle/PrefsWindow/Config.swift
+++ b/Rectangle/PrefsWindow/Config.swift
@@ -32,7 +32,8 @@ extension Defaults {
         let config = Config(bundleId: "com.knollsoft.Rectangle",
                             version: version,
                             shortcuts: shortcuts,
-                            defaults: codableDefaults)
+                            defaults: codableDefaults,
+                            presets: Defaults.presets.typedValue)
         
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
@@ -77,6 +78,10 @@ extension Defaults {
               let config = convert(jsonString: jsonString) else { return }
 
         apply(defaults: config.defaults)
+
+        if let presets = config.presets {
+            Defaults.presets.typedValue = presets
+        }
 
         for action in WindowAction.active {
             let importedShortcut = config.shortcuts[action.name] ?? action.aliasName.flatMap { config.shortcuts[$0] }
@@ -184,4 +189,20 @@ struct Config: Codable {
     let version: String
     let shortcuts: [String: Shortcut]
     let defaults: [String: CodableDefault]
+
+    /// Absent in configs exported before presets existed. Decoding tolerates both
+    /// its absence here and its presence in older builds, which ignore unknown keys.
+    let presets: PresetStore?
+
+    init(bundleId: String,
+         version: String,
+         shortcuts: [String: Shortcut],
+         defaults: [String: CodableDefault],
+         presets: PresetStore? = nil) {
+        self.bundleId = bundleId
+        self.version = version
+        self.shortcuts = shortcuts
+        self.defaults = defaults
+        self.presets = presets
+    }
 }

--- a/Rectangle/PrefsWindow/Config.swift
+++ b/Rectangle/PrefsWindow/Config.swift
@@ -32,7 +32,8 @@ extension Defaults {
         let config = Config(bundleId: "com.knollsoft.Rectangle",
                             version: version,
                             shortcuts: shortcuts,
-                            defaults: codableDefaults)
+                            defaults: codableDefaults,
+                            presets: Defaults.presets.typedValue)
         
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -74,6 +75,10 @@ extension Defaults {
               let config = convert(jsonString: jsonString) else { return }
 
         apply(defaults: config.defaults)
+
+        if let presets = config.presets {
+            Defaults.presets.typedValue = presets
+        }
 
         for action in WindowAction.active {
             let importedShortcut = config.shortcuts[action.name] ?? action.aliasName.flatMap { config.shortcuts[$0] }
@@ -181,4 +186,20 @@ struct Config: Codable {
     let version: String
     let shortcuts: [String: Shortcut]
     let defaults: [String: CodableDefault]
+
+    /// Absent in configs exported before presets existed. Decoding tolerates both
+    /// its absence here and its presence in older builds, which ignore unknown keys.
+    let presets: PresetStore?
+
+    init(bundleId: String,
+         version: String,
+         shortcuts: [String: Shortcut],
+         defaults: [String: CodableDefault],
+         presets: PresetStore? = nil) {
+        self.bundleId = bundleId
+        self.version = version
+        self.shortcuts = shortcuts
+        self.defaults = defaults
+        self.presets = presets
+    }
 }

--- a/Rectangle/PrefsWindow/Config.swift
+++ b/Rectangle/PrefsWindow/Config.swift
@@ -49,7 +49,17 @@ extension Defaults {
         let decoder = JSONDecoder()
         return try? decoder.decode(Config.self, from: jsonData)
     }
-    
+
+    /// Applies coded settings to the live defaults. Keys that are absent are left
+    /// alone. Shared by JSON import and by preset switching.
+    static func apply(defaults codableDefaults: [String: CodableDefault]) {
+        for availableDefault in Defaults.array {
+            if let codedDefault = codableDefaults[availableDefault.key] {
+                availableDefault.load(from: codedDefault)
+            }
+        }
+    }
+
     static func load(fileUrl: URL, notificationCenter: NotificationCenter = .default) {
         guard let dictTransformer = ValueTransformer(forName: NSValueTransformerName(rawValue: MASDictionaryTransformerName)) else { return }
         
@@ -63,12 +73,8 @@ extension Defaults {
         guard let jsonString = try? String(contentsOf: fileUrl, encoding: .utf8),
               let config = convert(jsonString: jsonString) else { return }
 
-        for availableDefault in Defaults.array {
-            if let codedDefault = config.defaults[availableDefault.key] {
-                availableDefault.load(from: codedDefault)
-            }
-        }
-        
+        apply(defaults: config.defaults)
+
         for action in WindowAction.active {
             let importedShortcut = config.shortcuts[action.name] ?? action.aliasName.flatMap { config.shortcuts[$0] }
             if let importedShortcut, importedShortcut.keyCode >= 0 {

--- a/Rectangle/PrefsWindow/PrefsViewController.swift
+++ b/Rectangle/PrefsWindow/PrefsViewController.swift
@@ -134,6 +134,12 @@ class PrefsViewController: NSViewController {
         subscribeToAllowAnyShortcutToggle()
 
         additionalShortcutsStackView.isHidden = true
+    }
+
+    /// awakeFromNib can run more than once for a storyboard scene, so anything that
+    /// inserts a view or registers an observer belongs here instead.
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
         initializePresetPicker()
         subscribeToConfigImported()
@@ -146,7 +152,9 @@ class PrefsViewController: NSViewController {
     }
 
     private func initializePresetPicker() {
-        guard let mainStack = additionalShortcutsStackView.superview as? NSStackView else { return }
+        guard presetPopUpButton == nil,
+              let mainStack = additionalShortcutsStackView.superview as? NSStackView
+        else { return }
 
         let popUpButton = NSPopUpButton(frame: .zero, pullsDown: false)
         popUpButton.translatesAutoresizingMaskIntoConstraints = false

--- a/Rectangle/PrefsWindow/PrefsViewController.swift
+++ b/Rectangle/PrefsWindow/PrefsViewController.swift
@@ -64,15 +64,6 @@ class PrefsViewController: NSViewController {
     @IBOutlet weak var showMoreButton: NSButton!
     @IBOutlet weak var additionalShortcutsStackView: NSStackView!
 
-    private var presetPopUpButton: NSPopUpButton?
-
-    private enum PresetMenuAction: Int {
-        case newFromDefaults = 1
-        case duplicate = 2
-        case rename = 3
-        case delete = 4
-    }
-
 
     // Settings
     override func awakeFromNib() {
@@ -136,12 +127,11 @@ class PrefsViewController: NSViewController {
         additionalShortcutsStackView.isHidden = true
     }
 
-    /// awakeFromNib can run more than once for a storyboard scene, so anything that
-    /// inserts a view or registers an observer belongs here instead.
+    /// awakeFromNib can run more than once for a storyboard scene, so registering an
+    /// observer belongs here instead.
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        initializePresetPicker()
         subscribeToConfigImported()
     }
     
@@ -149,140 +139,6 @@ class PrefsViewController: NSViewController {
         additionalShortcutsStackView.isHidden = !additionalShortcutsStackView.isHidden
         showMoreButton.title = additionalShortcutsStackView.isHidden
             ? "▶︎ ⋯" : "▼"
-    }
-
-    private func initializePresetPicker() {
-        guard presetPopUpButton == nil,
-              let mainStack = additionalShortcutsStackView.superview as? NSStackView
-        else { return }
-
-        let popUpButton = NSPopUpButton(frame: .zero, pullsDown: false)
-        popUpButton.translatesAutoresizingMaskIntoConstraints = false
-        popUpButton.target = self
-        popUpButton.action = #selector(presetSelectionChanged(_:))
-
-        let row = NSView()
-        row.translatesAutoresizingMaskIntoConstraints = false
-        row.addSubview(popUpButton)
-
-        mainStack.insertArrangedSubview(row, at: 0)
-
-        NSLayoutConstraint.activate([
-            row.widthAnchor.constraint(equalTo: mainStack.widthAnchor),
-            popUpButton.trailingAnchor.constraint(equalTo: row.trailingAnchor),
-            popUpButton.topAnchor.constraint(equalTo: row.topAnchor),
-            popUpButton.bottomAnchor.constraint(equalTo: row.bottomAnchor)
-        ])
-
-        presetPopUpButton = popUpButton
-        reloadPresetMenu()
-    }
-
-    private func reloadPresetMenu() {
-        guard let popUpButton = presetPopUpButton,
-              let manager = AppDelegate.instance.presetManager
-        else { return }
-
-        let menu = NSMenu()
-        let activeId = manager.activePreset?.id
-
-        for preset in manager.presets {
-            let item = NSMenuItem(title: preset.name, action: nil, keyEquivalent: "")
-            item.representedObject = preset.id
-            item.state = preset.id == activeId ? .on : .off
-            menu.addItem(item)
-        }
-
-        menu.addItem(.separator())
-        addPresetActionItem(to: menu,
-                            title: NSLocalizedString("New Preset from Defaults…", tableName: "Main", value: "", comment: ""),
-                            action: .newFromDefaults)
-        addPresetActionItem(to: menu,
-                            title: NSLocalizedString("Duplicate Preset…", tableName: "Main", value: "", comment: ""),
-                            action: .duplicate)
-        addPresetActionItem(to: menu,
-                            title: NSLocalizedString("Rename Preset…", tableName: "Main", value: "", comment: ""),
-                            action: .rename)
-        addPresetActionItem(to: menu,
-                            title: NSLocalizedString("Delete Preset", tableName: "Main", value: "", comment: ""),
-                            action: .delete)
-
-        popUpButton.menu = menu
-
-        if let activeId = activeId,
-           let index = manager.presets.firstIndex(where: { $0.id == activeId }) {
-            popUpButton.selectItem(at: index)
-        }
-    }
-
-    private func addPresetActionItem(to menu: NSMenu, title: String, action: PresetMenuAction) {
-        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-        item.tag = action.rawValue
-        menu.addItem(item)
-    }
-
-    @objc private func presetSelectionChanged(_ sender: NSPopUpButton) {
-        guard let manager = AppDelegate.instance.presetManager,
-              let item = sender.selectedItem
-        else { return }
-
-        if let id = item.representedObject as? UUID {
-            manager.activate(id)
-        } else if let action = PresetMenuAction(rawValue: item.tag) {
-            performPresetAction(action, with: manager)
-        }
-
-        reloadPresetMenu()
-    }
-
-    private func performPresetAction(_ action: PresetMenuAction, with manager: PresetManager) {
-        switch action {
-        case .newFromDefaults:
-            let suggestion = NSLocalizedString("New Preset", tableName: "Main", value: "", comment: "")
-            guard let name = promptForPresetName(question: NSLocalizedString("Name the new preset", tableName: "Main", value: "", comment: ""),
-                                                 defaultValue: suggestion)
-            else { return }
-            let preset = manager.createFromDefaults(named: name)
-            manager.activate(preset.id)
-
-        case .duplicate:
-            guard let active = manager.activePreset,
-                  let name = promptForPresetName(question: NSLocalizedString("Name the duplicated preset", tableName: "Main", value: "", comment: ""),
-                                                 defaultValue: active.name)
-            else { return }
-            if let copy = manager.duplicateActivePreset(named: name) {
-                manager.activate(copy.id)
-            }
-
-        case .rename:
-            guard let active = manager.activePreset,
-                  let name = promptForPresetName(question: NSLocalizedString("Rename this preset", tableName: "Main", value: "", comment: ""),
-                                                 defaultValue: active.name)
-            else { return }
-            manager.rename(active.id, to: name)
-
-        case .delete:
-            guard let active = manager.activePreset, manager.presets.count > 1 else { return }
-            let response = AlertUtil.twoButtonAlert(
-                question: NSLocalizedString("Delete this preset?", tableName: "Main", value: "", comment: ""),
-                text: active.name,
-                confirmText: NSLocalizedString("Delete", tableName: "Main", value: "", comment: ""),
-                cancelText: NSLocalizedString("Cancel", tableName: "Main", value: "", comment: ""))
-            guard response == .alertFirstButtonReturn else { return }
-            manager.delete(active.id)
-        }
-    }
-
-    private func promptForPresetName(question: String, defaultValue: String) -> String? {
-        let entered = AlertUtil.textInputAlert(
-            question: question,
-            text: "",
-            defaultValue: defaultValue,
-            confirmText: NSLocalizedString("OK", tableName: "Main", value: "", comment: ""),
-            cancelText: NSLocalizedString("Cancel", tableName: "Main", value: "", comment: ""))
-
-        guard let entered = entered else { return nil }
-        return PresetNaming.sanitized(entered)
     }
 
     private func subscribeToConfigImported() {
@@ -296,8 +152,6 @@ class PrefsViewController: NSViewController {
                 view.setAssociatedUserDefaultsKey(nil, withTransformerName: MASDictionaryTransformerName)
                 view.setAssociatedUserDefaultsKey(action.name, withTransformerName: MASDictionaryTransformerName)
             }
-
-            self.reloadPresetMenu()
         }
     }
 

--- a/Rectangle/PrefsWindow/PrefsViewController.swift
+++ b/Rectangle/PrefsWindow/PrefsViewController.swift
@@ -63,7 +63,17 @@ class PrefsViewController: NSViewController {
     
     @IBOutlet weak var showMoreButton: NSButton!
     @IBOutlet weak var additionalShortcutsStackView: NSStackView!
-    
+
+    private var presetPopUpButton: NSPopUpButton?
+
+    private enum PresetMenuAction: Int {
+        case newFromDefaults = 1
+        case duplicate = 2
+        case rename = 3
+        case delete = 4
+    }
+
+
     // Settings
     override func awakeFromNib() {
         
@@ -122,8 +132,11 @@ class PrefsViewController: NSViewController {
         }
         
         subscribeToAllowAnyShortcutToggle()
-        
+
         additionalShortcutsStackView.isHidden = true
+
+        initializePresetPicker()
+        subscribeToConfigImported()
     }
     
     @IBAction func toggleShowMore(_ sender: NSButton) {
@@ -131,7 +144,155 @@ class PrefsViewController: NSViewController {
         showMoreButton.title = additionalShortcutsStackView.isHidden
             ? "▶︎ ⋯" : "▼"
     }
-    
+
+    private func initializePresetPicker() {
+        guard let mainStack = additionalShortcutsStackView.superview as? NSStackView else { return }
+
+        let popUpButton = NSPopUpButton(frame: .zero, pullsDown: false)
+        popUpButton.translatesAutoresizingMaskIntoConstraints = false
+        popUpButton.target = self
+        popUpButton.action = #selector(presetSelectionChanged(_:))
+
+        let row = NSView()
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.addSubview(popUpButton)
+
+        mainStack.insertArrangedSubview(row, at: 0)
+
+        NSLayoutConstraint.activate([
+            row.widthAnchor.constraint(equalTo: mainStack.widthAnchor),
+            popUpButton.trailingAnchor.constraint(equalTo: row.trailingAnchor),
+            popUpButton.topAnchor.constraint(equalTo: row.topAnchor),
+            popUpButton.bottomAnchor.constraint(equalTo: row.bottomAnchor)
+        ])
+
+        presetPopUpButton = popUpButton
+        reloadPresetMenu()
+    }
+
+    private func reloadPresetMenu() {
+        guard let popUpButton = presetPopUpButton,
+              let manager = AppDelegate.instance.presetManager
+        else { return }
+
+        let menu = NSMenu()
+        let activeId = manager.activePreset?.id
+
+        for preset in manager.presets {
+            let item = NSMenuItem(title: preset.name, action: nil, keyEquivalent: "")
+            item.representedObject = preset.id
+            item.state = preset.id == activeId ? .on : .off
+            menu.addItem(item)
+        }
+
+        menu.addItem(.separator())
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("New Preset from Defaults…", tableName: "Main", value: "", comment: ""),
+                            action: .newFromDefaults)
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("Duplicate Preset…", tableName: "Main", value: "", comment: ""),
+                            action: .duplicate)
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("Rename Preset…", tableName: "Main", value: "", comment: ""),
+                            action: .rename)
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("Delete Preset", tableName: "Main", value: "", comment: ""),
+                            action: .delete)
+
+        popUpButton.menu = menu
+
+        if let activeId = activeId,
+           let index = manager.presets.firstIndex(where: { $0.id == activeId }) {
+            popUpButton.selectItem(at: index)
+        }
+    }
+
+    private func addPresetActionItem(to menu: NSMenu, title: String, action: PresetMenuAction) {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.tag = action.rawValue
+        menu.addItem(item)
+    }
+
+    @objc private func presetSelectionChanged(_ sender: NSPopUpButton) {
+        guard let manager = AppDelegate.instance.presetManager,
+              let item = sender.selectedItem
+        else { return }
+
+        if let id = item.representedObject as? UUID {
+            manager.activate(id)
+        } else if let action = PresetMenuAction(rawValue: item.tag) {
+            performPresetAction(action, with: manager)
+        }
+
+        reloadPresetMenu()
+    }
+
+    private func performPresetAction(_ action: PresetMenuAction, with manager: PresetManager) {
+        switch action {
+        case .newFromDefaults:
+            let suggestion = NSLocalizedString("New Preset", tableName: "Main", value: "", comment: "")
+            guard let name = promptForPresetName(question: NSLocalizedString("Name the new preset", tableName: "Main", value: "", comment: ""),
+                                                 defaultValue: suggestion)
+            else { return }
+            let preset = manager.createFromDefaults(named: name)
+            manager.activate(preset.id)
+
+        case .duplicate:
+            guard let active = manager.activePreset,
+                  let name = promptForPresetName(question: NSLocalizedString("Name the duplicated preset", tableName: "Main", value: "", comment: ""),
+                                                 defaultValue: active.name)
+            else { return }
+            if let copy = manager.duplicateActivePreset(named: name) {
+                manager.activate(copy.id)
+            }
+
+        case .rename:
+            guard let active = manager.activePreset,
+                  let name = promptForPresetName(question: NSLocalizedString("Rename this preset", tableName: "Main", value: "", comment: ""),
+                                                 defaultValue: active.name)
+            else { return }
+            manager.rename(active.id, to: name)
+
+        case .delete:
+            guard let active = manager.activePreset, manager.presets.count > 1 else { return }
+            let response = AlertUtil.twoButtonAlert(
+                question: NSLocalizedString("Delete this preset?", tableName: "Main", value: "", comment: ""),
+                text: active.name,
+                confirmText: NSLocalizedString("Delete", tableName: "Main", value: "", comment: ""),
+                cancelText: NSLocalizedString("Cancel", tableName: "Main", value: "", comment: ""))
+            guard response == .alertFirstButtonReturn else { return }
+            manager.delete(active.id)
+        }
+    }
+
+    private func promptForPresetName(question: String, defaultValue: String) -> String? {
+        let entered = AlertUtil.textInputAlert(
+            question: question,
+            text: "",
+            defaultValue: defaultValue,
+            confirmText: NSLocalizedString("OK", tableName: "Main", value: "", comment: ""),
+            cancelText: NSLocalizedString("Cancel", tableName: "Main", value: "", comment: ""))
+
+        guard let entered = entered else { return nil }
+        return PresetNaming.sanitized(entered)
+    }
+
+    private func subscribeToConfigImported() {
+        Notification.Name.configImported.onPost { [weak self] _ in
+            guard let self = self else { return }
+
+            // Rebind every recorder so the tab reflects the newly applied keys.
+            // setAssociatedUserDefaultsKey does not break the previous binding on
+            // its own, so pass nil first to unbind.
+            for (action, view) in self.actionsToViews {
+                view.setAssociatedUserDefaultsKey(nil, withTransformerName: MASDictionaryTransformerName)
+                view.setAssociatedUserDefaultsKey(action.name, withTransformerName: MASDictionaryTransformerName)
+            }
+
+            self.reloadPresetMenu()
+        }
+    }
+
     private func subscribeToAllowAnyShortcutToggle() {
         Notification.Name.allowAnyShortcut.onPost { notification in
             guard let enabled = notification.object as? Bool else { return }

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -293,6 +293,15 @@ class SettingsViewController: NSViewController {
         Notification.Name.windowSnapping.post(object: true)
     }
 
+    private var presetPopUpButton: NSPopUpButton?
+
+    private enum PresetMenuAction: Int {
+        case newFromDefaults = 1
+        case duplicate = 2
+        case rename = 3
+        case delete = 4
+    }
+
     @IBAction func showExtraSettings(_ sender: NSButton) {
         if extraSettingsPopover == nil {
             let popover = NSPopover()
@@ -940,9 +949,28 @@ class SettingsViewController: NSViewController {
             mainStackView.addArrangedSubview(hSplitRow)
             mainStackView.addArrangedSubview(vSplitRow)
 
+            let presetsHeaderLabel = NSTextField(labelWithString: NSLocalizedString("Presets", tableName: "Main", value: "", comment: ""))
+            presetsHeaderLabel.font = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize)
+            presetsHeaderLabel.alignment = .center
+            presetsHeaderLabel.translatesAutoresizingMaskIntoConstraints = false
+
+            let presetPopUpButton = NSPopUpButton(frame: .zero, pullsDown: false)
+            presetPopUpButton.translatesAutoresizingMaskIntoConstraints = false
+            presetPopUpButton.target = self
+            presetPopUpButton.action = #selector(presetSelectionChanged(_:))
+            self.presetPopUpButton = presetPopUpButton
+            reloadPresetMenu()
+
+            mainStackView.setCustomSpacing(12, after: vSplitRow)
+            mainStackView.addArrangedSubview(presetsHeaderLabel)
+            mainStackView.setCustomSpacing(10, after: presetsHeaderLabel)
+            mainStackView.addArrangedSubview(presetPopUpButton)
+
             NSLayoutConstraint.activate([
                 headerLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
                 splitRatioHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
+                presetsHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
+                presetPopUpButton.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
                 largerWidthLabel.widthAnchor.constraint(equalTo: smallerWidthLabel.widthAnchor),
                 smallerWidthLabel.widthAnchor.constraint(equalTo: widthStepLabel.widthAnchor),
                 widthStepLabel.widthAnchor.constraint(equalTo: topVerticalThirdLabel.widthAnchor),
@@ -1030,7 +1058,114 @@ class SettingsViewController: NSViewController {
             popover.contentViewController = viewController
             extraSettingsPopover = popover
         }
+        reloadPresetMenu()
         extraSettingsPopover?.show(relativeTo: sender.bounds, of: sender, preferredEdge: .maxY)
+    }
+
+    private func reloadPresetMenu() {
+        guard let popUpButton = presetPopUpButton,
+              let manager = AppDelegate.instance.presetManager
+        else { return }
+
+        let menu = NSMenu()
+        let activeId = manager.activePreset?.id
+
+        for preset in manager.presets {
+            let item = NSMenuItem(title: preset.name, action: nil, keyEquivalent: "")
+            item.representedObject = preset.id
+            menu.addItem(item)
+        }
+
+        menu.addItem(.separator())
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("New Preset from Defaults…", tableName: "Main", value: "", comment: ""),
+                            action: .newFromDefaults)
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("Duplicate Preset…", tableName: "Main", value: "", comment: ""),
+                            action: .duplicate)
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("Rename Preset…", tableName: "Main", value: "", comment: ""),
+                            action: .rename)
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("Delete Preset", tableName: "Main", value: "", comment: ""),
+                            action: .delete)
+
+        popUpButton.menu = menu
+
+        if let activeId = activeId,
+           let index = manager.presets.firstIndex(where: { $0.id == activeId }) {
+            popUpButton.selectItem(at: index)
+        }
+    }
+
+    private func addPresetActionItem(to menu: NSMenu, title: String, action: PresetMenuAction) {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.tag = action.rawValue
+        menu.addItem(item)
+    }
+
+    @objc private func presetSelectionChanged(_ sender: NSPopUpButton) {
+        guard let manager = AppDelegate.instance.presetManager,
+              let item = sender.selectedItem
+        else { return }
+
+        if let id = item.representedObject as? UUID {
+            manager.activate(id)
+        } else if let action = PresetMenuAction(rawValue: item.tag) {
+            performPresetAction(action, with: manager)
+        }
+
+        reloadPresetMenu()
+    }
+
+    private func performPresetAction(_ action: PresetMenuAction, with manager: PresetManager) {
+        switch action {
+        case .newFromDefaults:
+            let suggestion = NSLocalizedString("New Preset", tableName: "Main", value: "", comment: "")
+            guard let name = promptForPresetName(question: NSLocalizedString("Name the new preset", tableName: "Main", value: "", comment: ""),
+                                                 defaultValue: suggestion)
+            else { return }
+            let preset = manager.createFromDefaults(named: name)
+            manager.activate(preset.id)
+
+        case .duplicate:
+            guard let active = manager.activePreset,
+                  let name = promptForPresetName(question: NSLocalizedString("Name the duplicated preset", tableName: "Main", value: "", comment: ""),
+                                                 defaultValue: active.name)
+            else { return }
+            if let copy = manager.duplicateActivePreset(named: name) {
+                manager.activate(copy.id)
+            }
+
+        case .rename:
+            guard let active = manager.activePreset,
+                  let name = promptForPresetName(question: NSLocalizedString("Rename this preset", tableName: "Main", value: "", comment: ""),
+                                                 defaultValue: active.name)
+            else { return }
+            manager.rename(active.id, to: name)
+
+        case .delete:
+            guard let active = manager.activePreset, manager.presets.count > 1 else { return }
+            let response = AlertUtil.twoButtonAlert(
+                question: NSLocalizedString("Delete this preset?", tableName: "Main", value: "", comment: ""),
+                text: active.name,
+                confirmText: NSLocalizedString("Delete", tableName: "Main", value: "", comment: ""),
+                cancelText: NSLocalizedString("Cancel", tableName: "Main", value: "", comment: ""))
+            guard response == .alertFirstButtonReturn else { return }
+            manager.delete(active.id)
+        }
+    }
+
+    private func promptForPresetName(question: String, defaultValue: String) -> String? {
+        let entered = AlertUtil.textInputAlert(
+            question: question,
+            text: "",
+            defaultValue: defaultValue,
+            confirmText: NSLocalizedString("OK", tableName: "Main", value: "", comment: ""),
+            cancelText: NSLocalizedString("Cancel", tableName: "Main", value: "", comment: ""))
+
+        guard let entered = entered else { return nil }
+        return PresetNaming.sanitized(entered)
     }
     
     override func awakeFromNib() {
@@ -1082,6 +1217,7 @@ class SettingsViewController: NSViewController {
             self.initializeTodoModeSettings()
             self.initializeToggles()
             self.initializeCycleSizesView(animated: false)
+            self.reloadPresetMenu()
         })
         
         Notification.Name.menuBarIconHidden.onPost(using: {_ in

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -300,6 +300,15 @@ class SettingsViewController: NSViewController {
         Notification.Name.windowSnapping.post(object: true)
     }
 
+    private var presetPopUpButton: NSPopUpButton?
+
+    private enum PresetMenuAction: Int {
+        case newFromDefaults = 1
+        case duplicate = 2
+        case rename = 3
+        case delete = 4
+    }
+
     @IBAction func showExtraSettings(_ sender: NSButton) {
         if extraSettingsPopover == nil {
             let popover = NSPopover()
@@ -978,9 +987,28 @@ class SettingsViewController: NSViewController {
             mainStackView.addArrangedSubview(halvesCheckbox)
             halvesPreserveOtherAxisSizeCheckbox = halvesCheckbox
 
+            let presetsHeaderLabel = NSTextField(labelWithString: NSLocalizedString("Presets", tableName: "Main", value: "", comment: ""))
+            presetsHeaderLabel.font = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize)
+            presetsHeaderLabel.alignment = .center
+            presetsHeaderLabel.translatesAutoresizingMaskIntoConstraints = false
+
+            let presetPopUpButton = NSPopUpButton(frame: .zero, pullsDown: false)
+            presetPopUpButton.translatesAutoresizingMaskIntoConstraints = false
+            presetPopUpButton.target = self
+            presetPopUpButton.action = #selector(presetSelectionChanged(_:))
+            self.presetPopUpButton = presetPopUpButton
+            reloadPresetMenu()
+
+            mainStackView.setCustomSpacing(12, after: halvesCheckbox)
+            mainStackView.addArrangedSubview(presetsHeaderLabel)
+            mainStackView.setCustomSpacing(10, after: presetsHeaderLabel)
+            mainStackView.addArrangedSubview(presetPopUpButton)
+
             NSLayoutConstraint.activate([
                 headerLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
                 splitRatioHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
+                presetsHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
+                presetPopUpButton.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
                 largerWidthLabel.widthAnchor.constraint(equalTo: smallerWidthLabel.widthAnchor),
                 smallerWidthLabel.widthAnchor.constraint(equalTo: widthStepLabel.widthAnchor),
                 widthStepLabel.widthAnchor.constraint(equalTo: topVerticalThirdLabel.widthAnchor),
@@ -1072,7 +1100,114 @@ class SettingsViewController: NSViewController {
             popover.contentViewController = viewController
             extraSettingsPopover = popover
         }
+        reloadPresetMenu()
         extraSettingsPopover?.show(relativeTo: sender.bounds, of: sender, preferredEdge: .maxY)
+    }
+
+    private func reloadPresetMenu() {
+        guard let popUpButton = presetPopUpButton,
+              let manager = AppDelegate.instance.presetManager
+        else { return }
+
+        let menu = NSMenu()
+        let activeId = manager.activePreset?.id
+
+        for preset in manager.presets {
+            let item = NSMenuItem(title: preset.name, action: nil, keyEquivalent: "")
+            item.representedObject = preset.id
+            menu.addItem(item)
+        }
+
+        menu.addItem(.separator())
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("New Preset from Defaults…", tableName: "Main", value: "", comment: ""),
+                            action: .newFromDefaults)
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("Duplicate Preset…", tableName: "Main", value: "", comment: ""),
+                            action: .duplicate)
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("Rename Preset…", tableName: "Main", value: "", comment: ""),
+                            action: .rename)
+        addPresetActionItem(to: menu,
+                            title: NSLocalizedString("Delete Preset", tableName: "Main", value: "", comment: ""),
+                            action: .delete)
+
+        popUpButton.menu = menu
+
+        if let activeId = activeId,
+           let index = manager.presets.firstIndex(where: { $0.id == activeId }) {
+            popUpButton.selectItem(at: index)
+        }
+    }
+
+    private func addPresetActionItem(to menu: NSMenu, title: String, action: PresetMenuAction) {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.tag = action.rawValue
+        menu.addItem(item)
+    }
+
+    @objc private func presetSelectionChanged(_ sender: NSPopUpButton) {
+        guard let manager = AppDelegate.instance.presetManager,
+              let item = sender.selectedItem
+        else { return }
+
+        if let id = item.representedObject as? UUID {
+            manager.activate(id)
+        } else if let action = PresetMenuAction(rawValue: item.tag) {
+            performPresetAction(action, with: manager)
+        }
+
+        reloadPresetMenu()
+    }
+
+    private func performPresetAction(_ action: PresetMenuAction, with manager: PresetManager) {
+        switch action {
+        case .newFromDefaults:
+            let suggestion = NSLocalizedString("New Preset", tableName: "Main", value: "", comment: "")
+            guard let name = promptForPresetName(question: NSLocalizedString("Name the new preset", tableName: "Main", value: "", comment: ""),
+                                                 defaultValue: suggestion)
+            else { return }
+            let preset = manager.createFromDefaults(named: name)
+            manager.activate(preset.id)
+
+        case .duplicate:
+            guard let active = manager.activePreset,
+                  let name = promptForPresetName(question: NSLocalizedString("Name the duplicated preset", tableName: "Main", value: "", comment: ""),
+                                                 defaultValue: active.name)
+            else { return }
+            if let copy = manager.duplicateActivePreset(named: name) {
+                manager.activate(copy.id)
+            }
+
+        case .rename:
+            guard let active = manager.activePreset,
+                  let name = promptForPresetName(question: NSLocalizedString("Rename this preset", tableName: "Main", value: "", comment: ""),
+                                                 defaultValue: active.name)
+            else { return }
+            manager.rename(active.id, to: name)
+
+        case .delete:
+            guard let active = manager.activePreset, manager.presets.count > 1 else { return }
+            let response = AlertUtil.twoButtonAlert(
+                question: NSLocalizedString("Delete this preset?", tableName: "Main", value: "", comment: ""),
+                text: active.name,
+                confirmText: NSLocalizedString("Delete", tableName: "Main", value: "", comment: ""),
+                cancelText: NSLocalizedString("Cancel", tableName: "Main", value: "", comment: ""))
+            guard response == .alertFirstButtonReturn else { return }
+            manager.delete(active.id)
+        }
+    }
+
+    private func promptForPresetName(question: String, defaultValue: String) -> String? {
+        let entered = AlertUtil.textInputAlert(
+            question: question,
+            text: "",
+            defaultValue: defaultValue,
+            confirmText: NSLocalizedString("OK", tableName: "Main", value: "", comment: ""),
+            cancelText: NSLocalizedString("Cancel", tableName: "Main", value: "", comment: ""))
+
+        guard let entered = entered else { return nil }
+        return PresetNaming.sanitized(entered)
     }
     
     override func awakeFromNib() {
@@ -1128,6 +1263,7 @@ class SettingsViewController: NSViewController {
             self.initializeTodoModeSettings()
             self.initializeToggles()
             self.initializeCycleSizesView(animated: false)
+            self.reloadPresetMenu()
         })
         
         Notification.Name.menuBarIconHidden.onPost(using: {_ in

--- a/Rectangle/Presets/Preset.swift
+++ b/Rectangle/Presets/Preset.swift
@@ -1,0 +1,163 @@
+/// Preset.swift
+
+import Foundation
+
+struct Preset: Codable {
+    var id: UUID
+    var name: String
+    var version: String
+
+    /// Shortcuts the preset assigns explicitly.
+    var shortcuts: [String: Shortcut]
+
+    /// Shortcuts the preset deliberately leaves unbound. MASShortcut stores these
+    /// as an empty dictionary so they outrank the built-in default.
+    var clearedShortcuts: [String]
+
+    var defaults: [String: CodableDefault]
+}
+
+struct PresetStore: Codable {
+    var presets: [Preset]
+    var activePresetId: UUID?
+}
+
+/// What to write to a shortcut's UserDefaults key when a preset is applied.
+enum ShortcutWrite: Equatable {
+    /// Write this dictionary. An empty dictionary means "explicitly no shortcut".
+    case set([String: Int])
+
+    /// Remove the key so the shortcut registered by ShortcutManager applies again.
+    case remove
+}
+
+enum PresetScope {
+
+    /// Keys that describe the app itself rather than window behavior. They stay
+    /// global: switching presets must not change how the app launches, updates or
+    /// which apps are excluded, and must not overwrite the preset store itself.
+    static let excludedDefaultKeys: Set<String> = [
+        "presets",
+        "launchOnLogin",
+        "hideMenubarIcon",
+        "relaunchOpensMenu",
+        "SUEnableAutomaticChecks",
+        "notifiedOfProblemApps",
+        "showAllActionsInMenu",
+        "showAdditionalSizesInMenu",
+        "disabledApps",
+        "fullIgnoreBundleIds",
+        "doubleClickTitleBarIgnoredApps",
+        "systemWideMouseDownApps",
+        "todoMode",
+        "todoApplication"
+    ]
+
+    static var defaults: [Default] {
+        Defaults.array.filter { !excludedDefaultKeys.contains($0.key) }
+    }
+
+    static var shortcutKeys: [String] {
+        WindowAction.active.map { $0.name } + TodoManager.defaultsKeys
+    }
+}
+
+enum PresetSnapshot {
+
+    /// Splits shortcut keys of a persistent defaults domain into the ones the user
+    /// assigned and the ones the user cleared. Keys absent from the domain are in
+    /// neither list: they fall through to the registration domain.
+    ///
+    /// The domain must come from `persistentDomain(forName:)`, not from
+    /// `dictionary(forKey:)` — the latter resolves registered defaults and cannot
+    /// tell an untouched shortcut from an assigned one.
+    static func shortcutStates(in domain: [String: Any], keys: [String]) -> (assigned: [String: Shortcut], cleared: [String]) {
+        var assigned = [String: Shortcut]()
+        var cleared = [String]()
+
+        for key in keys {
+            guard let stored = domain[key] as? [String: Any] else { continue }
+
+            if let keyCode = (stored["keyCode"] as? NSNumber)?.intValue,
+               let modifierFlags = (stored["modifierFlags"] as? NSNumber)?.uintValue {
+                assigned[key] = Shortcut(modifierFlags, keyCode)
+            } else {
+                cleared.append(key)
+            }
+        }
+
+        return (assigned, cleared.sorted())
+    }
+
+    static func shortcutWrites(for preset: Preset, keys: [String]) -> [String: ShortcutWrite] {
+        let cleared = Set(preset.clearedShortcuts)
+
+        return keys.reduce(into: [String: ShortcutWrite]()) { writes, key in
+            if let shortcut = preset.shortcuts[key] {
+                writes[key] = .set(["keyCode": shortcut.keyCode,
+                                    "modifierFlags": Int(shortcut.modifierFlags)])
+            } else if cleared.contains(key) {
+                writes[key] = .set([:])
+            } else {
+                writes[key] = .remove
+            }
+        }
+    }
+
+    static func defaultsSnapshot(from defaults: [Default]) -> [String: CodableDefault] {
+        defaults.reduce(into: [String: CodableDefault]()) { snapshot, item in
+            snapshot[item.key] = item.toCodable()
+        }
+    }
+
+    static func builtInDefaultsSnapshot(from defaults: [Default]) -> [String: CodableDefault] {
+        defaults.reduce(into: [String: CodableDefault]()) { snapshot, item in
+            snapshot[item.key] = item.defaultCodable()
+        }
+    }
+}
+
+enum PresetMutation {
+
+    /// Removes a preset from a store. Returns nil when the removal must be refused:
+    /// the id is unknown, or it is the last remaining preset.
+    ///
+    /// `activates` is the preset that has to be applied to the live settings because
+    /// it took over as the active one. It is nil when the active preset survives.
+    static func removing(id: UUID, from store: PresetStore) -> (store: PresetStore, activates: Preset?)? {
+        guard store.presets.count > 1,
+              let index = store.presets.firstIndex(where: { $0.id == id })
+        else { return nil }
+
+        let activeIndex = store.presets.firstIndex { $0.id == store.activePresetId } ?? 0
+
+        var presets = store.presets
+        presets.remove(at: index)
+
+        guard index == activeIndex else {
+            return (PresetStore(presets: presets, activePresetId: store.activePresetId), nil)
+        }
+
+        let replacement = presets[0]
+        return (PresetStore(presets: presets, activePresetId: replacement.id), replacement)
+    }
+}
+
+enum PresetNaming {
+
+    static func sanitized(_ name: String) -> String? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Appends " 2", " 3", … until the name no longer collides.
+    static func unique(_ name: String, existing: [String]) -> String {
+        guard existing.contains(name) else { return name }
+
+        var suffix = 2
+        while existing.contains("\(name) \(suffix)") {
+            suffix += 1
+        }
+        return "\(name) \(suffix)"
+    }
+}

--- a/Rectangle/Presets/Preset.swift
+++ b/Rectangle/Presets/Preset.swift
@@ -35,9 +35,11 @@ enum PresetScope {
 
     /// Keys that describe the app itself rather than window behavior. They stay
     /// global: switching presets must not change how the app launches, updates or
-    /// which apps are excluded, and must not overwrite the preset store itself.
+    /// which apps are excluded.
+    ///
+    /// The preset store itself needs no entry here — it is not in `Defaults.array`,
+    /// so it can never reach a snapshot.
     static let excludedDefaultKeys: Set<String> = [
-        "presets",
         "launchOnLogin",
         "hideMenubarIcon",
         "relaunchOpensMenu",

--- a/Rectangle/Presets/PresetManager.swift
+++ b/Rectangle/Presets/PresetManager.swift
@@ -1,0 +1,162 @@
+/// PresetManager.swift
+
+import Cocoa
+
+/// Owns the list of presets and applies them.
+///
+/// The active preset mirrors the live settings: everything the user changes in
+/// the settings window is written straight to UserDefaults, and the stored copy
+/// of the active preset is refreshed whenever something is about to read it.
+/// That removes the need for a save button, a dirty flag, or change observers.
+class PresetManager {
+
+    private let userDefaults: UserDefaults
+    private let domainName: String
+
+    init(userDefaults: UserDefaults = .standard,
+         domainName: String = Bundle.main.bundleIdentifier ?? "com.knollsoft.Rectangle") {
+        self.userDefaults = userDefaults
+        self.domainName = domainName
+        seedIfEmpty()
+    }
+
+    var presets: [Preset] { store.presets }
+
+    var activePreset: Preset? {
+        let current = store
+        guard let index = activeIndex(in: current) else { return nil }
+        return current.presets[index]
+    }
+
+    /// Writes the live configuration into the active preset.
+    func syncActivePreset() {
+        var current = store
+        guard let index = activeIndex(in: current) else { return }
+
+        let existing = current.presets[index]
+        current.presets[index] = capture(named: existing.name, id: existing.id)
+        store = current
+    }
+
+    func activate(_ id: UUID) {
+        syncActivePreset()
+
+        guard let target = store.presets.first(where: { $0.id == id }) else { return }
+        apply(target)
+
+        var current = store
+        current.activePresetId = id
+        store = current
+    }
+
+    @discardableResult
+    func createFromDefaults(named name: String) -> Preset {
+        syncActivePreset()
+
+        var current = store
+        let preset = Preset(id: UUID(),
+                            name: PresetNaming.unique(name, existing: current.presets.map { $0.name }),
+                            version: bundleVersion,
+                            shortcuts: [:],
+                            clearedShortcuts: [],
+                            defaults: PresetSnapshot.builtInDefaultsSnapshot(from: PresetScope.defaults))
+        current.presets.append(preset)
+        store = current
+        return preset
+    }
+
+    @discardableResult
+    func duplicateActivePreset(named name: String) -> Preset? {
+        syncActivePreset()
+
+        var current = store
+        guard let index = activeIndex(in: current) else { return nil }
+
+        var copy = current.presets[index]
+        copy.id = UUID()
+        copy.name = PresetNaming.unique(name, existing: current.presets.map { $0.name })
+        current.presets.append(copy)
+        store = current
+        return copy
+    }
+
+    func rename(_ id: UUID, to name: String) {
+        guard let sanitized = PresetNaming.sanitized(name) else { return }
+
+        var current = store
+        guard let index = current.presets.firstIndex(where: { $0.id == id }) else { return }
+        current.presets[index].name = sanitized
+        store = current
+    }
+
+    /// Removes a preset. The last remaining preset cannot be removed. If the
+    /// active preset is removed, the first remaining one is applied.
+    ///
+    /// There is deliberately no syncActivePreset() here: the preset that mirrored
+    /// the live settings is the one being thrown away.
+    func delete(_ id: UUID) {
+        guard let result = PresetMutation.removing(id: id, from: store) else { return }
+
+        store = result.store
+
+        if let replacement = result.activates {
+            apply(replacement)
+        }
+    }
+
+    private var store: PresetStore {
+        get { Defaults.presets.typedValue ?? PresetStore(presets: [], activePresetId: nil) }
+        set { Defaults.presets.typedValue = newValue }
+    }
+
+    private var bundleVersion: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+    }
+
+    private func activeIndex(in store: PresetStore) -> Int? {
+        if let id = store.activePresetId,
+           let index = store.presets.firstIndex(where: { $0.id == id }) {
+            return index
+        }
+        return store.presets.isEmpty ? nil : 0
+    }
+
+    private func seedIfEmpty() {
+        guard store.presets.isEmpty else { return }
+
+        let name = NSLocalizedString("Default", tableName: "Main", value: "", comment: "")
+        let preset = capture(named: name)
+        store = PresetStore(presets: [preset], activePresetId: preset.id)
+    }
+
+    private func capture(named name: String, id: UUID = UUID()) -> Preset {
+        let domain = userDefaults.persistentDomain(forName: domainName) ?? [:]
+        let states = PresetSnapshot.shortcutStates(in: domain, keys: PresetScope.shortcutKeys)
+
+        return Preset(id: id,
+                      name: name,
+                      version: bundleVersion,
+                      shortcuts: states.assigned,
+                      clearedShortcuts: states.cleared,
+                      defaults: PresetSnapshot.defaultsSnapshot(from: PresetScope.defaults))
+    }
+
+    private func apply(_ preset: Preset) {
+        Notification.Name.windowSnapping.post(object: false)
+
+        // Settings first: alternateDefaultShortcuts decides which built-in shortcut
+        // set an unset key falls back to, and it has to be current before
+        // ShortcutManager re-registers its defaults.
+        Defaults.apply(defaults: preset.defaults)
+
+        for (key, write) in PresetSnapshot.shortcutWrites(for: preset, keys: PresetScope.shortcutKeys) {
+            switch write {
+            case .set(let dictionary): userDefaults.set(dictionary, forKey: key)
+            case .remove: userDefaults.removeObject(forKey: key)
+            }
+        }
+
+        Notification.Name.configImported.post()
+        Notification.Name.windowSnapping.post(object: true)
+    }
+}

--- a/Rectangle/SubsequentExecutionMode.swift
+++ b/Rectangle/SubsequentExecutionMode.swift
@@ -61,4 +61,8 @@ class SubsequentExecutionDefault: Default {
         return CodableDefault(int: value.rawValue)
     }
 
+    func defaultCodable() -> CodableDefault {
+        return CodableDefault(int: SubsequentExecutionMode.resize.rawValue)
+    }
+
 }

--- a/Rectangle/Utilities/AlertUtil.swift
+++ b/Rectangle/Utilities/AlertUtil.swift
@@ -33,4 +33,25 @@ class AlertUtil {
         alert.addButton(withTitle: buttonThreeText)
         return alert.runModal()
     }
+
+    static func textInputAlert(question: String,
+                               text: String,
+                               defaultValue: String,
+                               confirmText: String = "OK",
+                               cancelText: String = "Cancel") -> String? {
+        let alert = NSAlert()
+        alert.messageText = question
+        alert.informativeText = text
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: confirmText)
+        alert.addButton(withTitle: cancelText)
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        field.stringValue = defaultValue
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        return field.stringValue
+    }
 }

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -13671,6 +13671,9 @@
         }
       }
     },
+    "Default" : {
+
+    },
     "Default Shortcuts" : {
       "localizations" : {
         "ar" : {
@@ -14202,6 +14205,15 @@
           }
         }
       }
+    },
+    "Delete" : {
+
+    },
+    "Delete Preset" : {
+
+    },
+    "Delete this preset?" : {
+
     },
     "Disable in macOS" : {
       "extractionState" : "manual",
@@ -16170,6 +16182,9 @@
           }
         }
       }
+    },
+    "Duplicate Preset…" : {
+
     },
     "Eighths" : {
       "localizations" : {
@@ -31122,6 +31137,18 @@
         }
       }
     },
+    "Name the duplicated preset" : {
+
+    },
+    "Name the new preset" : {
+
+    },
+    "New Preset" : {
+
+    },
+    "New Preset from Defaults…" : {
+
+    },
     "Ninths" : {
       "localizations" : {
         "ko" : {
@@ -33154,6 +33181,9 @@
           }
         }
       }
+    },
+    "OK" : {
+
     },
     "Open System Settings" : {
       "localizations" : {
@@ -37492,6 +37522,12 @@
           }
         }
       }
+    },
+    "Rename Preset…" : {
+
+    },
+    "Rename this preset" : {
+
     },
     "Resize adjacent windows when cycling side or corner shortcuts" : {
 

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -34593,6 +34593,9 @@
     "Preserve maximize state when moving across displays" : {
 
     },
+    "Presets" : {
+
+    },
     "Press the shortcut repeatedly to cycle through all positions in the grid." : {
       "localizations" : {
         "ko" : {

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -13671,6 +13671,9 @@
         }
       }
     },
+    "Default" : {
+
+    },
     "Default Shortcuts" : {
       "localizations" : {
         "ar" : {
@@ -14202,6 +14205,15 @@
           }
         }
       }
+    },
+    "Delete" : {
+
+    },
+    "Delete Preset" : {
+
+    },
+    "Delete this preset?" : {
+
     },
     "Disable in macOS" : {
       "extractionState" : "manual",
@@ -16170,6 +16182,9 @@
           }
         }
       }
+    },
+    "Duplicate Preset…" : {
+
     },
     "Eighths" : {
       "localizations" : {
@@ -31128,6 +31143,18 @@
         }
       }
     },
+    "Name the duplicated preset" : {
+
+    },
+    "Name the new preset" : {
+
+    },
+    "New Preset" : {
+
+    },
+    "New Preset from Defaults…" : {
+
+    },
     "Ninths" : {
       "localizations" : {
         "ko" : {
@@ -33160,6 +33187,9 @@
           }
         }
       }
+    },
+    "OK" : {
+
     },
     "Open System Settings" : {
       "localizations" : {
@@ -37498,6 +37528,12 @@
           }
         }
       }
+    },
+    "Rename Preset…" : {
+
+    },
+    "Rename this preset" : {
+
     },
     "Resize adjacent windows when cycling side or corner shortcuts" : {
 

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -34599,6 +34599,9 @@
     "Preserve maximize state when moving across displays" : {
 
     },
+    "Presets" : {
+
+    },
     "Press the shortcut repeatedly to cycle through all positions in the grid." : {
       "localizations" : {
         "ko" : {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -3903,3 +3903,151 @@ final class NextPrevDisplayMappingTests: XCTestCase {
         )
     }
 }
+
+class PresetTests: XCTestCase {
+
+    private func makePreset(shortcuts: [String: Shortcut] = [:],
+                            cleared: [String] = [],
+                            defaults: [String: CodableDefault] = [:]) -> Preset {
+        Preset(id: UUID(),
+               name: "Test",
+               version: "1",
+               shortcuts: shortcuts,
+               clearedShortcuts: cleared,
+               defaults: defaults)
+    }
+
+    func testAbsentKeysAreNeitherAssignedNorCleared() {
+        let states = PresetSnapshot.shortcutStates(in: [:], keys: ["leftHalf", "rightHalf"])
+        XCTAssertTrue(states.assigned.isEmpty, "an absent key means the built-in default applies")
+        XCTAssertTrue(states.cleared.isEmpty)
+    }
+
+    func testEmptyDictionaryIsReadAsCleared() {
+        let domain: [String: Any] = ["leftHalf": [String: Any]()]
+        let states = PresetSnapshot.shortcutStates(in: domain, keys: ["leftHalf"])
+        XCTAssertTrue(states.assigned.isEmpty)
+        XCTAssertEqual(states.cleared, ["leftHalf"], "MASShortcut stores an empty dictionary for 'explicitly none'")
+    }
+
+    func testAssignedShortcutIsRead() {
+        let domain: [String: Any] = ["leftHalf": ["keyCode": 123, "modifierFlags": 1572864]]
+        let states = PresetSnapshot.shortcutStates(in: domain, keys: ["leftHalf"])
+        XCTAssertEqual(states.assigned["leftHalf"]?.keyCode, 123)
+        XCTAssertEqual(states.assigned["leftHalf"]?.modifierFlags, 1572864)
+        XCTAssertTrue(states.cleared.isEmpty)
+    }
+
+    func testKeysOutsideTheRequestedListAreIgnored() {
+        let domain: [String: Any] = ["gapSize": 4, "leftHalf": ["keyCode": 1, "modifierFlags": 2]]
+        let states = PresetSnapshot.shortcutStates(in: domain, keys: ["leftHalf"])
+        XCTAssertEqual(states.assigned.count, 1)
+    }
+
+    func testAllThreeShortcutStatesSurviveARoundTrip() {
+        let domain: [String: Any] = [
+            "leftHalf": ["keyCode": 123, "modifierFlags": 1572864],
+            "rightHalf": [String: Any]()
+        ]
+        let keys = ["leftHalf", "rightHalf", "maximize"]
+        let states = PresetSnapshot.shortcutStates(in: domain, keys: keys)
+        let preset = makePreset(shortcuts: states.assigned, cleared: states.cleared)
+
+        let writes = PresetSnapshot.shortcutWrites(for: preset, keys: keys)
+
+        XCTAssertEqual(writes["leftHalf"], .set(["keyCode": 123, "modifierFlags": 1572864]))
+        XCTAssertEqual(writes["rightHalf"], .set([:]), "a cleared shortcut must be written back as an empty dictionary")
+        XCTAssertEqual(writes["maximize"], .remove, "an unset shortcut must have its key removed so the default applies")
+    }
+
+    func testWritesCoverEveryRequestedKey() {
+        let keys = ["leftHalf", "rightHalf", "maximize"]
+        let writes = PresetSnapshot.shortcutWrites(for: makePreset(), keys: keys)
+        XCTAssertEqual(Set(writes.keys), Set(keys))
+    }
+
+    func testPresetEncodesAndDecodes() throws {
+        let preset = makePreset(shortcuts: ["leftHalf": Shortcut(1572864, 123)],
+                                cleared: ["rightHalf"],
+                                defaults: ["gapSize": CodableDefault(float: 4)])
+        let data = try JSONEncoder().encode(PresetStore(presets: [preset], activePresetId: preset.id))
+        let decoded = try JSONDecoder().decode(PresetStore.self, from: data)
+
+        XCTAssertEqual(decoded.presets.count, 1)
+        XCTAssertEqual(decoded.activePresetId, preset.id)
+        XCTAssertEqual(decoded.presets[0].shortcuts["leftHalf"]?.keyCode, 123)
+        XCTAssertEqual(decoded.presets[0].clearedShortcuts, ["rightHalf"])
+        XCTAssertEqual(decoded.presets[0].defaults["gapSize"]?.float, 4)
+    }
+
+    func testScopeExcludesAppLevelDefaults() {
+        let keys = PresetScope.defaults.map { $0.key }
+        XCTAssertFalse(keys.contains("launchOnLogin"))
+        XCTAssertFalse(keys.contains("hideMenubarIcon"))
+        XCTAssertFalse(keys.contains("disabledApps"))
+        XCTAssertTrue(keys.contains("gapSize"), "window behavior settings stay in scope")
+        XCTAssertTrue(keys.contains("alternateDefaultShortcuts"), "the default shortcut set is part of a preset")
+    }
+
+    func testShortcutKeysCoverEveryActionAndTodo() {
+        let keys = PresetScope.shortcutKeys
+        XCTAssertEqual(keys.count, WindowAction.active.count + TodoManager.defaultsKeys.count)
+        XCTAssertTrue(keys.contains("leftHalf"))
+        XCTAssertTrue(keys.contains("toggleTodo"))
+    }
+
+    func testBuiltInDefaultsSnapshotCoversEveryScopedKey() {
+        let snapshot = PresetSnapshot.builtInDefaultsSnapshot(from: PresetScope.defaults)
+        XCTAssertEqual(Set(snapshot.keys), Set(PresetScope.defaults.map { $0.key }))
+    }
+
+    func testUniqueNameAppendsACounter() {
+        XCTAssertEqual(PresetNaming.unique("TKL", existing: []), "TKL")
+        XCTAssertEqual(PresetNaming.unique("TKL", existing: ["TKL"]), "TKL 2")
+        XCTAssertEqual(PresetNaming.unique("TKL", existing: ["TKL", "TKL 2"]), "TKL 3")
+    }
+
+    func testSanitizedTrimsAndRejectsBlankNames() {
+        XCTAssertNil(PresetNaming.sanitized("   "))
+        XCTAssertNil(PresetNaming.sanitized(""))
+        XCTAssertEqual(PresetNaming.sanitized("  TKL  "), "TKL")
+    }
+
+    func testTheLastPresetCannotBeRemoved() {
+        let only = makePreset()
+        let store = PresetStore(presets: [only], activePresetId: only.id)
+        XCTAssertNil(PresetMutation.removing(id: only.id, from: store))
+    }
+
+    func testRemovingAnInactivePresetKeepsTheActiveOne() throws {
+        let active = makePreset()
+        let other = makePreset()
+        let store = PresetStore(presets: [active, other], activePresetId: active.id)
+
+        let result = try XCTUnwrap(PresetMutation.removing(id: other.id, from: store))
+
+        XCTAssertEqual(result.store.presets.map { $0.id }, [active.id])
+        XCTAssertEqual(result.store.activePresetId, active.id)
+        XCTAssertNil(result.activates, "nothing needs to be applied when the active preset survives")
+    }
+
+    func testRemovingTheActivePresetHandsOverToTheFirstRemaining() throws {
+        let active = makePreset()
+        let second = makePreset()
+        let third = makePreset()
+        let store = PresetStore(presets: [active, second, third], activePresetId: active.id)
+
+        let result = try XCTUnwrap(PresetMutation.removing(id: active.id, from: store))
+
+        XCTAssertEqual(result.store.presets.map { $0.id }, [second.id, third.id])
+        XCTAssertEqual(result.store.activePresetId, second.id)
+        XCTAssertEqual(result.activates?.id, second.id, "the new active preset must be applied to the live settings")
+    }
+
+    func testRemovingAnUnknownPresetIsRefused() {
+        let one = makePreset()
+        let two = makePreset()
+        let store = PresetStore(presets: [one, two], activePresetId: one.id)
+        XCTAssertNil(PresetMutation.removing(id: UUID(), from: store))
+    }
+}

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -218,6 +218,19 @@ class DefaultsExportTests: XCTestCase {
         XCTAssertTrue(keys.contains("cooperativeCornerResize"), "cooperativeCornerResize missing from Defaults.array")
         XCTAssertTrue(keys.contains("stackBadge"), "stackBadge missing from Defaults.array")
     }
+
+    func testPresetsInExportArray() {
+        let keys = Defaults.array.map { $0.key }
+        XCTAssertTrue(keys.contains("presets"), "presets missing from Defaults.array")
+    }
+
+    func testPresetScopeExcludesOnlyRealDefaultsKeys() {
+        let keys = Set(Defaults.array.map { $0.key })
+        for excluded in PresetScope.excludedDefaultKeys {
+            XCTAssertTrue(keys.contains(excluded),
+                          "\(excluded) is excluded from presets but is not a Defaults key — it was renamed or misspelled")
+        }
+    }
 }
 
 class ConfigImportTests: XCTestCase {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -134,6 +134,80 @@ class ScreenFlippedTests: XCTestCase {
     }
 }
 
+class DefaultCodableTests: XCTestCase {
+
+    private let scratchKeys = [
+        "testDefaultCodableBool",
+        "testDefaultCodableOptionalBool",
+        "testDefaultCodableString",
+        "testDefaultCodableFloat",
+        "testDefaultCodableInt",
+        "testDefaultCodableDouble",
+        "testDefaultCodableIntEnum",
+        "testDefaultCodableJSON"
+    ]
+
+    override func tearDown() {
+        scratchKeys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+        super.tearDown()
+    }
+
+    func testBoolDefaultReportsFalse() {
+        let sut = BoolDefault(key: "testDefaultCodableBool")
+        XCTAssertEqual(sut.defaultCodable().bool, false, "a BoolDefault is off unless the user turns it on")
+    }
+
+    func testOptionalBoolDefaultReportsNotSet() {
+        let sut = OptionalBoolDefault(key: "testDefaultCodableOptionalBool")
+        XCTAssertEqual(sut.defaultCodable().int, 0, "0 is the notSet encoding for OptionalBoolDefault")
+    }
+
+    func testStringDefaultReportsNil() {
+        let sut = StringDefault(key: "testDefaultCodableString")
+        XCTAssertNil(sut.defaultCodable().string)
+    }
+
+    func testFloatDefaultReportsDeclaredDefaultValue() {
+        let sut = FloatDefault(key: "testDefaultCodableFloat", defaultValue: 30)
+        XCTAssertEqual(sut.defaultCodable().float, 30)
+    }
+
+    func testIntDefaultReportsDeclaredDefaultValue() {
+        let sut = IntDefault(key: "testDefaultCodableInt", defaultValue: 250)
+        XCTAssertEqual(sut.defaultCodable().int, 250)
+    }
+
+    func testDoubleDefaultReportsDeclaredDefaultValue() {
+        let sut = DoubleDefault(key: "testDefaultCodableDouble", defaultValue: 0.25)
+        XCTAssertEqual(sut.defaultCodable().double, 0.25)
+    }
+
+    func testIntEnumDefaultReportsDeclaredDefaultValue() {
+        let sut = IntEnumDefault<EdgeAlignment>(key: "testDefaultCodableIntEnum", defaultValue: .edgesAndCorners)
+        XCTAssertEqual(sut.defaultCodable().int, EdgeAlignment.edgesAndCorners.rawValue)
+    }
+
+    func testJSONDefaultClearsTypedValueWhenLoadingNilString() {
+        let sut = JSONDefault<[String]>(key: "testDefaultCodableJSON")
+        sut.typedValue = ["a", "b"]
+        XCTAssertNotNil(sut.typedValue, "precondition: the typed value was stored")
+
+        sut.load(from: CodableDefault(string: nil))
+
+        XCTAssertNil(sut.typedValue, "a nil string must clear the decoded value, not leave the previous one")
+    }
+
+    func testRealDefaultsReportTheirDeclaredValues() {
+        XCTAssertEqual(Defaults.gapSize.defaultCodable().float, 0, "gapSize declares no default")
+        XCTAssertEqual(Defaults.widthStepSize.defaultCodable().float, 30)
+        XCTAssertEqual(Defaults.minimumWindowWidth.defaultCodable().double, 0.25)
+        XCTAssertEqual(Defaults.cyclingOverlapMaxCascade.defaultCodable().int, 1)
+        XCTAssertEqual(Defaults.moveFixedSizeToEdge.defaultCodable().int, EdgeAlignment.edgesAndCorners.rawValue)
+        XCTAssertEqual(Defaults.subsequentExecutionMode.defaultCodable().int, SubsequentExecutionMode.resize.rawValue)
+        XCTAssertEqual(Defaults.selectedCycleSizes.defaultCodable().int, 0)
+    }
+}
+
 class DefaultsExportTests: XCTestCase {
 
     func testOverlapDefaultsInExportArray() {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -219,9 +219,10 @@ class DefaultsExportTests: XCTestCase {
         XCTAssertTrue(keys.contains("stackBadge"), "stackBadge missing from Defaults.array")
     }
 
-    func testPresetsInExportArray() {
+    func testPresetsAreNotAnIndividualExportedSetting() {
         let keys = Defaults.array.map { $0.key }
-        XCTAssertTrue(keys.contains("presets"), "presets missing from Defaults.array")
+        XCTAssertFalse(keys.contains("presets"),
+                       "presets ride along in Config.presets, not as an escaped string among the settings")
     }
 
     func testPresetScopeExcludesOnlyRealDefaultsKeys() {
@@ -4062,5 +4063,35 @@ class PresetTests: XCTestCase {
         let two = makePreset()
         let store = PresetStore(presets: [one, two], activePresetId: one.id)
         XCTAssertNil(PresetMutation.removing(id: UUID(), from: store))
+    }
+
+    func testConfigCarriesPresetsThroughARoundTrip() throws {
+        let preset = makePreset(shortcuts: ["leftHalf": Shortcut(1572864, 123)],
+                                cleared: ["rightHalf"])
+        let config = Config(bundleId: "com.knollsoft.Rectangle",
+                            version: "104",
+                            shortcuts: ["leftHalf": Shortcut(1572864, 123)],
+                            defaults: ["gapSize": CodableDefault(float: 4)],
+                            presets: PresetStore(presets: [preset], activePresetId: preset.id))
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(Config.self, from: data)
+
+        XCTAssertEqual(decoded.presets?.presets.count, 1)
+        XCTAssertEqual(decoded.presets?.activePresetId, preset.id)
+        XCTAssertEqual(decoded.presets?.presets[0].clearedShortcuts, ["rightHalf"])
+    }
+
+    func testConfigExportedBeforePresetsExistedStillDecodes() throws {
+        let json = """
+        {"bundleId":"com.knollsoft.Rectangle","version":"100",\
+        "shortcuts":{"leftHalf":{"keyCode":123,"modifierFlags":1572864}},\
+        "defaults":{"gapSize":{"float":4}}}
+        """
+        let config = try XCTUnwrap(Defaults.convert(jsonString: json))
+
+        XCTAssertNil(config.presets, "a config without the field must decode, leaving presets untouched on import")
+        XCTAssertEqual(config.shortcuts["leftHalf"]?.keyCode, 123)
+        XCTAssertEqual(config.defaults["gapSize"]?.float, 4)
     }
 }

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -5039,3 +5039,150 @@ class HalvesPreserveOtherAxisSizeTests: XCTestCase {
     }
 }
 
+class PresetTests: XCTestCase {
+
+    private func makePreset(shortcuts: [String: Shortcut] = [:],
+                            cleared: [String] = [],
+                            defaults: [String: CodableDefault] = [:]) -> Preset {
+        Preset(id: UUID(),
+               name: "Test",
+               version: "1",
+               shortcuts: shortcuts,
+               clearedShortcuts: cleared,
+               defaults: defaults)
+    }
+
+    func testAbsentKeysAreNeitherAssignedNorCleared() {
+        let states = PresetSnapshot.shortcutStates(in: [:], keys: ["leftHalf", "rightHalf"])
+        XCTAssertTrue(states.assigned.isEmpty, "an absent key means the built-in default applies")
+        XCTAssertTrue(states.cleared.isEmpty)
+    }
+
+    func testEmptyDictionaryIsReadAsCleared() {
+        let domain: [String: Any] = ["leftHalf": [String: Any]()]
+        let states = PresetSnapshot.shortcutStates(in: domain, keys: ["leftHalf"])
+        XCTAssertTrue(states.assigned.isEmpty)
+        XCTAssertEqual(states.cleared, ["leftHalf"], "MASShortcut stores an empty dictionary for 'explicitly none'")
+    }
+
+    func testAssignedShortcutIsRead() {
+        let domain: [String: Any] = ["leftHalf": ["keyCode": 123, "modifierFlags": 1572864]]
+        let states = PresetSnapshot.shortcutStates(in: domain, keys: ["leftHalf"])
+        XCTAssertEqual(states.assigned["leftHalf"]?.keyCode, 123)
+        XCTAssertEqual(states.assigned["leftHalf"]?.modifierFlags, 1572864)
+        XCTAssertTrue(states.cleared.isEmpty)
+    }
+
+    func testKeysOutsideTheRequestedListAreIgnored() {
+        let domain: [String: Any] = ["gapSize": 4, "leftHalf": ["keyCode": 1, "modifierFlags": 2]]
+        let states = PresetSnapshot.shortcutStates(in: domain, keys: ["leftHalf"])
+        XCTAssertEqual(states.assigned.count, 1)
+    }
+
+    func testAllThreeShortcutStatesSurviveARoundTrip() {
+        let domain: [String: Any] = [
+            "leftHalf": ["keyCode": 123, "modifierFlags": 1572864],
+            "rightHalf": [String: Any]()
+        ]
+        let keys = ["leftHalf", "rightHalf", "maximize"]
+        let states = PresetSnapshot.shortcutStates(in: domain, keys: keys)
+        let preset = makePreset(shortcuts: states.assigned, cleared: states.cleared)
+
+        let writes = PresetSnapshot.shortcutWrites(for: preset, keys: keys)
+
+        XCTAssertEqual(writes["leftHalf"], .set(["keyCode": 123, "modifierFlags": 1572864]))
+        XCTAssertEqual(writes["rightHalf"], .set([:]), "a cleared shortcut must be written back as an empty dictionary")
+        XCTAssertEqual(writes["maximize"], .remove, "an unset shortcut must have its key removed so the default applies")
+    }
+
+    func testWritesCoverEveryRequestedKey() {
+        let keys = ["leftHalf", "rightHalf", "maximize"]
+        let writes = PresetSnapshot.shortcutWrites(for: makePreset(), keys: keys)
+        XCTAssertEqual(Set(writes.keys), Set(keys))
+    }
+
+    func testPresetEncodesAndDecodes() throws {
+        let preset = makePreset(shortcuts: ["leftHalf": Shortcut(1572864, 123)],
+                                cleared: ["rightHalf"],
+                                defaults: ["gapSize": CodableDefault(float: 4)])
+        let data = try JSONEncoder().encode(PresetStore(presets: [preset], activePresetId: preset.id))
+        let decoded = try JSONDecoder().decode(PresetStore.self, from: data)
+
+        XCTAssertEqual(decoded.presets.count, 1)
+        XCTAssertEqual(decoded.activePresetId, preset.id)
+        XCTAssertEqual(decoded.presets[0].shortcuts["leftHalf"]?.keyCode, 123)
+        XCTAssertEqual(decoded.presets[0].clearedShortcuts, ["rightHalf"])
+        XCTAssertEqual(decoded.presets[0].defaults["gapSize"]?.float, 4)
+    }
+
+    func testScopeExcludesAppLevelDefaults() {
+        let keys = PresetScope.defaults.map { $0.key }
+        XCTAssertFalse(keys.contains("launchOnLogin"))
+        XCTAssertFalse(keys.contains("hideMenubarIcon"))
+        XCTAssertFalse(keys.contains("disabledApps"))
+        XCTAssertTrue(keys.contains("gapSize"), "window behavior settings stay in scope")
+        XCTAssertTrue(keys.contains("alternateDefaultShortcuts"), "the default shortcut set is part of a preset")
+    }
+
+    func testShortcutKeysCoverEveryActionAndTodo() {
+        let keys = PresetScope.shortcutKeys
+        XCTAssertEqual(keys.count, WindowAction.active.count + TodoManager.defaultsKeys.count)
+        XCTAssertTrue(keys.contains("leftHalf"))
+        XCTAssertTrue(keys.contains("toggleTodo"))
+    }
+
+    func testBuiltInDefaultsSnapshotCoversEveryScopedKey() {
+        let snapshot = PresetSnapshot.builtInDefaultsSnapshot(from: PresetScope.defaults)
+        XCTAssertEqual(Set(snapshot.keys), Set(PresetScope.defaults.map { $0.key }))
+    }
+
+    func testUniqueNameAppendsACounter() {
+        XCTAssertEqual(PresetNaming.unique("TKL", existing: []), "TKL")
+        XCTAssertEqual(PresetNaming.unique("TKL", existing: ["TKL"]), "TKL 2")
+        XCTAssertEqual(PresetNaming.unique("TKL", existing: ["TKL", "TKL 2"]), "TKL 3")
+    }
+
+    func testSanitizedTrimsAndRejectsBlankNames() {
+        XCTAssertNil(PresetNaming.sanitized("   "))
+        XCTAssertNil(PresetNaming.sanitized(""))
+        XCTAssertEqual(PresetNaming.sanitized("  TKL  "), "TKL")
+    }
+
+    func testTheLastPresetCannotBeRemoved() {
+        let only = makePreset()
+        let store = PresetStore(presets: [only], activePresetId: only.id)
+        XCTAssertNil(PresetMutation.removing(id: only.id, from: store))
+    }
+
+    func testRemovingAnInactivePresetKeepsTheActiveOne() throws {
+        let active = makePreset()
+        let other = makePreset()
+        let store = PresetStore(presets: [active, other], activePresetId: active.id)
+
+        let result = try XCTUnwrap(PresetMutation.removing(id: other.id, from: store))
+
+        XCTAssertEqual(result.store.presets.map { $0.id }, [active.id])
+        XCTAssertEqual(result.store.activePresetId, active.id)
+        XCTAssertNil(result.activates, "nothing needs to be applied when the active preset survives")
+    }
+
+    func testRemovingTheActivePresetHandsOverToTheFirstRemaining() throws {
+        let active = makePreset()
+        let second = makePreset()
+        let third = makePreset()
+        let store = PresetStore(presets: [active, second, third], activePresetId: active.id)
+
+        let result = try XCTUnwrap(PresetMutation.removing(id: active.id, from: store))
+
+        XCTAssertEqual(result.store.presets.map { $0.id }, [second.id, third.id])
+        XCTAssertEqual(result.store.activePresetId, second.id)
+        XCTAssertEqual(result.activates?.id, second.id, "the new active preset must be applied to the live settings")
+    }
+
+    func testRemovingAnUnknownPresetIsRefused() {
+        let one = makePreset()
+        let two = makePreset()
+        let store = PresetStore(presets: [one, two], activePresetId: one.id)
+        XCTAssertNil(PresetMutation.removing(id: UUID(), from: store))
+    }
+}

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -351,6 +351,80 @@ final class DockVisibleFrameTests: XCTestCase {
     }
 }
 
+class DefaultCodableTests: XCTestCase {
+
+    private let scratchKeys = [
+        "testDefaultCodableBool",
+        "testDefaultCodableOptionalBool",
+        "testDefaultCodableString",
+        "testDefaultCodableFloat",
+        "testDefaultCodableInt",
+        "testDefaultCodableDouble",
+        "testDefaultCodableIntEnum",
+        "testDefaultCodableJSON"
+    ]
+
+    override func tearDown() {
+        scratchKeys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+        super.tearDown()
+    }
+
+    func testBoolDefaultReportsFalse() {
+        let sut = BoolDefault(key: "testDefaultCodableBool")
+        XCTAssertEqual(sut.defaultCodable().bool, false, "a BoolDefault is off unless the user turns it on")
+    }
+
+    func testOptionalBoolDefaultReportsNotSet() {
+        let sut = OptionalBoolDefault(key: "testDefaultCodableOptionalBool")
+        XCTAssertEqual(sut.defaultCodable().int, 0, "0 is the notSet encoding for OptionalBoolDefault")
+    }
+
+    func testStringDefaultReportsNil() {
+        let sut = StringDefault(key: "testDefaultCodableString")
+        XCTAssertNil(sut.defaultCodable().string)
+    }
+
+    func testFloatDefaultReportsDeclaredDefaultValue() {
+        let sut = FloatDefault(key: "testDefaultCodableFloat", defaultValue: 30)
+        XCTAssertEqual(sut.defaultCodable().float, 30)
+    }
+
+    func testIntDefaultReportsDeclaredDefaultValue() {
+        let sut = IntDefault(key: "testDefaultCodableInt", defaultValue: 250)
+        XCTAssertEqual(sut.defaultCodable().int, 250)
+    }
+
+    func testDoubleDefaultReportsDeclaredDefaultValue() {
+        let sut = DoubleDefault(key: "testDefaultCodableDouble", defaultValue: 0.25)
+        XCTAssertEqual(sut.defaultCodable().double, 0.25)
+    }
+
+    func testIntEnumDefaultReportsDeclaredDefaultValue() {
+        let sut = IntEnumDefault<EdgeAlignment>(key: "testDefaultCodableIntEnum", defaultValue: .edgesAndCorners)
+        XCTAssertEqual(sut.defaultCodable().int, EdgeAlignment.edgesAndCorners.rawValue)
+    }
+
+    func testJSONDefaultClearsTypedValueWhenLoadingNilString() {
+        let sut = JSONDefault<[String]>(key: "testDefaultCodableJSON")
+        sut.typedValue = ["a", "b"]
+        XCTAssertNotNil(sut.typedValue, "precondition: the typed value was stored")
+
+        sut.load(from: CodableDefault(string: nil))
+
+        XCTAssertNil(sut.typedValue, "a nil string must clear the decoded value, not leave the previous one")
+    }
+
+    func testRealDefaultsReportTheirDeclaredValues() {
+        XCTAssertEqual(Defaults.gapSize.defaultCodable().float, 0, "gapSize declares no default")
+        XCTAssertEqual(Defaults.widthStepSize.defaultCodable().float, 30)
+        XCTAssertEqual(Defaults.minimumWindowWidth.defaultCodable().double, 0.25)
+        XCTAssertEqual(Defaults.cyclingOverlapMaxCascade.defaultCodable().int, 1)
+        XCTAssertEqual(Defaults.moveFixedSizeToEdge.defaultCodable().int, EdgeAlignment.edgesAndCorners.rawValue)
+        XCTAssertEqual(Defaults.subsequentExecutionMode.defaultCodable().int, SubsequentExecutionMode.resize.rawValue)
+        XCTAssertEqual(Defaults.selectedCycleSizes.defaultCodable().int, 0)
+    }
+}
+
 class DefaultsExportTests: XCTestCase {
 
     func testOverlapDefaultsInExportArray() {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -436,9 +436,10 @@ class DefaultsExportTests: XCTestCase {
         XCTAssertTrue(keys.contains("stackBadge"), "stackBadge missing from Defaults.array")
     }
 
-    func testPresetsInExportArray() {
+    func testPresetsAreNotAnIndividualExportedSetting() {
         let keys = Defaults.array.map { $0.key }
-        XCTAssertTrue(keys.contains("presets"), "presets missing from Defaults.array")
+        XCTAssertFalse(keys.contains("presets"),
+                       "presets ride along in Config.presets, not as an escaped string among the settings")
     }
 
     func testPresetScopeExcludesOnlyRealDefaultsKeys() {
@@ -5197,5 +5198,35 @@ class PresetTests: XCTestCase {
         let two = makePreset()
         let store = PresetStore(presets: [one, two], activePresetId: one.id)
         XCTAssertNil(PresetMutation.removing(id: UUID(), from: store))
+    }
+
+    func testConfigCarriesPresetsThroughARoundTrip() throws {
+        let preset = makePreset(shortcuts: ["leftHalf": Shortcut(1572864, 123)],
+                                cleared: ["rightHalf"])
+        let config = Config(bundleId: "com.knollsoft.Rectangle",
+                            version: "104",
+                            shortcuts: ["leftHalf": Shortcut(1572864, 123)],
+                            defaults: ["gapSize": CodableDefault(float: 4)],
+                            presets: PresetStore(presets: [preset], activePresetId: preset.id))
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(Config.self, from: data)
+
+        XCTAssertEqual(decoded.presets?.presets.count, 1)
+        XCTAssertEqual(decoded.presets?.activePresetId, preset.id)
+        XCTAssertEqual(decoded.presets?.presets[0].clearedShortcuts, ["rightHalf"])
+    }
+
+    func testConfigExportedBeforePresetsExistedStillDecodes() throws {
+        let json = """
+        {"bundleId":"com.knollsoft.Rectangle","version":"100",\
+        "shortcuts":{"leftHalf":{"keyCode":123,"modifierFlags":1572864}},\
+        "defaults":{"gapSize":{"float":4}}}
+        """
+        let config = try XCTUnwrap(Defaults.convert(jsonString: json))
+
+        XCTAssertNil(config.presets, "a config without the field must decode, leaving presets untouched on import")
+        XCTAssertEqual(config.shortcuts["leftHalf"]?.keyCode, 123)
+        XCTAssertEqual(config.defaults["gapSize"]?.float, 4)
     }
 }

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -435,6 +435,19 @@ class DefaultsExportTests: XCTestCase {
         XCTAssertTrue(keys.contains("cooperativeCornerResize"), "cooperativeCornerResize missing from Defaults.array")
         XCTAssertTrue(keys.contains("stackBadge"), "stackBadge missing from Defaults.array")
     }
+
+    func testPresetsInExportArray() {
+        let keys = Defaults.array.map { $0.key }
+        XCTAssertTrue(keys.contains("presets"), "presets missing from Defaults.array")
+    }
+
+    func testPresetScopeExcludesOnlyRealDefaultsKeys() {
+        let keys = Set(Defaults.array.map { $0.key })
+        for excluded in PresetScope.excludedDefaultKeys {
+            XCTAssertTrue(keys.contains(excluded),
+                          "\(excluded) is excluded from presets but is not a Defaults key — it was renamed or misspelled")
+        }
+    }
 }
 
 class ConfigImportTests: XCTestCase {


### PR DESCRIPTION
Proposed and discussed first in #1818 — posting the PR now since you said you'd be inclined to move forward.

I switch between a full-size keyboard, a tenkeyless one, and the MacBook's built-in keyboard. Most of my shortcuts sit on the numeric keypad, so on the other two they're unreachable. Import/Export can move a configuration around, but it's two file dialogs each time, there's no notion of a named set, and a config file can't express "this action is deliberately unbound" — `Defaults.encoded()` skips the empty-dictionary state, so with #1805 making import authoritative the key is removed and the built-in default comes back instead.

## What this adds

A preset is a named snapshot of the shortcuts plus the settings that describe window behavior. Settings about the app itself — launch at login, update checks, menu bar icon, per-app exclusions, transient Todo state — stay global. The exclusion list is explicit and tested against `Defaults.array` so a future rename can't silently pull a key in.

Shortcuts are stored in all three states MASShortcut distinguishes (absent / explicitly unbound / assigned), so switching restores unbound bindings as unbound. Snapshots read `persistentDomain(forName:)` rather than `dictionary(forKey:)` to tell an untouched shortcut from an assigned one.

The active preset mirrors the live settings, so there's no save button or dirty state. Applying one writes settings first (so `alternateDefaultShortcuts` is current before `registerDefaults()` re-runs), then shortcuts, then posts `configImported` and lets the existing observers reconcile. Presets can be created from the built-in defaults or by duplicating the current one, and renamed or deleted.

## UI

Per your feedback, the picker is in the Extras popover under a "Presets" header rather than the Shortcuts tab. No storyboard changes. `PrefsViewController` keeps only a `configImported` observer so the shortcut recorders reflect a newly applied preset.

That observer is registered in `viewDidLoad` rather than `awakeFromNib`, because `awakeFromNib` runs twice for that scene — everything already in it happens to be idempotent, so it hadn't surfaced before.

<img width="448" height="221" alt="image" src="https://github.com/user-attachments/assets/e50824c6-62f1-42ce-8040-98b094dccdb9" />

## Export format

Presets ride along in Import/Export through a new optional `Config.presets` field rather than another entry in `defaults`, which would have put the whole library into the file as one escaped JSON string. Both directions stay compatible and there are tests for it: builds without the field ignore it when decoding, and the field is optional so older configs still load. `Config` keeps a memberwise initializer with `presets` defaulting to nil, so existing call sites are unchanged.

This is the one place the feature steps outside the "every new key goes in `Defaults.array`" convention. The convention's purpose — never silently dropping a key from export — is still met by the dedicated field.

## Along the way

- `Defaults.load(fileUrl:)`'s settings loop is extracted to `Defaults.apply(defaults:)` so import and preset switching share a path. Pure extraction, no behavior change.
- `JSONDefault.load(from:)` now clears its decoded value when a config sets the underlying string to nil; previously footprint colors and snap areas couldn't be reset through import. Different path from the `init(key:defaultValue:)` fix in #1811.

I've kept an eye on #1782 since you mentioned it — the `Defaults.apply(defaults:)` seam is small and isolated, so it shouldn't get in the way of reworking configuration management later.

## Testing

29 new tests, all passing. For reference, `f6279e2` runs 223 tests with 22 failing assertions across `ActiveSideSplitRatiosCooperativeTests`, `CooperativeCornerResizeTests` and `HalfSplitCornerCalculationTests`; this branch runs 252 with the same 22. I checked an unmodified checkout to confirm they aren't from this work — happy to open a separate issue for them if useful.

Happy to adjust anything, including hiding the picker behind a preference if you'd rather it not be visible by default.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
