### PR TITLE
Let a repeated Maximize restore the window's previous size and position (opt-in)

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		98C2755E231FF6A9009B9292 /* EventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C2755D231FF6A9009B9292 /* EventMonitor.swift */; };
 		98C27561231FFA5F009B9292 /* SnappingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C27560231FFA5F009B9292 /* SnappingManager.swift */; };
 		98C275672322E2DA009B9292 /* WindowHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C275662322E2DA009B9292 /* WindowHistory.swift */; };
+		7B4C0A212F1B000100C0FFEE /* RepeatedMaximizeRestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4C0A202F1B000100C0FFEE /* RepeatedMaximizeRestore.swift */; };
 		98C6DEF023CE191700CC0C1E /* GapCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C6DEEF23CE191700CC0C1E /* GapCalculation.swift */; };
 		98C97FFD25893B040061F01F /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C97FFC25893B040061F01F /* Config.swift */; };
 		98D1441324560B1E0090C603 /* AlertUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D1441224560B1E0090C603 /* AlertUtil.swift */; };
@@ -368,6 +369,7 @@
 		98C2755D231FF6A9009B9292 /* EventMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMonitor.swift; sourceTree = "<group>"; };
 		98C27560231FFA5F009B9292 /* SnappingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnappingManager.swift; sourceTree = "<group>"; };
 		98C275662322E2DA009B9292 /* WindowHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowHistory.swift; sourceTree = "<group>"; };
+		7B4C0A202F1B000100C0FFEE /* RepeatedMaximizeRestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatedMaximizeRestore.swift; sourceTree = "<group>"; };
 		98C6DEEF23CE191700CC0C1E /* GapCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GapCalculation.swift; sourceTree = "<group>"; };
 		98C97FFC25893B040061F01F /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		98D1441224560B1E0090C603 /* AlertUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertUtil.swift; sourceTree = "<group>"; };
@@ -716,6 +718,7 @@
 				9824703C22B13C7E0037B409 /* AccessibilityElement.swift */,
 				9824703E22B13FBC0037B409 /* ScreenDetection.swift */,
 				98C275662322E2DA009B9292 /* WindowHistory.swift */,
+				7B4C0A202F1B000100C0FFEE /* RepeatedMaximizeRestore.swift */,
 				9824704022B186D00037B409 /* WindowManager.swift */,
 				982470422EFA00010037B409 /* WindowManager+CooperativeCornerResize.swift */,
 				AA49DD1029B8C1B100690E13 /* TitleBarManager.swift */,
@@ -1089,6 +1092,7 @@
 				D04CE31027817ABE00BD47B3 /* BottomRightNinthCalculation.swift in Sources */,
 				98A009B92512538D00CFBF0C /* TopRightSixthCalculation.swift in Sources */,
 				98C275672322E2DA009B9292 /* WindowHistory.swift in Sources */,
+				7B4C0A212F1B000100C0FFEE /* RepeatedMaximizeRestore.swift in Sources */,
 				7BE578F32EFE11010083DAE3 /* ActiveSideSplitRatios.swift in Sources */,
 				9821403722B3D16700ABFB3F /* MaximizeHeightCalculation.swift in Sources */,
 				9824704122B186D00037B409 /* WindowManager.swift in Sources */,

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -25,6 +25,7 @@ class Defaults {
     static let centeredDirectionalMove = OptionalBoolDefault(key: "centeredDirectionalMove")
     static let resizeOnDirectionalMove = BoolDefault(key: "resizeOnDirectionalMove")
     static let halvesPreserveOtherAxisSize = BoolDefault(key: "halvesPreserveOtherAxisSize")
+    static let repeatedMaximizeRestoresPrevious = BoolDefault(key: "repeatedMaximizeRestoresPrevious")
     static let moveFixedSizeToEdge = IntEnumDefault<EdgeAlignment>(key: "moveFixedSizeToEdge", defaultValue: .edgesAndCorners)
     static let ignoredSnapAreas = IntDefault(key: "ignoredSnapAreas")
     static let traverseSingleScreen = OptionalBoolDefault(key: "traverseSingleScreen")
@@ -133,6 +134,7 @@ class Defaults {
         centeredDirectionalMove,
         resizeOnDirectionalMove,
         halvesPreserveOtherAxisSize,
+        repeatedMaximizeRestoresPrevious,
         ignoredSnapAreas,
         traverseSingleScreen,
         minimumWindowWidth,

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -51,6 +51,7 @@ class SettingsViewController: NSViewController {
     private var greenButtonOverrideCheckbox: NSButton?
     private var autoMaximizeCheckbox: NSButton?
     private var halvesPreserveOtherAxisSizeCheckbox: NSButton?
+    private var repeatedMaximizeRestoresPreviousCheckbox: NSButton?
     
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
         let newSetting: Bool = sender.state == .on
@@ -191,6 +192,10 @@ class SettingsViewController: NSViewController {
 
     @objc func toggleHalvesPreserveOtherAxisSize(_ sender: NSButton) {
         Defaults.halvesPreserveOtherAxisSize.enabled = sender.state == .on
+    }
+
+    @objc func toggleRepeatedMaximizeRestoresPrevious(_ sender: NSButton) {
+        Defaults.repeatedMaximizeRestoresPrevious.enabled = sender.state == .on
     }
 
     @IBAction func toggleTodoMode(_ sender: NSButton) {
@@ -975,6 +980,15 @@ class SettingsViewController: NSViewController {
             mainStackView.addArrangedSubview(halvesCheckbox)
             halvesPreserveOtherAxisSizeCheckbox = halvesCheckbox
 
+            let repeatedMaximizeCheckbox = NSButton(checkboxWithTitle: NSLocalizedString("Repeated Maximize restores the previous size and position", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleRepeatedMaximizeRestoresPrevious(_:)))
+            repeatedMaximizeCheckbox.state = Defaults.repeatedMaximizeRestoresPrevious.enabled ? .on : .off
+            repeatedMaximizeCheckbox.toolTip = NSLocalizedString("After Rectangle maximizes or almost maximizes a window, executing the same action again moves the window back to its previous size and position.", tableName: "Main", value: "", comment: "")
+            repeatedMaximizeCheckbox.translatesAutoresizingMaskIntoConstraints = false
+            repeatedMaximizeCheckbox.alignment = .left
+
+            mainStackView.addArrangedSubview(repeatedMaximizeCheckbox)
+            repeatedMaximizeRestoresPreviousCheckbox = repeatedMaximizeCheckbox
+
             NSLayoutConstraint.activate([
                 headerLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
                 splitRatioHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
@@ -1192,6 +1206,7 @@ class SettingsViewController: NSViewController {
         autoMaximizeCheckbox?.state = Defaults.autoMaximize.userDisabled ? .off : .on
 
         halvesPreserveOtherAxisSizeCheckbox?.state = Defaults.halvesPreserveOtherAxisSize.enabled ? .on : .off
+        repeatedMaximizeRestoresPreviousCheckbox?.state = Defaults.repeatedMaximizeRestoresPrevious.enabled ? .on : .off
 
         if StageUtil.stageCapable {
             stageSlider.intValue = Int32(Defaults.stageSize.value)

--- a/Rectangle/RepeatedMaximizeRestore.swift
+++ b/Rectangle/RepeatedMaximizeRestore.swift
@@ -1,0 +1,67 @@
+//
+//  RepeatedMaximizeRestore.swift
+//  Rectangle
+//
+
+import Foundation
+
+/// Opt-in (`repeatedMaximizeRestoresPrevious`): executing Maximize or Almost Maximize on a window that
+/// Rectangle has just put in that state restores the frame the window had right before, instead of
+/// doing nothing.
+///
+/// Consulted by `MaximizeCalculation` and `AlmostMaximizeCalculation` before they calculate their own
+/// rect. The restore is reported as `.restore`, so the next execution of the action maximizes the
+/// window again, calculated from scratch.
+enum RepeatedMaximizeRestore {
+    
+    static func applies(to action: WindowAction) -> Bool {
+        action == .maximize || action == .almostMaximize
+    }
+    
+    /// The result to use instead of maximizing, or nil to let the calculation proceed as usual.
+    /// Records the frame to come back to whenever the window is about to be maximized.
+    static func calculate(_ params: WindowCalculationParameters) -> WindowCalculationResult? {
+        guard Defaults.repeatedMaximizeRestoresPrevious.enabled,
+              applies(to: params.action),
+              let windowId = params.window.id
+        else { return nil }
+        
+        if let previousRect = restoreRect(for: params.action,
+                                          windowRect: params.window.rect,
+                                          lastAction: params.lastAction,
+                                          preMaximizeRect: AppDelegate.windowHistory.preMaximizeRects[windowId]) {
+            return WindowCalculationResult(rect: previousRect,
+                                           screen: params.usableScreens.currentScreen,
+                                           resultingAction: .restore)
+        }
+        
+        AppDelegate.windowHistory.preMaximizeRects[windowId] = params.window.rect
+        return nil
+    }
+    
+    /// The frame to restore instead of executing `action`, or nil to execute it normally.
+    ///
+    /// Restores only when `action` is the action that last positioned the window, the window has not
+    /// been moved since, and a frame from before was recorded for it. `windowRect` and the result are
+    /// normalized (screen flipped) rects, `lastAction` holds the accessibility rect it resulted in.
+    static func restoreRect(for action: WindowAction,
+                            windowRect: CGRect,
+                            lastAction: RectangleAction?,
+                            preMaximizeRect: CGRect?) -> CGRect? {
+        guard Defaults.repeatedMaximizeRestoresPrevious.enabled,
+              applies(to: action),
+              let lastAction,
+              lastAction.action == action,
+              lastAction.rect.screenFlipped == windowRect,
+              let preMaximizeRect
+        else { return nil }
+        return preMaximizeRect
+    }
+    
+    static func restoreRect(for action: WindowAction, windowId: CGWindowID, windowRect: CGRect) -> CGRect? {
+        restoreRect(for: action,
+                    windowRect: windowRect.screenFlipped,
+                    lastAction: AppDelegate.windowHistory.lastRectangleActions[windowId],
+                    preMaximizeRect: AppDelegate.windowHistory.preMaximizeRects[windowId])
+    }
+}

--- a/Rectangle/ShortcutManager.swift
+++ b/Rectangle/ShortcutManager.swift
@@ -222,7 +222,8 @@ class ShortcutManager {
                 return
             }
 
-            if isRepeatAction(parameters: parameters, windowElement: windowElement, windowId: windowId) {
+            if isRepeatAction(parameters: parameters, windowElement: windowElement, windowId: windowId),
+               RepeatedMaximizeRestore.restoreRect(for: parameters.action, windowId: windowId, windowRect: windowElement.frame) == nil {
                 if let screen = ScreenDetection().detectScreens(using: windowElement)?.adjacentScreens?.next{
                     parameters = ExecutionParameters(parameters.action, updateRestoreRect: parameters.updateRestoreRect, screen: screen, windowElement: windowElement, windowId: windowId)
                     // Bypass any other subsequent action by removing the last action

--- a/Rectangle/WindowCalculation/AlmostMaximizeCalculation.swift
+++ b/Rectangle/WindowCalculation/AlmostMaximizeCalculation.swift
@@ -19,6 +19,10 @@ class AlmostMaximizeCalculation: WindowCalculation {
             : CGFloat(defaultWidth)
     }
     
+    override func calculate(_ params: WindowCalculationParameters) -> WindowCalculationResult? {
+        RepeatedMaximizeRestore.calculate(params) ?? super.calculate(params)
+    }
+    
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
 
         let visibleFrameOfScreen = params.visibleFrameOfScreen

--- a/Rectangle/WindowCalculation/MaximizeCalculation.swift
+++ b/Rectangle/WindowCalculation/MaximizeCalculation.swift
@@ -4,6 +4,10 @@ import Foundation
 
 class MaximizeCalculation: WindowCalculation {
 
+    override func calculate(_ params: WindowCalculationParameters) -> WindowCalculationResult? {
+        RepeatedMaximizeRestore.calculate(params) ?? super.calculate(params)
+    }
+
     override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
         let visibleFrameOfScreen = params.visibleFrameOfScreen
 

--- a/Rectangle/WindowHistory.swift
+++ b/Rectangle/WindowHistory.swift
@@ -8,4 +8,6 @@ class WindowHistory {
     
     var lastRectangleActions = [CGWindowID: RectangleAction]() // the last window frame that this app positioned
     
+    var preMaximizeRects = [CGWindowID: CGRect]() // the normalized window frame right before this app last maximized / almost maximized it
+    
 }

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -8533,6 +8533,9 @@
         }
       }
     },
+    "After Rectangle maximizes or almost maximizes a window, executing the same action again moves the window back to its previous size and position." : {
+
+    },
     "agt-UL-0e3.title" : {
       "comment" : "Class = \"NSMenuItem\"; title = \"Use Default\"; ObjectID = \"agt-UL-0e3\";",
       "extractionState" : "manual",
@@ -37498,6 +37501,9 @@
           }
         }
       }
+    },
+    "Repeated Maximize restores the previous size and position" : {
+
     },
     "Resize adjacent windows when cycling side or corner shortcuts" : {
 

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -4965,3 +4965,166 @@ class HalvesPreserveOtherAxisSizeTests: XCTestCase {
     }
 }
 
+class RepeatedMaximizeRestoreTests: XCTestCase {
+
+    private var savedRepeatedMaximizeRestoresPrevious = false
+
+    private let windowId = CGWindowID(24_680)
+    private let screen = RepeatedMaximizeTestScreen(frame: CGRect(x: 0, y: 0, width: 1440, height: 900))
+    private let previousFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+    private let maximizedFrame = CGRect(x: 0, y: 25, width: 1440, height: 875)
+    private let almostMaximizedFrame = CGRect(x: 72, y: 69, width: 1296, height: 788)
+
+    override func setUp() {
+        super.setUp()
+        savedRepeatedMaximizeRestoresPrevious = Defaults.repeatedMaximizeRestoresPrevious.enabled
+        Defaults.repeatedMaximizeRestoresPrevious.enabled = true
+    }
+
+    override func tearDown() {
+        Defaults.repeatedMaximizeRestoresPrevious.enabled = savedRepeatedMaximizeRestoresPrevious
+        AppDelegate.windowHistory.preMaximizeRects.removeValue(forKey: windowId)
+        AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: windowId)
+        super.tearDown()
+    }
+
+    func testAppliesToMaximizeAndAlmostMaximizeOnly() {
+        XCTAssertTrue(RepeatedMaximizeRestore.applies(to: .maximize))
+        XCTAssertTrue(RepeatedMaximizeRestore.applies(to: .almostMaximize))
+        XCTAssertFalse(RepeatedMaximizeRestore.applies(to: .maximizeHeight))
+        XCTAssertFalse(RepeatedMaximizeRestore.applies(to: .leftHalf))
+        XCTAssertFalse(RepeatedMaximizeRestore.applies(to: .restore))
+    }
+
+    func testRepeatedMaximizeRestoresThePreviousFrame() {
+        XCTAssertEqual(restoreRect(.maximize, window: maximizedFrame, last: .maximize, lastRect: maximizedFrame), previousFrame)
+        XCTAssertEqual(restoreRect(.almostMaximize, window: almostMaximizedFrame, last: .almostMaximize, lastRect: almostMaximizedFrame), previousFrame)
+    }
+
+    func testDoesNothingWhenDisabled() {
+        Defaults.repeatedMaximizeRestoresPrevious.enabled = false
+        XCTAssertNil(restoreRect(.maximize, window: maximizedFrame, last: .maximize, lastRect: maximizedFrame))
+    }
+
+    func testDoesNothingWhenTheLastActionWasAnotherOne() {
+        XCTAssertNil(restoreRect(.maximize, window: almostMaximizedFrame, last: .almostMaximize, lastRect: almostMaximizedFrame))
+        XCTAssertNil(restoreRect(.almostMaximize, window: maximizedFrame, last: .maximize, lastRect: maximizedFrame))
+        XCTAssertNil(restoreRect(.maximize, window: maximizedFrame, last: .leftHalf, lastRect: maximizedFrame))
+    }
+
+    func testDoesNothingWithoutHistory() {
+        XCTAssertNil(restoreRect(.maximize, window: maximizedFrame, last: nil, lastRect: nil))
+        XCTAssertNil(restoreRect(.maximize, window: maximizedFrame, last: .maximize, lastRect: maximizedFrame, previous: nil))
+    }
+
+    func testDoesNothingWhenTheWindowMovedSinceTheLastAction() {
+        let moved = maximizedFrame.offsetBy(dx: 0, dy: 10)
+        XCTAssertNil(restoreRect(.maximize, window: moved, last: .maximize, lastRect: maximizedFrame))
+    }
+
+    func testIgnoresOtherActions() {
+        XCTAssertNil(restoreRect(.maximizeHeight, window: maximizedFrame, last: .maximizeHeight, lastRect: maximizedFrame))
+    }
+
+    // MARK: - Calculation entry point
+
+    func testRecordsThePreviousFrameAndFallsThroughWhenMaximizing() {
+        let params = calculationParams(.maximize, window: previousFrame, last: nil)
+
+        XCTAssertNil(RepeatedMaximizeRestore.calculate(params))
+        XCTAssertEqual(AppDelegate.windowHistory.preMaximizeRects[windowId], previousFrame.screenFlipped)
+    }
+
+    func testRestoresAsTheRestoreAction() {
+        AppDelegate.windowHistory.preMaximizeRects[windowId] = previousFrame.screenFlipped
+        let params = calculationParams(.maximize, window: maximizedFrame, last: .maximize, lastRect: maximizedFrame)
+
+        let result = RepeatedMaximizeRestore.calculate(params)
+
+        XCTAssertEqual(result?.rect, previousFrame.screenFlipped)
+        XCTAssertEqual(result?.resultingAction, .restore)
+    }
+
+    func testAlmostMaximizeRestoresTheSameWay() {
+        AppDelegate.windowHistory.preMaximizeRects[windowId] = previousFrame.screenFlipped
+        let params = calculationParams(.almostMaximize, window: almostMaximizedFrame, last: .almostMaximize, lastRect: almostMaximizedFrame)
+
+        let result = RepeatedMaximizeRestore.calculate(params)
+
+        XCTAssertEqual(result?.rect, previousFrame.screenFlipped)
+        XCTAssertEqual(result?.resultingAction, .restore)
+    }
+
+    func testMaximizesAgainAfterARestore() {
+        AppDelegate.windowHistory.preMaximizeRects[windowId] = maximizedFrame.screenFlipped
+        // The restore reported .restore, so the window's last action is no longer the maximize.
+        let params = calculationParams(.maximize, window: previousFrame, last: .restore, lastRect: previousFrame)
+
+        XCTAssertNil(RepeatedMaximizeRestore.calculate(params))
+        XCTAssertEqual(AppDelegate.windowHistory.preMaximizeRects[windowId], previousFrame.screenFlipped)
+    }
+
+    func testRecordsNothingWhenDisabled() {
+        Defaults.repeatedMaximizeRestoresPrevious.enabled = false
+        let params = calculationParams(.maximize, window: previousFrame, last: nil)
+
+        XCTAssertNil(RepeatedMaximizeRestore.calculate(params))
+        XCTAssertNil(AppDelegate.windowHistory.preMaximizeRects[windowId])
+    }
+
+    func testMaximizeCalculationRestoresThroughTheHelper() {
+        AppDelegate.windowHistory.preMaximizeRects[windowId] = previousFrame.screenFlipped
+        let params = calculationParams(.maximize, window: maximizedFrame, last: .maximize, lastRect: maximizedFrame)
+
+        let result = WindowCalculationFactory.maximizeCalculation.calculate(params)
+
+        XCTAssertEqual(result?.rect, previousFrame.screenFlipped)
+        XCTAssertEqual(result?.resultingAction, .restore)
+    }
+
+    // MARK: - Helpers
+
+    private func restoreRect(_ action: WindowAction,
+                             window: CGRect,
+                             last: WindowAction?,
+                             lastRect: CGRect?,
+                             previous: CGRect? = CGRect(x: 100, y: 100, width: 800, height: 600)) -> CGRect? {
+        RepeatedMaximizeRestore.restoreRect(for: action,
+                                            windowRect: window.screenFlipped,
+                                            lastAction: rectangleAction(last, lastRect),
+                                            preMaximizeRect: previous)
+    }
+
+    private func calculationParams(_ action: WindowAction,
+                                   window: CGRect,
+                                   last: WindowAction?,
+                                   lastRect: CGRect? = nil) -> WindowCalculationParameters {
+        WindowCalculationParameters(window: Window(id: windowId, rect: window.screenFlipped),
+                                    usableScreens: UsableScreens(currentScreen: screen, numScreens: 1),
+                                    action: action,
+                                    lastAction: rectangleAction(last, lastRect),
+                                    ignoreTodo: false)
+    }
+
+    private func rectangleAction(_ action: WindowAction?, _ rect: CGRect?) -> RectangleAction? {
+        action.map { RectangleAction(action: $0, subAction: nil, rect: rect ?? .null, count: 1) }
+    }
+}
+
+private final class RepeatedMaximizeTestScreen: NSScreen {
+    private let testFrame: CGRect
+
+    init(frame: CGRect) {
+        testFrame = frame
+        super.init()
+    }
+
+    override var frame: NSRect { testFrame }
+    override var visibleFrame: NSRect { testFrame }
+    override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
+    override var hash: Int { ObjectIdentifier(self).hashValue }
+
+    override func isEqual(_ object: Any?) -> Bool {
+        (object as AnyObject?) === self
+    }
+}

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -13,6 +13,7 @@ The preferences window is purposefully slim, but there's a lot that can be modif
 - [Enable Todo Mode](#enable-todo-mode)
 - [Only allow drag-to-snap when modifier keys are pressed](#only-allow-drag-to-snap-when-modifier-keys-are-pressed)
 - [Almost Maximize](#almost-maximize)
+- [Repeated Maximize restores the previous size and position](#repeated-maximize-restores-the-previous-size-and-position)
 - [Add an extra centering command with custom size](#add-an-extra-centering-command-with-custom-size)
 - [Add extra "ninths" sizing commands](#add-extra-ninths-sizing-commands)
 - [Add extra "eighths" sizing commands](#add-extra-eighths-sizing-commands)
@@ -154,6 +155,16 @@ defaults write com.knollsoft.Rectangle almostMaximizeHeight -float <VALUE_BETWEE
 
 ```bash
 defaults write com.knollsoft.Rectangle almostMaximizeWidth -float <VALUE_BETWEEN_0_&_1>
+```
+
+## Repeated Maximize restores the previous size and position
+
+By default, executing "Maximize" or "Almost Maximize" on a window that is already in that state does nothing. With this enabled, executing the same action again on a window that Rectangle has just maximized (or almost maximized) moves the window back to the size and position it had right before, so the shortcut toggles between the two. A window that was moved or resized by other means in between is maximized as usual.
+
+This can also be toggled with the "Repeated Maximize restores the previous size and position" checkbox at the bottom of the "Extras" popover in the General tab of the Settings window.
+
+```bash
+defaults write com.knollsoft.Rectangle repeatedMaximizeRestoresPrevious -bool true
 ```
 
 ## Add an extra centering command with custom size


### PR DESCRIPTION
## Summary

Adds an opt-in mode in which running **Maximize** (or Almost Maximize) again on a window Rectangle has just maximized moves it back to the size and position it had right before, so the shortcut toggles between maximized and the previous frame — the way toggling maximize works on KDE.

Today repeating Maximize on an already-maximized window does nothing, and getting the window back means the Restore shortcut, which also undoes every other Rectangle action since you last placed the window. This keeps Maximize and Restore as they are and only adds "press again to go back", behind a single default.

Off by default (`repeatedMaximizeRestoresPrevious`); nothing changes unless it is enabled.

Related: discussion #894 (requested there; you implemented it in Rectangle Pro). This is the narrow free-Rectangle version — no new shortcut, one self-contained type, one default. Same shape as #1824.

## Behavior when enabled

- Maximize on a window Rectangle just maximized → the window returns to its previous frame. Maximize again → maximized again. (Same for Almost Maximize.)
- Only the *same* action repeated restores: Maximize then Almost Maximize (or the reverse) switches between the two, as today.
- A window maximized by something else, or moved/resized between the two presses, is maximized as usual — the previous frame is used only when Maximize was the last thing Rectangle did to the window and it has not moved since.
- Restoring reuses the Restore action's semantics (clears the window's last-action history; leaves the Restore rect untouched).
- With the repeated-command setting on "Cycle through displays", the restore takes precedence over display cycling for these two actions.
- Works from the shortcut, the menu bar and the URL scheme.

## How it works

- The frame is captured in `WindowHistory.preMaximizeRects` whenever Maximize / Almost Maximize runs.
- The repeat is recognized from the window history exactly like the title-bar double-click restore (`TitleBarManager`): the window's last action is the same action and it has not moved since. No new geometry or heuristics.
- All the decision logic lives in one new type, `RepeatedMaximizeRestore`, consulted in `WindowManager.execute` (and in the display-cycling shortcut path).

## Docs / Tests

- Documented in `TerminalCommands.md`, and exposed as a checkbox at the bottom of the General → **Extras** popover (same place as #1824; title and tooltip registered in `Main.xcstrings`).
- 7 unit tests (`RepeatedMaximizeRestoreTests`); the full suite is green.

I'm happy to drop the checkbox and keep it Terminal-only if you'd prefer, like some of the other hidden defaults.
