### PR TITLE
Correct stale Dock insets during window actions

### DIFF
--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -155,13 +155,251 @@ enum ScreenOrdering: Int {
     case yThenMinX = 3
 }
 
+enum DockUtil {
+    // macOS can leave NSScreen.visibleFrame stale after Dock changes (#467).
+    // The Dock's AX list provides a live, fail-closed signal for its current screen and edge.
+    private static let bundleIdentifier = "com.apple.dock"
+    private static let edgeTolerance: CGFloat = 24
+    private static let minimumReliableInset: CGFloat = 8
+    private static let maximumInsetRatio: CGFloat = 0.33
+    private static var cachedSnapshot: Snapshot?
+    private static var snapshotInvalidationPending = false
+
+    private enum Edge: Equatable {
+        case left
+        case right
+        case bottom
+    }
+
+    struct Snapshot {
+        let screenFrames: [CGRect]
+        let dockFrame: CGRect?
+        let dockAutoHideEnabled: Bool
+    }
+
+    static func snapshot(for screens: [NSScreen]) -> Snapshot {
+        let screenFrames = screens.map(\.frame)
+        if Thread.isMainThread,
+           let cachedSnapshot,
+           cachedSnapshot.screenFrames == screenFrames {
+            return cachedSnapshot
+        }
+
+        let dockIsAutoHidden = dockAutoHideEnabled
+        let snapshot = Snapshot(
+            screenFrames: screenFrames,
+            dockFrame: dockIsAutoHidden ? nil : currentDockFrame(primaryScreenMaxY: screens.first?.frame.maxY),
+            dockAutoHideEnabled: dockIsAutoHidden
+        )
+
+        // adjustedVisibleFrame can run several times during one action. Reuse its synchronous
+        // preference/AX reads until control returns to the main queue, then refresh on the next event.
+        if Thread.isMainThread {
+            cachedSnapshot = snapshot
+            if !snapshotInvalidationPending {
+                snapshotInvalidationPending = true
+                DispatchQueue.main.async {
+                    cachedSnapshot = nil
+                    snapshotInvalidationPending = false
+                }
+            }
+        }
+        return snapshot
+    }
+
+    static func correctedVisibleFrame(for screen: NSScreen, snapshot: Snapshot) -> CGRect {
+        let screenFrame = screen.frame
+        let reportedVisibleFrame = screen.visibleFrame
+        let visibleFrame = correctedVisibleFrame(
+            screenFrame: screenFrame,
+            visibleFrame: reportedVisibleFrame,
+            screenFrames: snapshot.screenFrames,
+            dockFrame: snapshot.dockFrame,
+            dockAutoHideEnabled: snapshot.dockAutoHideEnabled
+        )
+
+        if visibleFrame != reportedVisibleFrame {
+            Logger.log("Corrected stale visible screen frame: \(reportedVisibleFrame.debugDescription) -> \(visibleFrame.debugDescription)")
+        }
+        return visibleFrame
+    }
+
+    static func correctedVisibleFrame(screenFrame: CGRect,
+                                      visibleFrame: CGRect,
+                                      screenFrames: [CGRect],
+                                      dockFrame: CGRect?,
+                                      dockAutoHideEnabled: Bool) -> CGRect {
+        guard !screenFrame.isNull, !visibleFrame.isNull else { return visibleFrame }
+
+        if dockAutoHideEnabled {
+            // AppKit can intentionally retain a small boundary used to reveal the hidden Dock.
+            return reclaimDockEdges(from: visibleFrame, screenFrame: screenFrame, preservingSmallInsets: true)
+        }
+
+        guard
+            let dockFrame,
+            !dockFrame.isNull,
+            dockFrame.width > 0,
+            dockFrame.height > 0,
+            let dockScreenFrame = dockScreenFrame(for: dockFrame, screenFrames: screenFrames),
+            let edge = dockEdge(for: dockFrame, screenFrame: dockScreenFrame)
+        else {
+            return visibleFrame
+        }
+
+        let dockInset = dockInset(for: dockFrame, screenFrame: dockScreenFrame, edge: edge)
+        let maximumInset = (edge == .bottom ? dockScreenFrame.height : dockScreenFrame.width) * maximumInsetRatio
+        guard dockInset > 0.5, dockInset <= maximumInset else { return visibleFrame }
+
+        guard screenFrame.equalTo(dockScreenFrame) else {
+            return reclaimDockEdges(from: visibleFrame, screenFrame: screenFrame)
+        }
+
+        let reportedInset = reportedInset(for: visibleFrame, screenFrame: screenFrame, edge: edge)
+        // AXList bounds describe the Dock's tiles rather than its exact reserved area.
+        // Preserve a plausible AppKit inset and use AX only to recover one that is missing.
+        let correctedInset = reportedInset > minimumReliableInset
+            ? reportedInset
+            : dockInset
+
+        var correctedFrame = reclaimDockEdges(from: visibleFrame, screenFrame: screenFrame)
+        let correctedMaxY = correctedFrame.maxY
+        switch edge {
+        case .left:
+            correctedFrame.origin.x = screenFrame.minX + correctedInset
+            correctedFrame.size.width = screenFrame.maxX - correctedFrame.minX
+        case .right:
+            correctedFrame.size.width = screenFrame.maxX - correctedInset - correctedFrame.minX
+        case .bottom:
+            correctedFrame.origin.y = screenFrame.minY + correctedInset
+            correctedFrame.size.height = correctedMaxY - correctedFrame.minY
+        }
+
+        guard correctedFrame.width > 0, correctedFrame.height > 0 else { return visibleFrame }
+        return correctedFrame
+    }
+
+    private static var dockAutoHideEnabled: Bool {
+        let domain = bundleIdentifier as CFString
+        _ = CFPreferencesAppSynchronize(domain)
+        return CFPreferencesCopyAppValue("autohide" as CFString, domain) as? Bool ?? false
+    }
+
+    private static func currentDockFrame(primaryScreenMaxY: CGFloat?) -> CGRect? {
+        guard let primaryScreenMaxY else { return nil }
+        guard let dockElement = AccessibilityElement(bundleIdentifier) else { return nil }
+        dockElement.setMessagingTimeout(0.1)
+        guard let dockListElement = dockElement.getChildElement(.list) else { return nil }
+        dockListElement.setMessagingTimeout(0.1)
+        let frame = dockListElement.frame
+        guard !frame.isNull else { return nil }
+        return CGRect(x: frame.minX, y: primaryScreenMaxY - frame.maxY, width: frame.width, height: frame.height)
+    }
+
+    private static func dockScreenFrame(for dockFrame: CGRect, screenFrames: [CGRect]) -> CGRect? {
+        let candidates = screenFrames
+            .compactMap { screenFrame -> (frame: CGRect, overlap: CGFloat)? in
+                let intersection = screenFrame.intersection(dockFrame)
+                guard !intersection.isNull else { return nil }
+                return (screenFrame, intersection.width * intersection.height)
+            }
+            .sorted { $0.overlap > $1.overlap }
+
+        guard
+            let candidate = candidates.first,
+            candidate.overlap >= dockFrame.width * dockFrame.height * 0.5
+        else {
+            return nil
+        }
+        if candidates.count > 1, abs(candidate.overlap - candidates[1].overlap) < 1 {
+            return nil
+        }
+        return candidate.frame
+    }
+
+    private static func dockEdge(for dockFrame: CGRect, screenFrame: CGRect) -> Edge? {
+        let intersection = screenFrame.intersection(dockFrame)
+        guard !intersection.isNull else { return nil }
+
+        if intersection.width >= intersection.height,
+           intersection.minY - screenFrame.minY <= edgeTolerance {
+            return .bottom
+        }
+        if intersection.height > intersection.width {
+            if intersection.minX - screenFrame.minX <= edgeTolerance {
+                return .left
+            }
+            if screenFrame.maxX - intersection.maxX <= edgeTolerance {
+                return .right
+            }
+        }
+        return nil
+    }
+
+    private static func dockInset(for dockFrame: CGRect, screenFrame: CGRect, edge: Edge) -> CGFloat {
+        switch edge {
+        case .left:
+            return max(0, dockFrame.maxX - screenFrame.minX)
+        case .right:
+            return max(0, screenFrame.maxX - dockFrame.minX)
+        case .bottom:
+            return max(0, dockFrame.maxY - screenFrame.minY)
+        }
+    }
+
+    private static func reportedInset(for visibleFrame: CGRect, screenFrame: CGRect, edge: Edge) -> CGFloat {
+        switch edge {
+        case .left:
+            return max(0, visibleFrame.minX - screenFrame.minX)
+        case .right:
+            return max(0, screenFrame.maxX - visibleFrame.maxX)
+        case .bottom:
+            return max(0, visibleFrame.minY - screenFrame.minY)
+        }
+    }
+
+    private static func reclaimDockEdges(from visibleFrame: CGRect,
+                                         screenFrame: CGRect,
+                                         preservingSmallInsets: Bool = false) -> CGRect {
+        let leftInset = reportedInset(for: visibleFrame, screenFrame: screenFrame, edge: .left)
+        let rightInset = reportedInset(for: visibleFrame, screenFrame: screenFrame, edge: .right)
+        let bottomInset = reportedInset(for: visibleFrame, screenFrame: screenFrame, edge: .bottom)
+        let preservedLeftInset = preservingSmallInsets && leftInset <= minimumReliableInset ? leftInset : 0
+        let preservedRightInset = preservingSmallInsets && rightInset <= minimumReliableInset ? rightInset : 0
+        let preservedBottomInset = preservingSmallInsets && bottomInset <= minimumReliableInset ? bottomInset : 0
+        // The Dock cannot reserve the top edge. Preserve AppKit's menu bar/notch boundary there.
+        let maxY = min(visibleFrame.maxY, screenFrame.maxY)
+        let minY = screenFrame.minY + preservedBottomInset
+        let width = screenFrame.width - preservedLeftInset - preservedRightInset
+        guard maxY > minY, width > 0 else { return visibleFrame }
+        return CGRect(x: screenFrame.minX + preservedLeftInset,
+                      y: minY,
+                      width: width,
+                      height: maxY - minY)
+    }
+}
+
 extension NSScreen {
 
     func adjustedVisibleFrame(_ ignoreTodo: Bool = false, _ ignoreStage: Bool = false) -> CGRect {
-        var newFrame = visibleFrame
+        let screens = NSScreen.screens
+        let dockSnapshot = DockUtil.snapshot(for: screens)
+        var newFrame: CGRect
 
         if !NSScreen.screensHaveSeparateSpaces && Defaults.combinedDisplayMode.userEnabled {
-            newFrame = NSScreen.screens.reduce(CGRect.null) { $0.union($1.visibleFrame) }
+            let combinedScreenFrame = dockSnapshot.screenFrames.reduce(CGRect.null) { $0.union($1) }
+            let combinedVisibleFrame = screens.reduce(CGRect.null) {
+                $0.union(DockUtil.correctedVisibleFrame(for: $1, snapshot: dockSnapshot))
+            }
+            newFrame = DockUtil.correctedVisibleFrame(
+                screenFrame: combinedScreenFrame,
+                visibleFrame: combinedVisibleFrame,
+                screenFrames: [combinedScreenFrame],
+                dockFrame: dockSnapshot.dockFrame,
+                dockAutoHideEnabled: dockSnapshot.dockAutoHideEnabled
+            )
+        } else {
+            newFrame = DockUtil.correctedVisibleFrame(for: self, snapshot: dockSnapshot)
         }
 
         if !ignoreStage && Defaults.stageSize.value > 0 {
@@ -206,4 +444,3 @@ extension NSScreen {
         NSScreen.screens.contains(where: {!$0.frame.isLandscape})
     }
 }
-

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -134,6 +134,222 @@ class ScreenFlippedTests: XCTestCase {
     }
 }
 
+final class DockVisibleFrameTests: XCTestCase {
+    private let screen = CGRect(x: 0, y: 0, width: 1440, height: 900)
+    private let visibleWithoutDock = CGRect(x: 0, y: 0, width: 1440, height: 875)
+
+    func testAddsMissingBottomDockInset() {
+        let dock = CGRect(x: 400, y: 8, width: 640, height: 62)
+
+        XCTAssertEqual(
+            corrected(visibleFrame: visibleWithoutDock, dockFrame: dock),
+            CGRect(x: 0, y: 70, width: 1440, height: 805)
+        )
+    }
+
+    func testAddsMissingLeftDockInset() {
+        let dock = CGRect(x: 8, y: 180, width: 62, height: 540)
+
+        XCTAssertEqual(
+            corrected(visibleFrame: visibleWithoutDock, dockFrame: dock),
+            CGRect(x: 70, y: 0, width: 1370, height: 875)
+        )
+    }
+
+    func testAddsMissingRightDockInset() {
+        let dock = CGRect(x: 1370, y: 180, width: 62, height: 540)
+
+        XCTAssertEqual(
+            corrected(visibleFrame: visibleWithoutDock, dockFrame: dock),
+            CGRect(x: 0, y: 0, width: 1370, height: 875)
+        )
+    }
+
+    func testPreservesAccurateAppKitInsetWhenDockFrameDiffersSlightly() {
+        let reportedVisibleFrame = CGRect(x: 0, y: 60, width: 1440, height: 815)
+        let dock = CGRect(x: 30, y: 10, width: 1380, height: 53)
+
+        XCTAssertEqual(
+            corrected(visibleFrame: reportedVisibleFrame, dockFrame: dock),
+            reportedVisibleFrame
+        )
+    }
+
+    func testPreservesPlausibleAppKitInsetWhenAXDiffersMaterially() {
+        let reportedVisibleFrame = CGRect(x: 0, y: 75, width: 1440, height: 800)
+        let dock = CGRect(x: 400, y: 8, width: 640, height: 32)
+
+        XCTAssertEqual(
+            corrected(visibleFrame: reportedVisibleFrame, dockFrame: dock),
+            reportedVisibleFrame
+        )
+    }
+
+    func testReclaimsPhantomInsetAfterDockMovesToAnotherDisplay() {
+        let externalScreen = CGRect(x: 1440, y: 0, width: 1920, height: 1080)
+        let dock = CGRect(x: 1740, y: 8, width: 1320, height: 62)
+        let staleVisibleFrame = CGRect(x: 0, y: 75, width: 1440, height: 800)
+
+        XCTAssertEqual(
+            corrected(
+                visibleFrame: staleVisibleFrame,
+                screenFrames: [screen, externalScreen],
+                dockFrame: dock
+            ),
+            visibleWithoutDock
+        )
+    }
+
+    func testCorrectsNewDockDisplayAfterMove() {
+        let externalScreen = CGRect(x: 1440, y: 0, width: 1920, height: 1080)
+        let externalVisibleFrame = CGRect(x: 1440, y: 0, width: 1920, height: 1055)
+        let dock = CGRect(x: 1740, y: 8, width: 1320, height: 62)
+
+        XCTAssertEqual(
+            DockUtil.correctedVisibleFrame(
+                screenFrame: externalScreen,
+                visibleFrame: externalVisibleFrame,
+                screenFrames: [screen, externalScreen],
+                dockFrame: dock,
+                dockAutoHideEnabled: false
+            ),
+            CGRect(x: 1440, y: 70, width: 1920, height: 985)
+        )
+    }
+
+    func testAutoHideReclaimsStaleInsetAndPreservesSmallRevealBoundary() {
+        let reportedVisibleFrame = CGRect(x: 70, y: 4, width: 1370, height: 871)
+
+        XCTAssertEqual(
+            corrected(
+                visibleFrame: reportedVisibleFrame,
+                dockFrame: nil,
+                dockAutoHideEnabled: true
+            ),
+            CGRect(x: 0, y: 4, width: 1440, height: 871)
+        )
+    }
+
+    func testAutoHideReclaimsStaleBottomInset() {
+        let reportedVisibleFrame = CGRect(x: 0, y: 75, width: 1440, height: 800)
+
+        XCTAssertEqual(
+            corrected(
+                visibleFrame: reportedVisibleFrame,
+                dockFrame: nil,
+                dockAutoHideEnabled: true
+            ),
+            visibleWithoutDock
+        )
+    }
+
+    func testLiveDockClearsStaleWrongEdgeInset() {
+        let staleLeftDockFrame = CGRect(x: 4, y: 0, width: 1436, height: 875)
+        let currentBottomDock = CGRect(x: 400, y: 8, width: 640, height: 62)
+
+        XCTAssertEqual(
+            corrected(visibleFrame: staleLeftDockFrame, dockFrame: currentBottomDock),
+            CGRect(x: 0, y: 70, width: 1440, height: 805)
+        )
+    }
+
+    func testUnreadableDockKeepsReportedFrame() {
+        let reportedVisibleFrame = CGRect(x: 0, y: 75, width: 1440, height: 800)
+
+        XCTAssertEqual(
+            corrected(visibleFrame: reportedVisibleFrame, dockFrame: nil),
+            reportedVisibleFrame
+        )
+    }
+
+    func testCenteredDockFrameIsIgnored() {
+        let reportedVisibleFrame = CGRect(x: 0, y: 75, width: 1440, height: 800)
+        let invalidDock = CGRect(x: 400, y: 300, width: 640, height: 62)
+
+        XCTAssertEqual(
+            corrected(visibleFrame: reportedVisibleFrame, dockFrame: invalidDock),
+            reportedVisibleFrame
+        )
+    }
+
+    func testOversizedDockFrameIsIgnoredBeforeReclaimingAnotherDisplay() {
+        let externalScreen = CGRect(x: 1440, y: 0, width: 1920, height: 1080)
+        let invalidDock = CGRect(x: 1440, y: 0, width: 1920, height: 500)
+        let reportedVisibleFrame = CGRect(x: 0, y: 75, width: 1440, height: 800)
+
+        XCTAssertEqual(
+            corrected(
+                visibleFrame: reportedVisibleFrame,
+                screenFrames: [screen, externalScreen],
+                dockFrame: invalidDock
+            ),
+            reportedVisibleFrame
+        )
+    }
+
+    func testCorrectsDockOnNegativeOriginDisplay() {
+        let externalScreen = CGRect(x: -1920, y: 0, width: 1920, height: 1080)
+        let externalVisibleFrame = CGRect(x: -1920, y: 0, width: 1920, height: 1055)
+        let dock = CGRect(x: -1912, y: 240, width: 62, height: 600)
+
+        XCTAssertEqual(
+            DockUtil.correctedVisibleFrame(
+                screenFrame: externalScreen,
+                visibleFrame: externalVisibleFrame,
+                screenFrames: [externalScreen, screen],
+                dockFrame: dock,
+                dockAutoHideEnabled: false
+            ),
+            CGRect(x: -1850, y: 0, width: 1850, height: 1055)
+        )
+    }
+
+    func testAmbiguousDockHostIsIgnored() {
+        let upperScreen = CGRect(x: 0, y: 900, width: 1440, height: 900)
+        let ambiguousDock = CGRect(x: 400, y: 870, width: 640, height: 60)
+        let reportedVisibleFrame = CGRect(x: 0, y: 75, width: 1440, height: 800)
+
+        XCTAssertEqual(
+            corrected(
+                visibleFrame: reportedVisibleFrame,
+                screenFrames: [screen, upperScreen],
+                dockFrame: ambiguousDock
+            ),
+            reportedVisibleFrame
+        )
+    }
+
+    func testCombinedDisplayFrameRetainsOuterBottomDockInset() {
+        let combinedScreen = CGRect(x: 0, y: 0, width: 3360, height: 1080)
+        let combinedVisibleFrame = CGRect(x: 0, y: 0, width: 3360, height: 1055)
+        let dock = CGRect(x: 400, y: 8, width: 640, height: 62)
+
+        XCTAssertEqual(
+            DockUtil.correctedVisibleFrame(
+                screenFrame: combinedScreen,
+                visibleFrame: combinedVisibleFrame,
+                screenFrames: [combinedScreen],
+                dockFrame: dock,
+                dockAutoHideEnabled: false
+            ),
+            CGRect(x: 0, y: 70, width: 3360, height: 985)
+        )
+    }
+
+    private func corrected(visibleFrame: CGRect,
+                           screenFrames: [CGRect]? = nil,
+                           dockFrame: CGRect?,
+                           dockAutoHideEnabled: Bool = false) -> CGRect {
+        DockUtil.correctedVisibleFrame(
+            screenFrame: screen,
+            visibleFrame: visibleFrame,
+            screenFrames: screenFrames ?? [screen],
+            dockFrame: dockFrame,
+            dockAutoHideEnabled: dockAutoHideEnabled
+        )
+    }
+}
+
 class DefaultsExportTests: XCTestCase {
 
     func testOverlapDefaultsInExportArray() {


### PR DESCRIPTION
## Summary

- refresh Dock placement when AppKit reports a stale visible frame
- repair missing and phantom Dock reservations after display, edge, and auto-hide changes
- preserve menu bar and notch boundaries while failing closed on ambiguous accessibility geometry
- add coverage for Dock placements, display moves, auto-hide, invalid geometry, and combined displays

## Root cause

macOS can leave `NSScreen.visibleFrame` stale after Dock preference or display-topology changes. Rectangle used that frame directly, so the first Maximize or related action could overlap the Dock or retain space for its former location.

## Testing

- `DockVisibleFrameTests`: 16 passed
- full Rectangle test suite: 250 passed
- `git diff --check`

Fixes #467
Related to #1674