### PR TITLE
Prevent Chromium Enhanced UI performance regression

### DIFF
--- a/Rectangle/AccessibilityElement.swift
+++ b/Rectangle/AccessibilityElement.swift
@@ -133,26 +133,26 @@ class AccessibilityElement {
     /// When windows take a long time to adjust size & position, there is some visual stutter with doing each of these actions. The stutter can be slightly reduced by removing the initial size adjustment, which can make unsnap restore appear smoother.
     func setFrame(_ frame: CGRect, adjustSizeFirst: Bool = true) {
         let appElement = applicationElement
-        var enhancedUI: Bool? = nil
-
-        if let appElement = appElement {
-            enhancedUI = appElement.enhancedUserInterface
-            if enhancedUI == true {
-                Logger.log("AXEnhancedUserInterface was enabled, will disable before resizing")
-                appElement.enhancedUserInterface = false
+        let builtInAssistiveTechnologyEnabled = NSWorkspace.shared.isVoiceOverEnabled
+            || NSWorkspace.shared.isSwitchControlEnabled
+        Defaults.enhancedUI.value.performWindowAdjustment(
+            bundleIdentifier: appElement?.bundleIdentifier,
+            builtInAssistiveTechnologyEnabled: builtInAssistiveTechnologyEnabled,
+            readEnhancedUI: { appElement?.enhancedUserInterface },
+            writeEnhancedUI: { enabled in
+                if !enabled {
+                    Logger.log("AXEnhancedUserInterface was enabled, will disable before resizing")
+                }
+                appElement?.enhancedUserInterface = enabled
+            },
+            adjustment: {
+                if adjustSizeFirst {
+                    size = frame.size
+                }
+                position = frame.origin
+                size = frame.size
             }
-        }
-
-        if adjustSizeFirst {
-            size = frame.size
-        }
-        position = frame.origin
-        size = frame.size
-
-        // If "enhanced user interface" was originally enabled for the app, turn it back on
-        if Defaults.enhancedUI.value == .disableEnable, let appElement = appElement, enhancedUI == true {
-            appElement.enhancedUserInterface = true
-        }
+        )
     }
     
     private var childElements: [AccessibilityElement]? {
@@ -230,6 +230,11 @@ class AccessibilityElement {
     
     var pid: pid_t? {
         wrappedElement.getPid()
+    }
+
+    var bundleIdentifier: String? {
+        guard let pid else { return nil }
+        return NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
     }
     
     var windowElement: AccessibilityElement? {
@@ -469,7 +474,88 @@ class StageWindowAccessibilityElement: AccessibilityElement {
 }
 
 enum EnhancedUI: Int {
-    case disableEnable = 1 /// The default behavior - disable Enhanced UI on every window move/resize
-    case disableOnly = 2 /// Don't re-enable enhanced UI after it gets disabled
-    case frontmostDisable = 3 /// Disable enhanced UI every time the frontmost app gets changed
+    case disableEnable = 1 /// Always restore Enhanced UI after moving/resizing when it was previously enabled
+    case disableOnly = 2 /// Don't re-enable Enhanced UI after it gets disabled
+    case frontmostDisable = 3 /// Disable Enhanced UI every time the frontmost app changes
+    case automatic = 4 /// Avoid re-enabling Chromium accessibility while preserving Enhanced UI for other apps
+
+    private static let chromiumBrowserBundleIdentifierFamilies = [
+        "com.google.Chrome",
+        "org.chromium.Chromium",
+        "com.microsoft.edgemac",
+        "com.brave.Browser",
+        "com.vivaldi.Vivaldi",
+        "com.operasoftware.Opera",
+        "com.operasoftware.OperaNext",
+        "com.operasoftware.OperaDeveloper",
+        "com.operasoftware.OperaNightly",
+        "com.operasoftware.OperaGX",
+        "com.operasoftware.OperaGXNext",
+        "com.operasoftware.OperaGXDeveloper",
+        "com.operasoftware.OperaGXNightly",
+        "company.thebrowser.Browser",
+        "company.thebrowser.dia",
+        "ai.perplexity.comet",
+        "com.openai.atlas"
+    ]
+
+    static func isKnownChromiumBrowser(bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return chromiumBrowserBundleIdentifierFamilies.contains {
+            bundleIdentifier == $0 || bundleIdentifier.hasPrefix("\($0).")
+        }
+    }
+
+    private func restoresEnhancedUI(
+        bundleIdentifier: String?,
+        builtInAssistiveTechnologyEnabled: Bool
+    ) -> Bool {
+        switch self {
+        case .disableEnable:
+            return true
+        case .disableOnly, .frontmostDisable:
+            return false
+        case .automatic:
+            return builtInAssistiveTechnologyEnabled
+                || !Self.isKnownChromiumBrowser(bundleIdentifier: bundleIdentifier)
+        }
+    }
+
+    func disablesEnhancedUIOnApplicationActivation(
+        bundleIdentifier: String?,
+        builtInAssistiveTechnologyEnabled: Bool
+    ) -> Bool {
+        switch self {
+        case .frontmostDisable:
+            return true
+        case .automatic:
+            return !builtInAssistiveTechnologyEnabled
+                && Self.isKnownChromiumBrowser(bundleIdentifier: bundleIdentifier)
+        case .disableEnable, .disableOnly:
+            return false
+        }
+    }
+
+    func performWindowAdjustment(
+        bundleIdentifier: String?,
+        builtInAssistiveTechnologyEnabled: Bool,
+        readEnhancedUI: () -> Bool?,
+        writeEnhancedUI: (Bool) -> Void,
+        adjustment: () -> Void
+    ) {
+        let enhancedUIWasEnabled = readEnhancedUI()
+        if enhancedUIWasEnabled == true {
+            writeEnhancedUI(false)
+        }
+
+        adjustment()
+
+        if enhancedUIWasEnabled == true,
+           restoresEnhancedUI(
+               bundleIdentifier: bundleIdentifier,
+               builtInAssistiveTechnologyEnabled: builtInAssistiveTechnologyEnabled
+           ) {
+            writeEnhancedUI(true)
+        }
+    }
 }

--- a/Rectangle/ApplicationToggle.swift
+++ b/Rectangle/ApplicationToggle.swift
@@ -18,6 +18,7 @@ class ApplicationToggle: NSObject {
         if let disabledApps = Defaults.disabledApps.typedValue {
             self.disabledApps = disabledApps
         }
+        applyEnhancedUIActivationPolicy(to: NSWorkspace.shared.frontmostApplication)
     }
     
     public func reloadFromDefaults() {
@@ -71,6 +72,25 @@ class ApplicationToggle: NSObject {
     private func registerFrontAppChangeNote() {
         NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(self.receiveFrontAppChangeNote(_:)), name: NSWorkspace.didActivateApplicationNotification, object: nil)
     }
+
+    private func applyEnhancedUIActivationPolicy(to application: NSRunningApplication?) {
+        guard let application else { return }
+        let enhancedUI = Defaults.enhancedUI.value
+        let bundleIdentifier = application.bundleIdentifier
+        let builtInAssistiveTechnologyEnabled = NSWorkspace.shared.isVoiceOverEnabled
+            || NSWorkspace.shared.isSwitchControlEnabled
+        guard enhancedUI.disablesEnhancedUIOnApplicationActivation(
+            bundleIdentifier: bundleIdentifier,
+            builtInAssistiveTechnologyEnabled: builtInAssistiveTechnologyEnabled
+        ) else { return }
+
+        let activatedApplicationPid = application.processIdentifier
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
+            guard let activatedApplication = NSRunningApplication(processIdentifier: activatedApplicationPid),
+                  activatedApplication.bundleIdentifier == bundleIdentifier else { return }
+            AccessibilityElement(activatedApplicationPid).enhancedUserInterface = false
+        }
+    }
     
     @objc func receiveFrontAppChangeNote(_ notification: Notification) {
         if let application = notification.userInfo?["NSWorkspaceApplicationKey"] as? NSRunningApplication {
@@ -86,11 +106,7 @@ class ApplicationToggle: NSObject {
             } else {
                 enableShortcuts()
             }
-            if Defaults.enhancedUI.value == .frontmostDisable {
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
-                    AccessibilityElement.getFrontApplicationElement()?.enhancedUserInterface = false
-                }
-            }
+            applyEnhancedUIActivationPolicy(to: application)
         }
     }
 }

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -89,7 +89,11 @@ class Defaults {
     static let landscapeSnapAreas = JSONDefault<[Directional:SnapAreaConfig]>(key: "landscapeSnapAreas")
     static let portraitSnapAreas = JSONDefault<[Directional:SnapAreaConfig]>(key: "portraitSnapAreas")
     static let missionControlDragging = OptionalBoolDefault(key: "missionControlDragging")
-    static let enhancedUI = IntEnumDefault<EnhancedUI>(key: "enhancedUI", defaultValue: .disableEnable)
+    static let enhancedUI = IntEnumDefault<EnhancedUI>(
+        key: "enhancedUI",
+        defaultValue: .automatic,
+        invalidValueFallback: .disableEnable
+    )
     static let footprintAnimationDurationMultiplier = FloatDefault(key: "footprintAnimationDurationMultiplier", defaultValue: 0)
     static let hapticFeedbackOnSnap = OptionalBoolDefault(key: "hapticFeedbackOnSnap")
     static let missionControlDraggingAllowedOffscreenDistance = FloatDefault(key: "missionControlDraggingAllowedOffscreenDistance", defaultValue: 25)
@@ -495,7 +499,7 @@ class JSONDefault<T: Codable>: StringDefault {
 
 class IntEnumDefault<E: RawRepresentable>: Default where E.RawValue == Int {
     public private(set) var key: String
-    private let defaultValue: E
+    private let invalidValueFallback: E
 
     var _value: E
     var value: E {
@@ -508,16 +512,21 @@ class IntEnumDefault<E: RawRepresentable>: Default where E.RawValue == Int {
         get { _value }
     }
 
-    init(key: String, defaultValue: E) {
+    init(key: String, defaultValue: E, invalidValueFallback: E? = nil) {
         self.key = key
-        self.defaultValue = defaultValue
-        let intValue = UserDefaults.standard.integer(forKey: key)
-        _value = E(rawValue: intValue) ?? defaultValue
+        let invalidValueFallback = invalidValueFallback ?? defaultValue
+        self.invalidValueFallback = invalidValueFallback
+        if UserDefaults.standard.object(forKey: key) == nil {
+            _value = defaultValue
+        } else {
+            let intValue = UserDefaults.standard.integer(forKey: key)
+            _value = E(rawValue: intValue) ?? invalidValueFallback
+        }
     }
 
     func load(from codable: CodableDefault) {
         if let intValue = codable.int, _value.rawValue != intValue {
-            _value = E(rawValue: intValue) ?? defaultValue
+            _value = E(rawValue: intValue) ?? invalidValueFallback
             UserDefaults.standard.set(_value.rawValue, forKey: key)
         }
     }

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -548,6 +548,208 @@ class ChangeSizeCalculationTests: XCTestCase {
     }
 }
 
+class EnhancedUITests: XCTestCase {
+    private func adjustmentEvents(
+        mode: EnhancedUI,
+        bundleIdentifier: String? = "com.google.Chrome",
+        builtInAssistiveTechnologyEnabled: Bool = false,
+        initialEnhancedUI: Bool?
+    ) -> [String] {
+        var events = [String]()
+        mode.performWindowAdjustment(
+            bundleIdentifier: bundleIdentifier,
+            builtInAssistiveTechnologyEnabled: builtInAssistiveTechnologyEnabled,
+            readEnhancedUI: {
+                events.append("read")
+                return initialEnhancedUI
+            },
+            writeEnhancedUI: { events.append("write:\($0)") },
+            adjustment: { events.append("adjust") }
+        )
+        return events
+    }
+
+    func testAutomaticModeLeavesEnhancedUIDisabledForChromium() {
+        XCTAssertEqual(
+            adjustmentEvents(mode: .automatic, initialEnhancedUI: true),
+            ["read", "write:false", "adjust"]
+        )
+    }
+
+    func testAutomaticModeRestoresEnhancedUIForOtherApps() {
+        XCTAssertEqual(
+            adjustmentEvents(
+                mode: .automatic,
+                bundleIdentifier: "com.apple.Safari",
+                initialEnhancedUI: true
+            ),
+            ["read", "write:false", "adjust", "write:true"]
+        )
+        XCTAssertEqual(
+            adjustmentEvents(
+                mode: .automatic,
+                bundleIdentifier: nil,
+                initialEnhancedUI: true
+            ),
+            ["read", "write:false", "adjust", "write:true"]
+        )
+    }
+
+    func testAutomaticModeRestoresEnhancedUIForBuiltInAssistiveTechnology() {
+        XCTAssertEqual(
+            adjustmentEvents(
+                mode: .automatic,
+                builtInAssistiveTechnologyEnabled: true,
+                initialEnhancedUI: true
+            ),
+            ["read", "write:false", "adjust", "write:true"]
+        )
+    }
+
+    func testExplicitModesKeepTheirExistingRestoreBehavior() {
+        XCTAssertEqual(
+            adjustmentEvents(mode: .disableEnable, initialEnhancedUI: true),
+            ["read", "write:false", "adjust", "write:true"]
+        )
+        XCTAssertEqual(
+            adjustmentEvents(mode: .disableOnly, initialEnhancedUI: true),
+            ["read", "write:false", "adjust"]
+        )
+        XCTAssertEqual(
+            adjustmentEvents(mode: .frontmostDisable, initialEnhancedUI: true),
+            ["read", "write:false", "adjust"]
+        )
+    }
+
+    func testDisabledOrUnavailableEnhancedUIDoesNotWrite() {
+        XCTAssertEqual(
+            adjustmentEvents(mode: .automatic, initialEnhancedUI: false),
+            ["read", "adjust"]
+        )
+        XCTAssertEqual(
+            adjustmentEvents(mode: .automatic, initialEnhancedUI: nil),
+            ["read", "adjust"]
+        )
+    }
+
+    func testApplicationActivationPolicy() {
+        XCTAssertTrue(
+            EnhancedUI.automatic.disablesEnhancedUIOnApplicationActivation(
+                bundleIdentifier: "com.google.Chrome",
+                builtInAssistiveTechnologyEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            EnhancedUI.automatic.disablesEnhancedUIOnApplicationActivation(
+                bundleIdentifier: "com.google.Chrome",
+                builtInAssistiveTechnologyEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            EnhancedUI.automatic.disablesEnhancedUIOnApplicationActivation(
+                bundleIdentifier: "com.apple.Safari",
+                builtInAssistiveTechnologyEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            EnhancedUI.automatic.disablesEnhancedUIOnApplicationActivation(
+                bundleIdentifier: nil,
+                builtInAssistiveTechnologyEnabled: false
+            )
+        )
+        XCTAssertTrue(
+            EnhancedUI.frontmostDisable.disablesEnhancedUIOnApplicationActivation(
+                bundleIdentifier: "com.apple.Safari",
+                builtInAssistiveTechnologyEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            EnhancedUI.disableEnable.disablesEnhancedUIOnApplicationActivation(
+                bundleIdentifier: "com.google.Chrome",
+                builtInAssistiveTechnologyEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            EnhancedUI.disableOnly.disablesEnhancedUIOnApplicationActivation(
+                bundleIdentifier: "com.google.Chrome",
+                builtInAssistiveTechnologyEnabled: false
+            )
+        )
+    }
+
+    func testKnownChromiumBrowserBundleIdentifiers() {
+        let matchingBundleIdentifiers = [
+            "com.google.Chrome",
+            "com.google.Chrome.canary",
+            "org.chromium.Chromium",
+            "com.microsoft.edgemac",
+            "com.microsoft.edgemac.Beta",
+            "com.brave.Browser",
+            "com.brave.Browser.nightly",
+            "com.vivaldi.Vivaldi",
+            "com.operasoftware.Opera",
+            "com.operasoftware.OperaNext",
+            "com.operasoftware.OperaDeveloper",
+            "com.operasoftware.OperaNightly",
+            "com.operasoftware.OperaGX",
+            "com.operasoftware.OperaGXNext",
+            "com.operasoftware.OperaGXDeveloper",
+            "com.operasoftware.OperaGXNightly",
+            "company.thebrowser.Browser",
+            "company.thebrowser.dia",
+            "ai.perplexity.comet",
+            "com.openai.atlas"
+        ]
+        let nonmatchingBundleIdentifiers: [String?] = [
+            nil,
+            "com.apple.Safari",
+            "com.google.Chromecast",
+            "com.google.ChromeHelper",
+            "com.brave.BrowserHelper"
+        ]
+
+        for bundleIdentifier in matchingBundleIdentifiers {
+            XCTAssertTrue(EnhancedUI.isKnownChromiumBrowser(bundleIdentifier: bundleIdentifier))
+        }
+        for bundleIdentifier in nonmatchingBundleIdentifiers {
+            XCTAssertFalse(EnhancedUI.isKnownChromiumBrowser(bundleIdentifier: bundleIdentifier))
+        }
+    }
+
+    func testEnhancedUIPreferenceMigrationAndRawValues() {
+        let key = "RectangleTests.enhancedUI.\(UUID().uuidString)"
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+
+        let absentPreference = IntEnumDefault<EnhancedUI>(
+            key: key,
+            defaultValue: .automatic,
+            invalidValueFallback: .disableEnable
+        )
+        XCTAssertEqual(absentPreference.value.rawValue, 4)
+
+        UserDefaults.standard.set(0, forKey: key)
+        let legacyZeroPreference = IntEnumDefault<EnhancedUI>(
+            key: key,
+            defaultValue: .automatic,
+            invalidValueFallback: .disableEnable
+        )
+        XCTAssertEqual(legacyZeroPreference.value.rawValue, 1)
+
+        for rawValue in 1...4 {
+            UserDefaults.standard.set(rawValue, forKey: key)
+            let preference = IntEnumDefault<EnhancedUI>(
+                key: key,
+                defaultValue: .automatic,
+                invalidValueFallback: .disableEnable
+            )
+            XCTAssertEqual(preference.value.rawValue, rawValue)
+        }
+
+        legacyZeroPreference.load(from: CodableDefault(int: 0))
+        XCTAssertEqual(legacyZeroPreference.value.rawValue, 1)
+    }
+}
+
 class CooperativeCornerResizeTests: XCTestCase {
     private let screenFrame = CGRect(x: 0, y: 0, width: 1200, height: 900)
     private let minimumSize = CGSize(width: 100, height: 100)

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -33,6 +33,7 @@ The preferences window is purposefully slim, but there's a lot that can be modif
 - [Disabling gaps when maximizing](#disabling-gaps-when-maximizing)
 - [Enabling snap areas for sixths](#enabling-snap-areas-for-sixths)
 - [Move cursor with window](#move-cursor-with-window)
+- [Control Enhanced UI handling](#control-enhanced-ui-handling)
 - [Prevent a window that is quickly dragged above the menu bar from going into Mission Control](#prevent-a-window-that-is-quickly-dragged-above-the-menu-bar-from-going-into-mission-control)
 - [Change the behavior of double-click window title bar](#change-the-behavior-of-double-click-window-title-bar)
 - [Change the order of displays to order by x coordinate](#change-the-order-of-displays-to-order-by-x-coordinate-for-next-and-prev-displays-commands)
@@ -480,6 +481,27 @@ There's an option in the UI for moving the cursor with the window when going acr
 ```bash
 defaults write com.knollsoft.Rectangle moveCursor -int 1
 ```
+
+## Control Enhanced UI handling
+
+Some apps enable the macOS `AXEnhancedUserInterface` accessibility mode. Rectangle disables this mode while moving or resizing a window because its animated window updates can otherwise produce incorrect frames. Chromium browsers can also enable expensive web accessibility processing when the mode is restored.
+
+Rectangle uses automatic handling by default: it restores Enhanced UI for other apps, but leaves it disabled after Rectangle window actions, when known Chromium browser families activate, and when one is already frontmost as Rectangle starts. VoiceOver and Switch Control keep the prior restore behavior. The behavior can be overridden with:
+
+```bash
+defaults write com.knollsoft.Rectangle enhancedUI -int <MODE>
+```
+
+`enhancedUI` accepts the following values:
+
+| Mode | Behavior |
+|------|----------|
+| `1` | Always restore Enhanced UI after a Rectangle window action if it was enabled beforehand. Use this when assistive software depends on the mode. |
+| `2` | Disable Enhanced UI when encountered and do not restore it. |
+| `3` | Behave like mode 2 and also disable Enhanced UI whenever the frontmost app changes. |
+| `4` | Automatic handling (default). |
+
+Automatic handling can still interfere with third-party assistive software that enables Enhanced UI inside a Chromium browser; use mode 1 when that software depends on the mode. Modes 2 and 3 apply the same risk to every app. Legacy mode `0` is treated as mode 1.
 
 ## Prevent a window that is quickly dragged above the menu bar from going into Mission Control
 


### PR DESCRIPTION
## Summary

- add automatic Enhanced UI handling for recognized Chromium browsers
- disable Enhanced UI when a recognized browser starts or activates, and leave it disabled after Rectangle window adjustments
- preserve restore behavior for other apps, VoiceOver, Switch Control, and existing explicit modes
- document the available modes and add regression coverage for the policy and preference migration

Fixes #1751

## Testing

- EnhancedUITests: 8 passed
- Full Rectangle test suite: 242 passed