### PR TITLE
Let half actions preserve the window's size on the other axis (opt-in)

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		7BE578F32EFE11010083DAE3 /* ActiveSideSplitRatios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE578F22EFE11010083DAE3 /* ActiveSideSplitRatios.swift */; };
 		7EC9E3BAD5BC57E49A7BCEE5 /* TwelfthsRepeated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3592F8E85CE82B8FA662A31 /* TwelfthsRepeated.swift */; };
 		866661F2257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */; };
+		7B4C0A1F2F1A000100C0FFEE /* HalvesPreserveOtherAxisSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4C0A1E2F1A000100C0FFEE /* HalvesPreserveOtherAxisSize.swift */; };
 		88763FEFFA3AECF8502604D6 /* LowerMiddleCenterLeftSixteenthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378C96D832D4CC6BCCF9D604 /* LowerMiddleCenterLeftSixteenthCalculation.swift */; };
 		895C73559E1ACEFBBE8DC32D /* UpperMiddleCenterRightSixteenthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBF3EA35F0C110A170EAD33 /* UpperMiddleCenterRightSixteenthCalculation.swift */; };
 		8B1D14E3A55936EBCCC1E807 /* MiddleRightTwelfthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA84AB4DB9E7EEFCE50AA6D8 /* MiddleRightTwelfthCalculation.swift */; };
@@ -254,6 +255,7 @@
 		7E8357E928530D10A806F3CD /* TopRightTwelfthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopRightTwelfthCalculation.swift; sourceTree = "<group>"; };
 		84E2DBE0733F31BC159BC99C /* UpperMiddleLeftSixteenthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpperMiddleLeftSixteenthCalculation.swift; sourceTree = "<group>"; };
 		866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatedExecutionsInThirdsCalculation.swift; sourceTree = "<group>"; };
+		7B4C0A1E2F1A000100C0FFEE /* HalvesPreserveOtherAxisSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalvesPreserveOtherAxisSize.swift; sourceTree = "<group>"; };
 		87EC57F37CFD790695177AC8 /* LowerMiddleRightSixteenthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LowerMiddleRightSixteenthCalculation.swift; sourceTree = "<group>"; };
 		88454ABE5C62BD610AEA3EB5 /* BottomCenterLeftSixteenthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomCenterLeftSixteenthCalculation.swift; sourceTree = "<group>"; };
 		8AE08B666CCCD1805CAB08BD /* LowerMiddleCenterRightSixteenthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LowerMiddleCenterRightSixteenthCalculation.swift; sourceTree = "<group>"; };
@@ -553,6 +555,7 @@
 				98A6EDDC251F3F4A00F74B10 /* SixthsRepeated.swift */,
 				BB0000000000000000000002 /* QuartersRepeated.swift */,
 				866661F1257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift */,
+				7B4C0A1E2F1A000100C0FFEE /* HalvesPreserveOtherAxisSize.swift */,
 				30166BCF24F27D6A00A38608 /* SpecifiedCalculation.swift */,
 				D04CE31127817C9B00BD47B3 /* NinthsRepeated.swift */,
 				D04CE2FF2781794E00BD47B3 /* TopLeftNinthCalculation.swift */,
@@ -1073,6 +1076,7 @@
 				98FD7C612687BCB6009E9DAF /* LastThreeFourthsCalculation.swift in Sources */,
 				9821402522B3887200ABFB3F /* MaximizeCalculation.swift in Sources */,
 				866661F2257D248A00A9CD2D /* RepeatedExecutionsInThirdsCalculation.swift in Sources */,
+				7B4C0A1F2F1A000100C0FFEE /* HalvesPreserveOtherAxisSize.swift in Sources */,
 				9824704D22B189250037B409 /* WindowCalculation.swift in Sources */,
 				98C1008E230B9EF6006E5344 /* NextPrevDisplayCalculation.swift in Sources */,
 				9824703122AFA8470037B409 /* RectangleStatusItem.swift in Sources */,

--- a/Rectangle/CycleSize.swift
+++ b/Rectangle/CycleSize.swift
@@ -38,6 +38,14 @@ enum CycleSize: Int, CaseIterable {
         
         return [firstSize] + greaterThanFistSizes + lessThanFistSizes
     }()
+
+    /// The sizes repeated executions cycle through, in cycling order.
+    static func sortedSelectedSizes() -> [CycleSize] {
+        let useDefaultPositions = !Defaults.cycleSizesIsChanged.enabled
+        let positions = useDefaultPositions ? defaultSizes : Defaults.selectedCycleSizes.value
+
+        return sortedSizes.filter { positions.contains($0) }
+    }
 }
 
 enum CornerCycleExpansionAxis: Int {

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -24,6 +24,7 @@ class Defaults {
     static let snapEdgeMarginRight = FloatDefault(key: "snapEdgeMarginRight", defaultValue: 5)
     static let centeredDirectionalMove = OptionalBoolDefault(key: "centeredDirectionalMove")
     static let resizeOnDirectionalMove = BoolDefault(key: "resizeOnDirectionalMove")
+    static let halvesPreserveOtherAxisSize = BoolDefault(key: "halvesPreserveOtherAxisSize")
     static let moveFixedSizeToEdge = IntEnumDefault<EdgeAlignment>(key: "moveFixedSizeToEdge", defaultValue: .edgesAndCorners)
     static let ignoredSnapAreas = IntDefault(key: "ignoredSnapAreas")
     static let traverseSingleScreen = OptionalBoolDefault(key: "traverseSingleScreen")
@@ -127,6 +128,7 @@ class Defaults {
         snapEdgeMarginRight,
         centeredDirectionalMove,
         resizeOnDirectionalMove,
+        halvesPreserveOtherAxisSize,
         ignoredSnapAreas,
         traverseSingleScreen,
         minimumWindowWidth,

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -49,6 +49,7 @@ class SettingsViewController: NSViewController {
     private var combinedDisplayModeCheckbox: NSButton?
     private var greenButtonOverrideCheckbox: NSButton?
     private var autoMaximizeCheckbox: NSButton?
+    private var halvesPreserveOtherAxisSizeCheckbox: NSButton?
     
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
         let newSetting: Bool = sender.state == .on
@@ -185,6 +186,10 @@ class SettingsViewController: NSViewController {
 
     @objc func toggleAutoMaximize(_ sender: NSButton) {
         Defaults.autoMaximize.enabled = sender.state == .on
+    }
+
+    @objc func toggleHalvesPreserveOtherAxisSize(_ sender: NSButton) {
+        Defaults.halvesPreserveOtherAxisSize.enabled = sender.state == .on
     }
 
     @IBAction func toggleTodoMode(_ sender: NSButton) {
@@ -941,6 +946,16 @@ class SettingsViewController: NSViewController {
             mainStackView.addArrangedSubview(hSplitRow)
             mainStackView.addArrangedSubview(vSplitRow)
 
+            let halvesCheckbox = NSButton(checkboxWithTitle: NSLocalizedString("Half actions preserve the window's size on the other axis", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleHalvesPreserveOtherAxisSize(_:)))
+            halvesCheckbox.state = Defaults.halvesPreserveOtherAxisSize.enabled ? .on : .off
+            halvesCheckbox.toolTip = NSLocalizedString("Left Half then Top Half moves the window to the top left quarter; the action for the opposite edge expands it back.", tableName: "Main", value: "", comment: "")
+            halvesCheckbox.translatesAutoresizingMaskIntoConstraints = false
+            halvesCheckbox.alignment = .left
+
+            mainStackView.setCustomSpacing(8, after: vSplitRow)
+            mainStackView.addArrangedSubview(halvesCheckbox)
+            halvesPreserveOtherAxisSizeCheckbox = halvesCheckbox
+
             NSLayoutConstraint.activate([
                 headerLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
                 splitRatioHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
@@ -1150,6 +1165,8 @@ class SettingsViewController: NSViewController {
         greenButtonOverrideCheckbox?.state = Defaults.greenButtonOverride.enabled ? .on : .off
 
         autoMaximizeCheckbox?.state = Defaults.autoMaximize.userDisabled ? .off : .on
+
+        halvesPreserveOtherAxisSizeCheckbox?.state = Defaults.halvesPreserveOtherAxisSize.enabled ? .on : .off
 
         if StageUtil.stageCapable {
             stageSlider.intValue = Int32(Defaults.stageSize.value)

--- a/Rectangle/WindowCalculation/BottomHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/BottomHalfCalculation.swift
@@ -6,6 +6,10 @@ class BottomHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalcul
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
+        if Defaults.halvesPreserveOtherAxisSize.enabled, let tiledRect = HalvesPreserveOtherAxisSize.rect(for: params) {
+            return tiledRect
+        }
+
         if params.lastAction == nil || !Defaults.subsequentExecutionMode.resizes {
             return calculateFirstRect(params)
         }

--- a/Rectangle/WindowCalculation/HalvesPreserveOtherAxisSize.swift
+++ b/Rectangle/WindowCalculation/HalvesPreserveOtherAxisSize.swift
@@ -1,0 +1,194 @@
+/// HalvesPreserveOtherAxisSize.swift
+
+import Foundation
+
+/// Makes Left Half, Right Half, Top Half and Bottom Half behave like keyboard tiling on Windows or
+/// KDE: each action only changes the axis it belongs to (Left/Right → width, Top/Bottom → height)
+/// and keeps the other axis as it is, so that Left Half followed by Top Half lands on the top left
+/// quarter, Top Half followed by Left Half does the same, and Bottom Half then takes that window
+/// back to Left Half.
+///
+/// Along its own axis an action docks the window to its edge when the window spans the whole axis,
+/// expands the window to the whole axis when it is docked to the opposite edge, and leaves it alone
+/// when it is already docked to that edge inside a quarter. Windows that are not tiled at all, and
+/// plain halves that get the same action again, behave exactly as without the feature (including
+/// cycling sizes or moving across displays on repeated executions).
+///
+/// Opt-in via the `halvesPreserveOtherAxisSize` default.
+enum HalvesPreserveOtherAxisSize {
+
+    /// Where a window sits along one axis of the screen.
+    enum AxisState: Equatable {
+        /// Spans the whole axis, or has an extent that no half action produces (floating windows).
+        case full
+        /// Docked to one edge. The rect carries the ungapped extent along that axis.
+        case docked(HalfSplitSide, CGRect)
+    }
+
+    enum Axis {
+        case horizontal, vertical
+    }
+
+    /// Slack for windows that can't take an exact frame, e.g. terminals that resize in character cells.
+    static let matchingTolerance: CGFloat = 10
+
+    /// The rect a half action produces with the feature enabled, or nil when the action should behave
+    /// exactly as it does without the feature: the window is not tiled, or it is a plain half that is
+    /// docked to the action's edge already, in which case Rectangle's usual repeated execution applies.
+    static func rect(for params: RectCalculationParameters) -> RectResult? {
+        guard let (axis, side) = axisAndSide(of: params.action) else { return nil }
+
+        let visibleFrame = params.visibleFrameOfScreen
+        var horizontal = axisState(of: params.window.rect, along: .horizontal, in: visibleFrame)
+        var vertical = axisState(of: params.window.rect, along: .vertical, in: visibleFrame)
+        let own = axis == .horizontal ? horizontal : vertical
+        let other = axis == .horizontal ? vertical : horizontal
+
+        let newOwn: AxisState
+        switch own {
+        case .full:
+            // Not tiled along this axis: dock to the edge, unless the window is not tiled at all
+            // (then the plain half is exactly what the action does anyway).
+            guard other != .full else { return nil }
+            newOwn = .docked(side, dockedRect(along: axis, side: side, in: visibleFrame))
+        case .docked(let dockedSide, _) where dockedSide == side:
+            // Already docked to this edge: a plain half repeats as usual (cycle sizes, move across
+            // displays); inside a quarter there is nothing to do.
+            guard other != .full else { return nil }
+            newOwn = own
+        case .docked:
+            // Docked to the opposite edge: expand along this axis.
+            newOwn = .full
+        }
+
+        if axis == .horizontal {
+            horizontal = newOwn
+        } else {
+            vertical = newOwn
+        }
+        return compose(horizontal: horizontal, vertical: vertical, in: visibleFrame)
+    }
+
+    /// The state of `window` along `axis`: docked if its position and extent match (within tolerance)
+    /// an edge-docked rect that Rectangle's half actions produce, at the active split ratio or any cycle
+    /// size, with or without gaps applied.
+    static func axisState(of window: CGRect, along axis: Axis, in visibleFrame: CGRect) -> AxisState {
+        guard !window.isNull, !visibleFrame.isNull, visibleFrame.width > 0, visibleFrame.height > 0 else {
+            return .full
+        }
+
+        let ratio = splitRatio(along: axis, in: visibleFrame)
+        let gapSize = Defaults.gapSize.value
+
+        for side in [HalfSplitSide.leading, .trailing] {
+            let fractions = [side == .leading ? ratio : 1 - ratio] + CycleSize.allCases.map { $0.fraction }
+
+            for fraction in fractions {
+                let docked = dockedRect(along: axis, side: side, fraction: fraction, in: visibleFrame)
+                guard extent(of: docked, along: axis) < extent(of: visibleFrame, along: axis) - matchingTolerance else {
+                    continue
+                }
+
+                var candidates = [docked]
+                if gapSize > 0 {
+                    candidates.append(GapCalculation.applyGaps(docked,
+                                                               dimension: axis == .horizontal ? .horizontal : .vertical,
+                                                               sharedEdges: sharedEdge(along: axis, side: side),
+                                                               gapSize: gapSize,
+                                                               skipTopGap: Defaults.skipGapTopEdge.enabled))
+                }
+
+                if candidates.contains(where: { matches(window, $0, along: axis) }) {
+                    return .docked(side, docked)
+                }
+            }
+        }
+
+        return .full
+    }
+
+    private static func compose(horizontal: AxisState, vertical: AxisState, in visibleFrame: CGRect) -> RectResult {
+        var rect = visibleFrame
+        if case .docked(_, let column) = horizontal {
+            rect.origin.x = column.minX
+            rect.size.width = column.width
+        }
+        if case .docked(_, let row) = vertical {
+            rect.origin.y = row.minY
+            rect.size.height = row.height
+        }
+
+        // Report the action that produces this rect so gaps and history match it.
+        switch (horizontal, vertical) {
+        case (.full, .full):
+            return RectResult(rect, resultingAction: .maximize)
+        case (.docked(.leading, _), .full):
+            return RectResult(rect, resultingAction: .leftHalf)
+        case (.docked(.trailing, _), .full):
+            return RectResult(rect, resultingAction: .rightHalf)
+        case (.full, .docked(.leading, _)):
+            return RectResult(rect, resultingAction: .topHalf)
+        case (.full, .docked(.trailing, _)):
+            return RectResult(rect, resultingAction: .bottomHalf)
+        case (.docked(.leading, _), .docked(.leading, _)):
+            return RectResult(rect, resultingAction: .topLeft, subAction: .topLeftQuarter)
+        case (.docked(.trailing, _), .docked(.leading, _)):
+            return RectResult(rect, resultingAction: .topRight, subAction: .topRightQuarter)
+        case (.docked(.leading, _), .docked(.trailing, _)):
+            return RectResult(rect, resultingAction: .bottomLeft, subAction: .bottomLeftQuarter)
+        case (.docked(.trailing, _), .docked(.trailing, _)):
+            return RectResult(rect, resultingAction: .bottomRight, subAction: .bottomRightQuarter)
+        }
+    }
+
+    private static func axisAndSide(of action: WindowAction) -> (Axis, HalfSplitSide)? {
+        switch action {
+        case .leftHalf: return (.horizontal, .leading)
+        case .rightHalf: return (.horizontal, .trailing)
+        case .topHalf: return (.vertical, .leading)
+        case .bottomHalf: return (.vertical, .trailing)
+        default: return nil
+        }
+    }
+
+    private static func splitRatio(along axis: Axis, in visibleFrame: CGRect) -> Float {
+        axis == .horizontal
+            ? ActiveSideSplitRatios.shared.horizontalRatio(for: visibleFrame)
+            : ActiveSideSplitRatios.shared.verticalRatio(for: visibleFrame)
+    }
+
+    private static func dockedRect(along axis: Axis, side: HalfSplitSide, in visibleFrame: CGRect) -> CGRect {
+        let ratio = splitRatio(along: axis, in: visibleFrame)
+        return dockedRect(along: axis, side: side, fraction: side == .leading ? ratio : 1 - ratio, in: visibleFrame)
+    }
+
+    private static func dockedRect(along axis: Axis, side: HalfSplitSide, fraction: Float, in visibleFrame: CGRect) -> CGRect {
+        axis == .horizontal
+            ? HalfSplitFrameCalculation.horizontalRect(in: visibleFrame, side: side, fraction: fraction)
+            : HalfSplitFrameCalculation.verticalRect(in: visibleFrame, side: side, fraction: fraction)
+    }
+
+    private static func sharedEdge(along axis: Axis, side: HalfSplitSide) -> Edge {
+        switch (axis, side) {
+        case (.horizontal, .leading): return .right
+        case (.horizontal, .trailing): return .left
+        case (.vertical, .leading): return .bottom
+        case (.vertical, .trailing): return .top
+        }
+    }
+
+    private static func extent(of rect: CGRect, along axis: Axis) -> CGFloat {
+        axis == .horizontal ? rect.width : rect.height
+    }
+
+    private static func matches(_ window: CGRect, _ candidate: CGRect, along axis: Axis) -> Bool {
+        switch axis {
+        case .horizontal:
+            return abs(window.minX - candidate.minX) <= matchingTolerance
+                && abs(window.width - candidate.width) <= matchingTolerance
+        case .vertical:
+            return abs(window.minY - candidate.minY) <= matchingTolerance
+                && abs(window.height - candidate.height) <= matchingTolerance
+        }
+    }
+}

--- a/Rectangle/WindowCalculation/HalvesPreserveOtherAxisSize.swift
+++ b/Rectangle/WindowCalculation/HalvesPreserveOtherAxisSize.swift
@@ -9,10 +9,11 @@ import Foundation
 /// back to Left Half.
 ///
 /// Along its own axis an action docks the window to its edge when the window spans the whole axis,
-/// expands the window to the whole axis when it is docked to the opposite edge, and leaves it alone
-/// when it is already docked to that edge inside a quarter. Windows that are not tiled at all, and
-/// plain halves that get the same action again, behave exactly as without the feature (including
-/// cycling sizes or moving across displays on repeated executions).
+/// expands the window to the whole axis when it is docked to the opposite edge, and cycles the window
+/// through the cycle sizes along that axis when it is already docked to that edge inside a quarter
+/// (if repeated commands resize; otherwise it leaves the window alone). Windows that are not tiled at
+/// all, and plain halves that get the same action again, behave exactly as without the feature
+/// (including cycling sizes or moving across displays on repeated executions).
 ///
 /// Opt-in via the `halvesPreserveOtherAxisSize` default.
 enum HalvesPreserveOtherAxisSize {
@@ -51,11 +52,16 @@ enum HalvesPreserveOtherAxisSize {
             // (then the plain half is exactly what the action does anyway).
             guard other != .full else { return nil }
             newOwn = .docked(side, dockedRect(along: axis, side: side, in: visibleFrame))
-        case .docked(let dockedSide, _) where dockedSide == side:
+        case .docked(let dockedSide, let currentRect) where dockedSide == side:
             // Already docked to this edge: a plain half repeats as usual (cycle sizes, move across
-            // displays); inside a quarter there is nothing to do.
+            // displays); inside a quarter the window cycles sizes along this axis if repeated commands
+            // resize, and stays as it is otherwise.
             guard other != .full else { return nil }
-            newOwn = own
+            if Defaults.subsequentExecutionMode.resizes, let next = nextCycleSize(after: currentRect, along: axis, side: side, in: visibleFrame) {
+                newOwn = .docked(side, dockedRect(along: axis, side: side, fraction: next.fraction, in: visibleFrame))
+            } else {
+                newOwn = own
+            }
         case .docked:
             // Docked to the opposite edge: expand along this axis.
             newOwn = .full
@@ -105,6 +111,20 @@ enum HalvesPreserveOtherAxisSize {
         }
 
         return .full
+    }
+
+    /// The cycle size that follows `currentRect` in the cycling order: the one after the size the rect
+    /// has, or the first one when the rect has a size that is not selected for cycling (e.g. a custom
+    /// split ratio). Nil when no cycle sizes are selected.
+    private static func nextCycleSize(after currentRect: CGRect, along axis: Axis, side: HalfSplitSide, in visibleFrame: CGRect) -> CycleSize? {
+        let sizes = CycleSize.sortedSelectedSizes()
+        guard !sizes.isEmpty else { return nil }
+
+        let currentIndex = sizes.firstIndex { size in
+            matches(currentRect, dockedRect(along: axis, side: side, fraction: size.fraction, in: visibleFrame), along: axis)
+        }
+        guard let currentIndex else { return sizes[0] }
+        return sizes[(currentIndex + 1) % sizes.count]
     }
 
     private static func compose(horizontal: AxisState, vertical: AxisState, in visibleFrame: CGRect) -> RectResult {

--- a/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/LeftRightHalfCalculation.swift
@@ -7,6 +7,13 @@ class LeftRightHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCal
     override func calculate(_ params: WindowCalculationParameters) -> WindowCalculationResult? {
         
         let usableScreens = params.usableScreens
+
+        if Defaults.halvesPreserveOtherAxisSize.enabled, let tiledRect = HalvesPreserveOtherAxisSize.rect(for: params.asRectParams()) {
+            return WindowCalculationResult(rect: tiledRect.rect,
+                                           screen: usableScreens.currentScreen,
+                                           resultingAction: tiledRect.resultingAction ?? params.action,
+                                           resultingSubAction: tiledRect.subAction)
+        }
         
         switch Defaults.subsequentExecutionMode.value {
             

--- a/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
+++ b/Rectangle/WindowCalculation/RepeatedExecutionsCalculation.swift
@@ -13,11 +13,7 @@ protocol RepeatedExecutionsCalculation {
 extension RepeatedExecutionsCalculation {
     
     func sortedCycleSizes() -> [CycleSize] {
-        let useDefaultPositions = !Defaults.cycleSizesIsChanged.enabled
-        let positions = useDefaultPositions ? CycleSize.defaultSizes : Defaults.selectedCycleSizes.value
-        
-        return CycleSize.sortedSizes
-            .filter { positions.contains($0) }
+        CycleSize.sortedSelectedSizes()
     }
     
     func calculateRepeatedRect(_ params: RectCalculationParameters) -> RectResult {

--- a/Rectangle/WindowCalculation/TopHalfCalculation.swift
+++ b/Rectangle/WindowCalculation/TopHalfCalculation.swift
@@ -6,6 +6,10 @@ class TopHalfCalculation: WindowCalculation, RepeatedExecutionsInThirdsCalculati
 
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
+        if Defaults.halvesPreserveOtherAxisSize.enabled, let tiledRect = HalvesPreserveOtherAxisSize.rect(for: params) {
+            return tiledRect
+        }
+
         if params.lastAction == nil || !Defaults.subsequentExecutionMode.resizes {
             return calculateFirstRect(params)
         }

--- a/Rectangle/WindowCalculation/WindowCalculation.swift
+++ b/Rectangle/WindowCalculation/WindowCalculation.swift
@@ -19,7 +19,7 @@ class WindowCalculation: Calculation {
             return nil
         }
         
-        return WindowCalculationResult(rect: rectResult.rect, screen: params.usableScreens.currentScreen, resultingAction: params.action, resultingSubAction: rectResult.subAction)
+        return WindowCalculationResult(rect: rectResult.rect, screen: params.usableScreens.currentScreen, resultingAction: rectResult.resultingAction ?? params.action, resultingSubAction: rectResult.subAction)
     }
 
     func calculateRect(_ params: RectCalculationParameters) -> RectResult {

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -21207,6 +21207,9 @@
         }
       }
     },
+    "Half actions preserve the window's size on the other axis" : {
+
+    },
     "heT-W6-Fyf.title" : {
       "comment" : "Class = \"NSButtonCell\"; title = \"Double-click window title bar to maximize/restore\"; ObjectID = \"heT-W6-Fyf\";",
       "extractionState" : "extracted_with_value",
@@ -27761,6 +27764,9 @@
           }
         }
       }
+    },
+    "Left Half then Top Half moves the window to the top left quarter; the action for the opposite edge expands it back." : {
+
     },
     "Left or right side" : {
       "localizations" : {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -4046,3 +4046,288 @@ final class NextPrevDisplayMappingTests: XCTestCase {
         )
     }
 }
+
+class HalvesPreserveOtherAxisSizeTests: XCTestCase {
+
+    private var savedHalvesPreserveOtherAxisSize = false
+    private var savedGapSize: Float = 0
+    private var savedSkipGapTopEdge = false
+    private var savedHorizontalSplitRatio: Float = 50
+    private var savedVerticalSplitRatio: Float = 50
+    private var savedSubsequentExecutionMode: SubsequentExecutionMode = .resize
+    private var savedCycleSizesIsChanged = false
+    private var savedCooperativeCornerResize = false
+
+    private let visibleFrame = CGRect(x: 10, y: 20, width: 1200, height: 900)
+    // Ungapped rects that the half and quarter actions produce on `visibleFrame` at the default 50% split.
+    private let leftHalf = CGRect(x: 10, y: 20, width: 600, height: 900)
+    private let rightHalf = CGRect(x: 610, y: 20, width: 600, height: 900)
+    private let topHalf = CGRect(x: 10, y: 470, width: 1200, height: 450)
+    private let bottomHalf = CGRect(x: 10, y: 20, width: 1200, height: 450)
+    private let topLeftQuarter = CGRect(x: 10, y: 470, width: 600, height: 450)
+    private let topRightQuarter = CGRect(x: 610, y: 470, width: 600, height: 450)
+    private let bottomLeftQuarter = CGRect(x: 10, y: 20, width: 600, height: 450)
+    private let bottomRightQuarter = CGRect(x: 610, y: 20, width: 600, height: 450)
+
+    override func setUp() {
+        super.setUp()
+        savedHalvesPreserveOtherAxisSize = Defaults.halvesPreserveOtherAxisSize.enabled
+        savedGapSize = Defaults.gapSize.value
+        savedSkipGapTopEdge = Defaults.skipGapTopEdge.enabled
+        savedHorizontalSplitRatio = Defaults.horizontalSplitRatio.value
+        savedVerticalSplitRatio = Defaults.verticalSplitRatio.value
+        savedSubsequentExecutionMode = Defaults.subsequentExecutionMode.value
+        savedCycleSizesIsChanged = Defaults.cycleSizesIsChanged.enabled
+        savedCooperativeCornerResize = Defaults.cooperativeCornerResize.enabled
+        Defaults.halvesPreserveOtherAxisSize.enabled = true
+        Defaults.gapSize.value = 0
+        Defaults.skipGapTopEdge.enabled = false
+        Defaults.horizontalSplitRatio.value = 50
+        Defaults.verticalSplitRatio.value = 50
+        Defaults.subsequentExecutionMode.value = .resize
+        Defaults.cycleSizesIsChanged.enabled = false
+        Defaults.cooperativeCornerResize.enabled = false
+        ActiveSideSplitRatios.shared.resetAll()
+    }
+
+    override func tearDown() {
+        Defaults.halvesPreserveOtherAxisSize.enabled = savedHalvesPreserveOtherAxisSize
+        Defaults.gapSize.value = savedGapSize
+        Defaults.skipGapTopEdge.enabled = savedSkipGapTopEdge
+        Defaults.horizontalSplitRatio.value = savedHorizontalSplitRatio
+        Defaults.verticalSplitRatio.value = savedVerticalSplitRatio
+        Defaults.subsequentExecutionMode.value = savedSubsequentExecutionMode
+        Defaults.cycleSizesIsChanged.enabled = savedCycleSizesIsChanged
+        Defaults.cooperativeCornerResize.enabled = savedCooperativeCornerResize
+        ActiveSideSplitRatios.shared.resetAll()
+        super.tearDown()
+    }
+
+    // MARK: A half action keeps the other axis: Left + Top = top left quarter, in either order
+
+    func testTopHalfKeepsLeftHalfColumn() {
+        assertTiled(.topHalf, from: leftHalf, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testLeftHalfKeepsTopHalfRow() {
+        assertTiled(.leftHalf, from: topHalf, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testBottomHalfKeepsRightHalfColumn() {
+        assertTiled(.bottomHalf, from: rightHalf, gives: bottomRightQuarter, as: .bottomRight, subAction: .bottomRightQuarter)
+    }
+
+    func testRightHalfKeepsBottomHalfRow() {
+        assertTiled(.rightHalf, from: bottomHalf, gives: bottomRightQuarter, as: .bottomRight, subAction: .bottomRightQuarter)
+    }
+
+    func testTopHalfKeepsRightHalfColumn() {
+        assertTiled(.topHalf, from: rightHalf, gives: topRightQuarter, as: .topRight, subAction: .topRightQuarter)
+    }
+
+    func testBottomHalfKeepsLeftHalfColumn() {
+        assertTiled(.bottomHalf, from: leftHalf, gives: bottomLeftQuarter, as: .bottomLeft, subAction: .bottomLeftQuarter)
+    }
+
+    // MARK: The action for the opposite edge expands the window along that axis
+
+    func testBottomHalfExpandsTopLeftQuarterToLeftHalf() {
+        assertTiled(.bottomHalf, from: topLeftQuarter, gives: leftHalf, as: .leftHalf)
+    }
+
+    func testTopHalfExpandsBottomLeftQuarterToLeftHalf() {
+        assertTiled(.topHalf, from: bottomLeftQuarter, gives: leftHalf, as: .leftHalf)
+    }
+
+    func testRightHalfExpandsTopLeftQuarterToTopHalf() {
+        assertTiled(.rightHalf, from: topLeftQuarter, gives: topHalf, as: .topHalf)
+    }
+
+    func testLeftHalfExpandsBottomRightQuarterToBottomHalf() {
+        assertTiled(.leftHalf, from: bottomRightQuarter, gives: bottomHalf, as: .bottomHalf)
+    }
+
+    func testLeftHalfExpandsRightHalfToFullScreen() {
+        assertTiled(.leftHalf, from: rightHalf, gives: visibleFrame, as: .maximize)
+    }
+
+    func testTopHalfExpandsBottomHalfToFullScreen() {
+        assertTiled(.topHalf, from: bottomHalf, gives: visibleFrame, as: .maximize)
+    }
+
+    // MARK: The action for the edge a quarter is docked to does nothing
+
+    func testTopHalfLeavesTopLeftQuarterAlone() {
+        assertTiled(.topHalf, from: topLeftQuarter, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testLeftHalfLeavesTopLeftQuarterAlone() {
+        assertTiled(.leftHalf, from: topLeftQuarter, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testRightHalfLeavesBottomRightQuarterAlone() {
+        assertTiled(.rightHalf, from: bottomRightQuarter, gives: bottomRightQuarter, as: .bottomRight, subAction: .bottomRightQuarter)
+    }
+
+    func testRepeatedTopHalfInsideQuarterDoesNotCycleHeight() {
+        let params = params(for: .topHalf, windowRect: topLeftQuarter,
+                            lastAction: RectangleAction(action: .topHalf, subAction: .topLeftQuarter, rect: topLeftQuarter, count: 1))
+
+        let result = WindowCalculationFactory.topHalfCalculation.calculateRect(params)
+
+        XCTAssertEqual(result.rect, topLeftQuarter)
+        XCTAssertEqual(result.subAction, .topLeftQuarter)
+    }
+
+    // MARK: Plain halves and windows that are not tiled behave as without the feature
+
+    func testPlainHalvesRepeatAsUsual() {
+        XCTAssertNil(tiled(.leftHalf, from: leftHalf))
+        XCTAssertNil(tiled(.rightHalf, from: rightHalf))
+        XCTAssertNil(tiled(.topHalf, from: topHalf))
+        XCTAssertNil(tiled(.bottomHalf, from: bottomHalf))
+    }
+
+    func testRepeatedPlainTopHalfStillCyclesHeight() {
+        let params = params(for: .topHalf, windowRect: topHalf,
+                            lastAction: RectangleAction(action: .topHalf, subAction: nil, rect: topHalf, count: 1))
+
+        let result = WindowCalculationFactory.topHalfCalculation.calculateRect(params)
+
+        XCTAssertEqual(result.rect, CGRect(x: 10, y: 320, width: 1200, height: 600))
+    }
+
+    func testUntiledWindowsAreNotAffected() {
+        let floating = CGRect(x: 300, y: 100, width: 700, height: 500)
+        let centeredColumn = CGRect(x: 310, y: 20, width: 600, height: 900)
+
+        for action in [WindowAction.leftHalf, .rightHalf, .topHalf, .bottomHalf] {
+            XCTAssertNil(tiled(action, from: floating), "\(action)")
+            XCTAssertNil(tiled(action, from: visibleFrame), "\(action)")
+        }
+        XCTAssertNil(tiled(.topHalf, from: centeredColumn))
+    }
+
+    func testTopHalfCalculationFallsBackToDefaultBehaviorForUntiledWindows() {
+        let result = WindowCalculationFactory.topHalfCalculation.calculateRect(params(for: .topHalf, windowRect: CGRect(x: 300, y: 100, width: 700, height: 500)))
+
+        XCTAssertEqual(result.rect, topHalf)
+        XCTAssertNil(result.resultingAction)
+        XCTAssertNil(result.subAction)
+    }
+
+    func testTopHalfCalculationTilesWhenEnabled() {
+        let result = WindowCalculationFactory.topHalfCalculation.calculateRect(params(for: .topHalf, windowRect: leftHalf))
+
+        XCTAssertEqual(result.rect, topLeftQuarter)
+        XCTAssertEqual(result.resultingAction, .topLeft)
+        XCTAssertEqual(result.subAction, .topLeftQuarter)
+    }
+
+    func testBottomHalfCalculationTilesWhenEnabled() {
+        let result = WindowCalculationFactory.bottomHalfCalculation.calculateRect(params(for: .bottomHalf, windowRect: topLeftQuarter))
+
+        XCTAssertEqual(result.rect, leftHalf)
+        XCTAssertEqual(result.resultingAction, .leftHalf)
+    }
+
+    func testDisabledFeatureKeepsFullWidthTopHalf() {
+        Defaults.halvesPreserveOtherAxisSize.enabled = false
+
+        let result = WindowCalculationFactory.topHalfCalculation.calculateRect(params(for: .topHalf, windowRect: leftHalf))
+
+        XCTAssertEqual(result.rect, topHalf)
+        XCTAssertNil(result.resultingAction)
+        XCTAssertNil(result.subAction)
+    }
+
+    // MARK: Columns and rows other than exactly one half
+
+    func testTopHalfKeepsCycledTwoThirdsColumn() {
+        assertTiled(.topHalf, from: CGRect(x: 10, y: 20, width: 800, height: 900),
+                    gives: CGRect(x: 10, y: 470, width: 800, height: 450), as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testBottomHalfExpandsTwoThirdsWideTopLeftQuarterToTwoThirdsColumn() {
+        assertTiled(.bottomHalf, from: CGRect(x: 10, y: 470, width: 800, height: 450),
+                    gives: CGRect(x: 10, y: 20, width: 800, height: 900), as: .leftHalf)
+    }
+
+    func testLeftHalfKeepsCycledTopThirdRow() {
+        assertTiled(.leftHalf, from: CGRect(x: 10, y: 620, width: 1200, height: 300),
+                    gives: CGRect(x: 10, y: 620, width: 600, height: 300), as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testTopHalfKeepsRightThirdColumn() {
+        assertTiled(.topHalf, from: CGRect(x: 810, y: 20, width: 400, height: 900),
+                    gives: CGRect(x: 810, y: 470, width: 400, height: 450), as: .topRight, subAction: .topRightQuarter)
+    }
+
+    func testCustomSplitRatioIsUsedForRecognitionAndResults() {
+        Defaults.horizontalSplitRatio.value = 60
+
+        assertTiled(.topHalf, from: CGRect(x: 10, y: 20, width: 720, height: 900),
+                    gives: CGRect(x: 10, y: 470, width: 720, height: 450), as: .topLeft, subAction: .topLeftQuarter)
+        assertTiled(.topHalf, from: CGRect(x: 730, y: 20, width: 480, height: 900),
+                    gives: CGRect(x: 730, y: 470, width: 480, height: 450), as: .topRight, subAction: .topRightQuarter)
+        assertTiled(.leftHalf, from: topHalf,
+                    gives: CGRect(x: 10, y: 470, width: 720, height: 450), as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    // MARK: Gaps and tolerance
+
+    func testRecognizesGappedColumnAndReturnsUngappedRect() {
+        Defaults.gapSize.value = 20
+        // Left half with gaps applied by WindowManager: inset 20 on each side, half a gap back on the shared right edge.
+        let gappedLeftHalf = CGRect(x: 30, y: 40, width: 570, height: 860)
+
+        assertTiled(.topHalf, from: gappedLeftHalf, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testRecognizesGappedRowWithSkippedTopGap() {
+        Defaults.gapSize.value = 20
+        Defaults.skipGapTopEdge.enabled = true
+        let gappedTopHalf = GapCalculation.applyGaps(topHalf, dimension: .both, sharedEdges: .bottom, gapSize: 20, skipTopGap: true)
+
+        assertTiled(.leftHalf, from: gappedTopHalf, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testToleratesWindowsThatCannotTakeTheExactSize() {
+        assertTiled(.topHalf, from: CGRect(x: 10, y: 20, width: 594, height: 900),
+                    gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testDoesNotMatchWindowsFarFromAnyColumn() {
+        XCTAssertNil(tiled(.topHalf, from: CGRect(x: 10, y: 20, width: 560, height: 900)))
+    }
+
+    // MARK: Helpers
+
+    private func tiled(_ action: WindowAction, from windowRect: CGRect) -> RectResult? {
+        HalvesPreserveOtherAxisSize.rect(for: params(for: action, windowRect: windowRect))
+    }
+
+    private func assertTiled(_ action: WindowAction,
+                             from windowRect: CGRect,
+                             gives expectedRect: CGRect,
+                             as expectedAction: WindowAction,
+                             subAction expectedSubAction: SubWindowAction? = nil,
+                             file: StaticString = #filePath,
+                             line: UInt = #line) {
+        guard let result = tiled(action, from: windowRect) else {
+            XCTFail("\(action) from \(windowRect) fell back to the default behavior", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(result.rect, expectedRect, file: file, line: line)
+        XCTAssertEqual(result.resultingAction, expectedAction, file: file, line: line)
+        XCTAssertEqual(result.subAction, expectedSubAction, file: file, line: line)
+    }
+
+    private func params(for action: WindowAction, windowRect: CGRect, lastAction: RectangleAction? = nil) -> RectCalculationParameters {
+        RectCalculationParameters(window: Window(id: 1, rect: windowRect),
+                                  visibleFrameOfScreen: visibleFrame,
+                                  action: action,
+                                  lastAction: lastAction)
+    }
+}
+

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -4155,27 +4155,91 @@ class HalvesPreserveOtherAxisSizeTests: XCTestCase {
         assertTiled(.topHalf, from: bottomHalf, gives: visibleFrame, as: .maximize)
     }
 
-    // MARK: The action for the edge a quarter is docked to does nothing
+    // MARK: The action for the edge a quarter is docked to cycles sizes along its own axis
 
-    func testTopHalfLeavesTopLeftQuarterAlone() {
-        assertTiled(.topHalf, from: topLeftQuarter, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+    func testLeftHalfCyclesWidthOfTopLeftQuarter() {
+        let twoThirdsWide = CGRect(x: 10, y: 470, width: 800, height: 450)
+        let oneThirdWide = CGRect(x: 10, y: 470, width: 400, height: 450)
+
+        assertTiled(.leftHalf, from: topLeftQuarter, gives: twoThirdsWide, as: .topLeft, subAction: .topLeftQuarter)
+        assertTiled(.leftHalf, from: twoThirdsWide, gives: oneThirdWide, as: .topLeft, subAction: .topLeftQuarter)
+        assertTiled(.leftHalf, from: oneThirdWide, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
     }
 
-    func testLeftHalfLeavesTopLeftQuarterAlone() {
+    func testRightHalfCyclesWidthOfBottomRightQuarterFromItsEdge() {
+        assertTiled(.rightHalf, from: bottomRightQuarter,
+                    gives: CGRect(x: 410, y: 20, width: 800, height: 450), as: .bottomRight, subAction: .bottomRightQuarter)
+    }
+
+    func testTopHalfCyclesHeightOfTopLeftQuarter() {
+        let twoThirdsHigh = CGRect(x: 10, y: 320, width: 600, height: 600)
+        let oneThirdHigh = CGRect(x: 10, y: 620, width: 600, height: 300)
+
+        assertTiled(.topHalf, from: topLeftQuarter, gives: twoThirdsHigh, as: .topLeft, subAction: .topLeftQuarter)
+        assertTiled(.topHalf, from: twoThirdsHigh, gives: oneThirdHigh, as: .topLeft, subAction: .topLeftQuarter)
+        assertTiled(.topHalf, from: oneThirdHigh, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testBottomHalfCyclesHeightOfBottomRightQuarterFromItsEdge() {
+        assertTiled(.bottomHalf, from: bottomRightQuarter,
+                    gives: CGRect(x: 610, y: 20, width: 600, height: 600), as: .bottomRight, subAction: .bottomRightQuarter)
+    }
+
+    func testCyclingInsideQuarterUsesSelectedCycleSizes() {
+        let savedSelectedCycleSizes = Defaults.selectedCycleSizes.value
+        defer { Defaults.selectedCycleSizes.value = savedSelectedCycleSizes }
+        Defaults.cycleSizesIsChanged.enabled = true
+        Defaults.selectedCycleSizes.value = [.twoThirds, .oneQuarter]
+
+        let twoThirdsWide = CGRect(x: 10, y: 470, width: 800, height: 450)
+        let oneQuarterWide = CGRect(x: 10, y: 470, width: 300, height: 450)
+
+        // One half is not selected: the cycle starts at the first selected size and never returns to one half.
+        assertTiled(.leftHalf, from: topLeftQuarter, gives: twoThirdsWide, as: .topLeft, subAction: .topLeftQuarter)
+        assertTiled(.leftHalf, from: twoThirdsWide, gives: oneQuarterWide, as: .topLeft, subAction: .topLeftQuarter)
+        assertTiled(.leftHalf, from: oneQuarterWide, gives: twoThirdsWide, as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testCyclingInsideQuarterStartsOverFromCustomSplitRatio() {
+        Defaults.horizontalSplitRatio.value = 60
+        let sixtyPercentWide = CGRect(x: 10, y: 470, width: 720, height: 450)
+
+        assertTiled(.leftHalf, from: sixtyPercentWide, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testCyclingInsideQuarterRecognizesGappedWindow() {
+        Defaults.gapSize.value = 20
+        let gappedTopLeftQuarter = GapCalculation.applyGaps(topLeftQuarter, dimension: .both, sharedEdges: [.right, .bottom], gapSize: 20, skipTopGap: false)
+
+        assertTiled(.leftHalf, from: gappedTopLeftQuarter,
+                    gives: CGRect(x: 10, y: 470, width: 800, height: 450), as: .topLeft, subAction: .topLeftQuarter)
+    }
+
+    func testQuarterStaysPutWhenRepeatedCommandsDoNotResize() {
+        for mode in [SubsequentExecutionMode.none, .acrossMonitor, .cycleMonitor] {
+            Defaults.subsequentExecutionMode.value = mode
+            assertTiled(.leftHalf, from: topLeftQuarter, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+            assertTiled(.topHalf, from: topLeftQuarter, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
+        }
+    }
+
+    func testQuarterStaysPutWhenNoCycleSizesAreSelected() {
+        let savedSelectedCycleSizes = Defaults.selectedCycleSizes.value
+        defer { Defaults.selectedCycleSizes.value = savedSelectedCycleSizes }
+        Defaults.cycleSizesIsChanged.enabled = true
+        Defaults.selectedCycleSizes.value = []
+
         assertTiled(.leftHalf, from: topLeftQuarter, gives: topLeftQuarter, as: .topLeft, subAction: .topLeftQuarter)
     }
 
-    func testRightHalfLeavesBottomRightQuarterAlone() {
-        assertTiled(.rightHalf, from: bottomRightQuarter, gives: bottomRightQuarter, as: .bottomRight, subAction: .bottomRightQuarter)
-    }
-
-    func testRepeatedTopHalfInsideQuarterDoesNotCycleHeight() {
+    func testRepeatedTopHalfInsideQuarterCyclesHeightWithoutHistory() {
         let params = params(for: .topHalf, windowRect: topLeftQuarter,
-                            lastAction: RectangleAction(action: .topHalf, subAction: .topLeftQuarter, rect: topLeftQuarter, count: 1))
+                            lastAction: RectangleAction(action: .topLeft, subAction: .topLeftQuarter, rect: topLeftQuarter, count: 5))
 
         let result = WindowCalculationFactory.topHalfCalculation.calculateRect(params)
 
-        XCTAssertEqual(result.rect, topLeftQuarter)
+        XCTAssertEqual(result.rect, CGRect(x: 10, y: 320, width: 600, height: 600))
+        XCTAssertEqual(result.resultingAction, .topLeft)
         XCTAssertEqual(result.subAction, .topLeftQuarter)
     }
 

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -8,6 +8,7 @@ The preferences window is purposefully slim, but there's a lot that can be modif
 - [Adjust Behavior on Repeated Commands](#adjust-behavior-on-repeated-commands)
 - [Cycle thirds on repeated Center Half commands](#cycle-thirds-on-repeated-center-half-commands)
 - [Resize on Directional Move](#resize-on-directional-move)
+- [Make the half actions tile like Windows or KDE](#make-the-half-actions-tile-like-windows-or-kde)
 - [Adjust macOS Ventura Stage Manager size](#adjust-macos-ventura-stage-manager-size)
 - [Enable Todo Mode](#enable-todo-mode)
 - [Only allow drag-to-snap when modifier keys are pressed](#only-allow-drag-to-snap-when-modifier-keys-are-pressed)
@@ -86,6 +87,19 @@ Note that if subsequent execution mode is set to cycle displays when this is ena
 
 ```bash
 defaults write com.knollsoft.Rectangle resizeOnDirectionalMove -bool true
+```
+
+## Make the half actions tile like Windows or KDE
+
+By default, Left Half, Right Half, Top Half and Bottom Half always give the window the full height or width of the screen. Enable this to have each of them only change its own axis and keep the other one, like the Win + arrow keys on Windows or keyboard tiling on KDE:
+
+- Left Half followed by Top Half puts the window in the top left quarter (so does Top Half followed by Left Half).
+- Inside a quarter, the action for the edge the window is docked to does nothing, and the action for the opposite edge expands the window along that axis: Bottom Half takes a top left quarter back to Left Half, Right Half takes it to Top Half.
+- The same goes for halves: Right Half followed by Left Half fills the screen.
+- Windows that are not tiled, and halves that get their own action again, behave as usual (repeated executions still cycle sizes or move across displays, depending on the setting for repeated commands).
+
+```bash
+defaults write com.knollsoft.Rectangle halvesPreserveOtherAxisSize -bool true
 ```
 
 ## Adjust macOS Ventura Stage Manager size

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -94,7 +94,8 @@ defaults write com.knollsoft.Rectangle resizeOnDirectionalMove -bool true
 By default, Left Half, Right Half, Top Half and Bottom Half always give the window the full height or width of the screen. Enable this to have each of them only change its own axis and keep the other one, like the Win + arrow keys on Windows or keyboard tiling on KDE:
 
 - Left Half followed by Top Half puts the window in the top left quarter (so does Top Half followed by Left Half).
-- Inside a quarter, the action for the edge the window is docked to does nothing, and the action for the opposite edge expands the window along that axis: Bottom Half takes a top left quarter back to Left Half, Right Half takes it to Top Half.
+- Inside a quarter, the action for the opposite edge expands the window along that axis: Bottom Half takes a top left quarter back to Left Half, Right Half takes it to Top Half.
+- Inside a quarter, the action for the edge the window is docked to cycles the window through the cycle sizes along that axis and keeps the other one: Left Half takes a top left quarter to two thirds wide, then one third wide, while Top Half does the same to its height. This follows the setting for repeated commands; when it does not resize, the window stays as it is.
 - The same goes for halves: Right Half followed by Left Half fills the screen.
 - Windows that are not tiled, and halves that get their own action again, behave as usual (repeated executions still cycle sizes or move across displays, depending on the setting for repeated commands).
 


### PR DESCRIPTION
## Summary

Adds an opt-in mode in which Left Half, Right Half, Top Half and Bottom Half only change the axis they belong to (Left/Right → width, Top/Bottom → height) and keep the window's size and position on the other axis — the way Win + arrow keys tile windows on Windows, or keyboard tiling works on KDE.

With it, the four half shortcuts are enough to reach every half and quarter: Left Half then Top Half lands in the top left quarter, Bottom Half from there expands back to Left Half, and Right Half then Left Half fills the screen.

Off by default (`halvesPreserveOtherAxisSize`); nothing changes unless it is enabled.

Related: discussions #665 and #811 (where this was asked for, and you said you would be fine merging a good PR for it configurable via Terminal command), and #144. This is the narrow version discussed there: no separate "Windows mode" and no preset or extra shortcuts — the existing half actions simply take the window's current position into account, the logic lives in one self-contained class, and everything sits behind a single default.

## Behavior when enabled

Each half action looks at where the window currently sits along its own axis and leaves the other axis exactly as it is:

| Window along the action's axis | Left Half / Top Half | Right Half / Bottom Half |
|---|---|---|
| spans the whole axis (or has a size no half action produces) | dock to the left / top edge | dock to the right / bottom edge |
| docked to the left / top edge | inside a quarter: cycle sizes along this axis, keep the other (if the repeated-command setting resizes; otherwise no change); plain half: repeats as today (cycle sizes, move across displays, …) | expand to the whole axis |
| docked to the right / bottom edge | expand to the whole axis | inside a quarter: cycle sizes along this axis, keep the other; plain half: repeats as today |

Some sequences:

| Sequence | Result |
|---|---|
| Left Half, Top Half (or Top Half, Left Half) | top left quarter |
| top left quarter, Bottom Half | Left Half |
| top left quarter, Right Half | Top Half |
| top left quarter, Left Half | ⅔ wide top left quarter, then ⅓, then ½ again (height unchanged; with the default cycle sizes) |
| top left quarter, Top Half | ⅔ high top left quarter, then ⅓, then ½ again (width unchanged) |
| Right Half, Left Half | full width and height (same as Maximize, including its gap setting) |
| Left Half, Left Half | as today: cycle 1/2 → 2/3 → 1/3, move across displays, or nothing, depending on the repeated-command setting |
| untiled (floating, centered, …) window, any half | as today |

Untiled windows and repeated executions of a plain half deliberately fall through to the existing code, so the feature never changes what the repeated-command setting does. Inside a quarter the cycle is driven by the window's current size (the size after the one it has now, or the first selected size if it has none of them), not by the execution count, because the history there holds the corner action.

## How it works

- `HalvesPreserveOtherAxisSize.rect(for:)` recognizes the window's state on each axis purely from its current frame: an axis counts as "docked" when the window's origin and extent match (within 10 pt, for apps that resize in character cells) an edge-docked rect that a half action produces on that screen — at the active split ratio or any cycle size, with or without gaps applied. Anything else counts as "whole axis". It returns `nil` whenever the existing logic should run.
- `LeftRightHalfCalculation`, `TopHalfCalculation` and `BottomHalfCalculation` consult it first when the default is enabled; otherwise they are untouched.
- The result reports the geometrically equivalent action (`.topLeft` + `.topLeftQuarter`, `.leftHalf`, `.maximize`, …) as `resultingAction` / `subAction`, so gaps and the window history behave exactly as if that action had been executed. For that, `WindowCalculation.calculate` now forwards `RectResult.resultingAction` instead of ignoring it — every subclass that sets it already overrides `calculate`, so this is not a behavior change by itself.
- Drag to snap goes through the same calculations, so the footprint preview matches the snap. With the default unsnap-restore the dragged window is back at its original size when it snaps, so snapping behaves as before.

## Testing

- `HalvesPreserveOtherAxisSizeTests` (38 cases): every state transition, cycling inside quarters (both axes, custom cycle-size selection, non-50 % split ratio, gaps, the non-resizing repeated-command modes, no selected sizes), fallback to the existing logic for untiled windows and repeated plain halves, cycled 2/3 and 1/3 columns/rows, non-50 % split ratios, gaps (including the skip-top-edge option), matching tolerance, and the disabled path.
- Full suite on top of 64a9186 (v0.99): 272 tests, 0 failures.
- Used daily on macOS 26.6 since 2026-08-21 with 5 px gaps, 50 % splits and the default repeated-command setting (resize).

## Try it

A notarized Apple-silicon build of this branch (unofficial, signed with my own Developer ID) is attached to https://github.com/maxing-labs/Rectangle/releases/tag/v0.99-halvesPreserveOtherAxis-b109 — install, then tick the checkbox at the bottom of the Extras popover in Settings.

## Docs / UI

- `TerminalCommands.md`: new section "Make the half actions tile like Windows or KDE" with the `defaults write` command.
- The second commit moves the ordering of the selected cycle sizes from `RepeatedExecutionsCalculation.sortedCycleSizes()` into `CycleSize.sortedSelectedSizes()` so the new code can share it; the protocol extension just delegates to it.
- Settings gets a "Half actions preserve the window's size on the other axis" checkbox, unchecked by default, at the bottom of the Extras popover in the General tab (below the side split ratio rows, as requested), with a tooltip describing the Left Half → Top Half → Bottom Half round trip; the two strings are registered in `Main.xcstrings`. Happy to drop the checkbox and keep this terminal-only if you prefer.




