### PR TITLE
Make Screen Edge Gap setting editable in UI

### DIFF
--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -42,8 +42,9 @@ class Defaults {
     static let screenEdgeGapTop = FloatDefault(key: "screenEdgeGapTop", defaultValue: 0)
     static let screenEdgeGapBottom = FloatDefault(key: "screenEdgeGapBottom", defaultValue: 0)
     static let screenEdgeGapLeft = FloatDefault(key: "screenEdgeGapLeft", defaultValue: 0)
-    static let screenEdgeGapRight = FloatDefault(key: "screenEdgeGapRight", defaultValue: 0)
-    static let screenEdgeGapsOnMainScreenOnly = BoolDefault(key: "screenEdgeGapsOnMainScreenOnly")
+    static let screenEdgeGapRight = FloatDefault(key: "screenEdgeGapRight", defaultValue: 370)
+    static let screenEdgeGapRightEnabled = BoolDefault(key: "screenEdgeGapRightEnabled")
+    static let screenEdgeGapsOnMainScreenOnly = BoolDefault(key: "screenEdgeGapsOnMainScreenOnly", defaultValue: true)
     static let screenEdgeGapTopNotch = FloatDefault(key: "screenEdgeGapTopNotch", defaultValue: 0)
     static let lastVersion = StringDefault(key: "lastVersion")
     static let installVersion = StringDefault(key: "installVersion")
@@ -148,6 +149,7 @@ class Defaults {
         screenEdgeGapBottom,
         screenEdgeGapLeft,
         screenEdgeGapRight,
+        screenEdgeGapRightEnabled,
         screenEdgeGapsOnMainScreenOnly,
         screenEdgeGapTopNotch,
         showAllActionsInMenu,
@@ -244,9 +246,13 @@ class BoolDefault: Default {
         }
     }
     
-    init(key: String) {
+    init(key: String, defaultValue: Bool = false) {
         self.key = key
-        enabled = UserDefaults.standard.bool(forKey: key)
+        if UserDefaults.standard.object(forKey: key) == nil {
+            enabled = defaultValue
+        } else {
+            enabled = UserDefaults.standard.bool(forKey: key)
+        }
         initialized = true
     }
     

--- a/Rectangle/PrefsWindow/SettingsViewController.swift
+++ b/Rectangle/PrefsWindow/SettingsViewController.swift
@@ -5,6 +5,10 @@ import ServiceManagement
 import Sparkle
 import MASShortcut
 
+private class FlippedView: NSView {
+    override var isFlipped: Bool { true }
+}
+
 class SettingsViewController: NSViewController {
         
     @IBOutlet weak var launchOnLoginCheckbox: NSButton!
@@ -51,6 +55,7 @@ class SettingsViewController: NSViewController {
     private var greenButtonOverrideCheckbox: NSButton?
     private var autoMaximizeCheckbox: NSButton?
     private var halvesPreserveOtherAxisSizeCheckbox: NSButton?
+    private var rightScreenEdgeGapField: AutoSaveFloatField?
     
     @IBAction func toggleLaunchOnLogin(_ sender: NSButton) {
         let newSetting: Bool = sender.state == .on
@@ -128,6 +133,17 @@ class SettingsViewController: NSViewController {
 
     @objc func toggleCyclingOverlapOffset(_ sender: NSButton) {
         Defaults.cyclingOverlapOffset.enabled = sender.state == .on
+    }
+
+    @objc func toggleScreenEdgeGapRight(_ sender: NSButton) {
+        let enabled = sender.state == .on
+        Defaults.screenEdgeGapRightEnabled.enabled = enabled
+        rightScreenEdgeGapField?.isEnabled = enabled
+        rightScreenEdgeGapField?.isEditable = enabled
+    }
+
+    @objc func toggleScreenEdgeGapsOnMainScreenOnly(_ sender: NSButton) {
+        Defaults.screenEdgeGapsOnMainScreenOnly.enabled = sender.state == .on
     }
 
     @objc func setCornerCycleExpansionAxis(_ sender: NSButton) {
@@ -323,6 +339,17 @@ class SettingsViewController: NSViewController {
             smallerWidthLabel.alignment = .right
             let widthStepLabel = NSTextField(labelWithString: NSLocalizedString("Width Step (px)", tableName: "Main", value: "", comment: ""))
             widthStepLabel.alignment = .right
+            let screenEdgeGapsHeaderLabel = NSTextField(labelWithString: NSLocalizedString("Right edge gap", tableName: "Main", value: "", comment: ""))
+            screenEdgeGapsHeaderLabel.font = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize)
+            screenEdgeGapsHeaderLabel.alignment = .center
+            screenEdgeGapsHeaderLabel.translatesAutoresizingMaskIntoConstraints = false
+            let screenEdgeGapsHintLabel = NSTextField(wrappingLabelWithString: NSLocalizedString("Reserve space along the right side before Rectangle calculates window sizes. This can e.g. keep notification banners visible.", tableName: "Main", value: "", comment: ""))
+            screenEdgeGapsHintLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+            screenEdgeGapsHintLabel.textColor = .secondaryLabelColor
+            screenEdgeGapsHintLabel.alignment = .center
+            screenEdgeGapsHintLabel.translatesAutoresizingMaskIntoConstraints = false
+            let rightScreenEdgeGapLabel = NSTextField(labelWithString: NSLocalizedString("Gap width (px)", tableName: "Main", value: "", comment: ""))
+            rightScreenEdgeGapLabel.alignment = .right
             
             let topVerticalThirdLabel = NSTextField(labelWithString: NSLocalizedString("Top Third", tableName: "Main", value: "", comment: ""))
             topVerticalThirdLabel.alignment = .right
@@ -355,6 +382,7 @@ class SettingsViewController: NSViewController {
             largerWidthLabel.translatesAutoresizingMaskIntoConstraints = false
             smallerWidthLabel.translatesAutoresizingMaskIntoConstraints = false
             widthStepLabel.translatesAutoresizingMaskIntoConstraints = false
+            rightScreenEdgeGapLabel.translatesAutoresizingMaskIntoConstraints = false
             topVerticalThirdLabel.translatesAutoresizingMaskIntoConstraints = false
             middleVerticalThirdLabel.translatesAutoresizingMaskIntoConstraints = false
             bottomVerticalThirdLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -399,6 +427,30 @@ class SettingsViewController: NSViewController {
             integerFormatter.allowsFloats = false
             integerFormatter.minimum = 1
             widthStepField.formatter = integerFormatter
+
+            let screenEdgeGapFormatter = NumberFormatter()
+            screenEdgeGapFormatter.allowsFloats = false
+            screenEdgeGapFormatter.minimum = 0
+
+            let rightScreenEdgeGapField = AutoSaveFloatField(frame: NSRect(x: 0, y: 0, width: 160, height: 19))
+            rightScreenEdgeGapField.stringValue = String(Int(Defaults.screenEdgeGapRight.value))
+            rightScreenEdgeGapField.delegate = self
+            rightScreenEdgeGapField.defaults = Defaults.screenEdgeGapRight
+            rightScreenEdgeGapField.fallbackValue = 370
+            rightScreenEdgeGapField.translatesAutoresizingMaskIntoConstraints = false
+            rightScreenEdgeGapField.refusesFirstResponder = true
+            rightScreenEdgeGapField.alignment = .right
+            rightScreenEdgeGapField.formatter = screenEdgeGapFormatter
+            rightScreenEdgeGapField.isEnabled = Defaults.screenEdgeGapRightEnabled.enabled
+            rightScreenEdgeGapField.isEditable = Defaults.screenEdgeGapRightEnabled.enabled
+            rightScreenEdgeGapField.toolTip = NSLocalizedString("Leaves space along the right side of the usable screen area for notifications or other overlays.", tableName: "Main", value: "", comment: "")
+            self.rightScreenEdgeGapField = rightScreenEdgeGapField
+
+            let rightScreenEdgeGapCheckbox = NSButton(checkboxWithTitle: NSLocalizedString("Use right edge gap", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleScreenEdgeGapRight(_:)))
+            rightScreenEdgeGapCheckbox.state = Defaults.screenEdgeGapRightEnabled.enabled ? .on : .off
+            rightScreenEdgeGapCheckbox.translatesAutoresizingMaskIntoConstraints = false
+            rightScreenEdgeGapCheckbox.alignment = .left
+            rightScreenEdgeGapCheckbox.imageHugsTitle = true
 
             let splitRatioHeaderLabel = NSTextField(labelWithString: NSLocalizedString("Side Split Ratio", tableName: "Main", value: "", comment: ""))
             splitRatioHeaderLabel.font = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize)
@@ -683,6 +735,13 @@ class SettingsViewController: NSViewController {
             widthStepRow.spacing = 18
             widthStepRow.addArrangedSubview(widthStepLabel)
             widthStepRow.addArrangedSubview(widthStepField)
+
+            let rightScreenEdgeGapRow = NSStackView()
+            rightScreenEdgeGapRow.orientation = .horizontal
+            rightScreenEdgeGapRow.alignment = .centerY
+            rightScreenEdgeGapRow.spacing = 18
+            rightScreenEdgeGapRow.addArrangedSubview(rightScreenEdgeGapLabel)
+            rightScreenEdgeGapRow.addArrangedSubview(rightScreenEdgeGapField)
 
             let hSplitRow = NSStackView()
             hSplitRow.orientation = .horizontal
@@ -974,13 +1033,29 @@ class SettingsViewController: NSViewController {
             halvesCheckbox.translatesAutoresizingMaskIntoConstraints = false
             halvesCheckbox.alignment = .left
 
+            let screenEdgeGapsOnMainScreenOnlyCheckbox = NSButton(checkboxWithTitle: NSLocalizedString("Only use on main display", tableName: "Main", value: "", comment: ""), target: self, action: #selector(toggleScreenEdgeGapsOnMainScreenOnly(_:)))
+            screenEdgeGapsOnMainScreenOnlyCheckbox.state = Defaults.screenEdgeGapsOnMainScreenOnly.enabled ? .on : .off
+            screenEdgeGapsOnMainScreenOnlyCheckbox.toolTip = NSLocalizedString("When enabled, screen edge gaps are ignored on secondary displays.", tableName: "Main", value: "", comment: "")
+            screenEdgeGapsOnMainScreenOnlyCheckbox.translatesAutoresizingMaskIntoConstraints = false
+            screenEdgeGapsOnMainScreenOnlyCheckbox.alignment = .left
+
             mainStackView.setCustomSpacing(8, after: vSplitRow)
             mainStackView.addArrangedSubview(halvesCheckbox)
             halvesPreserveOtherAxisSizeCheckbox = halvesCheckbox
+            mainStackView.setCustomSpacing(12, after: halvesCheckbox)
+            mainStackView.addArrangedSubview(screenEdgeGapsHeaderLabel)
+            mainStackView.setCustomSpacing(4, after: screenEdgeGapsHeaderLabel)
+            mainStackView.addArrangedSubview(screenEdgeGapsHintLabel)
+            mainStackView.setCustomSpacing(8, after: screenEdgeGapsHintLabel)
+            mainStackView.addArrangedSubview(rightScreenEdgeGapCheckbox)
+            mainStackView.addArrangedSubview(screenEdgeGapsOnMainScreenOnlyCheckbox)
+            mainStackView.addArrangedSubview(rightScreenEdgeGapRow)
 
             NSLayoutConstraint.activate([
                 headerLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
                 splitRatioHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
+                screenEdgeGapsHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
+                screenEdgeGapsHintLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor, constant: -20),
                 largerWidthLabel.widthAnchor.constraint(equalTo: smallerWidthLabel.widthAnchor),
                 smallerWidthLabel.widthAnchor.constraint(equalTo: widthStepLabel.widthAnchor),
                 widthStepLabel.widthAnchor.constraint(equalTo: topVerticalThirdLabel.widthAnchor),
@@ -1003,10 +1078,12 @@ class SettingsViewController: NSViewController {
                 stackBadgeToggleShortcutView.leadingAnchor.constraint(equalTo: sixteenthsCyclingShortcutView.leadingAnchor),
                 stackBadgeToggleShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 hSplitLabel.widthAnchor.constraint(equalTo: vSplitLabel.widthAnchor),
+                vSplitLabel.widthAnchor.constraint(equalTo: rightScreenEdgeGapLabel.widthAnchor),
                 largerWidthLabelStack.widthAnchor.constraint(equalTo: smallerWidthLabelStack.widthAnchor),
                 largerWidthShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 smallerWidthShortcutView.widthAnchor.constraint(equalToConstant: 160),
                 widthStepField.widthAnchor.constraint(equalToConstant: 160),
+                rightScreenEdgeGapField.widthAnchor.constraint(equalToConstant: 160),
                 hSplitControlsStack.widthAnchor.constraint(equalToConstant: 160),
                 vSplitControlsStack.widthAnchor.constraint(equalToConstant: 160),
                 hSplitPopUpButton.widthAnchor.constraint(equalToConstant: 100),
@@ -1035,6 +1112,8 @@ class SettingsViewController: NSViewController {
                 stackBadgeCheckbox.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 stackBadgeToggleRow.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 stackBadgeToggleShortcutView.widthAnchor.constraint(equalToConstant: 160),
+                rightScreenEdgeGapCheckbox.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
+                screenEdgeGapsOnMainScreenOnlyCheckbox.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 smallerWidthShortcutView.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 topVerticalThirdShortcutView.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 middleVerticalThirdShortcutView.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
@@ -1054,18 +1133,35 @@ class SettingsViewController: NSViewController {
                 sixteenthsCyclingShortcutView.leadingAnchor.constraint(equalTo: largerWidthShortcutView.leadingAnchor),
                 gridHeaderLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
                 cyclingHintLabel.widthAnchor.constraint(equalTo: mainStackView.widthAnchor, constant: -20),
+                rightScreenEdgeGapField.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor),
                 hSplitControlsStack.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor),
                 vSplitControlsStack.trailingAnchor.constraint(equalTo: largerWidthShortcutView.trailingAnchor)
             ])
 
-            let containerView = NSView()
-            containerView.addSubview(mainStackView)
+            let documentSize = NSSize(width: mainStackView.fittingSize.width + 30, height: mainStackView.fittingSize.height + 20)
+            let containerView = NSView(frame: NSRect(origin: .zero, size: documentSize))
+            let scrollView = NSScrollView(frame: containerView.bounds)
+            scrollView.translatesAutoresizingMaskIntoConstraints = false
+            scrollView.hasVerticalScroller = true
+            scrollView.hasHorizontalScroller = false
+            scrollView.autohidesScrollers = false
+            scrollView.drawsBackground = false
+            scrollView.borderType = .noBorder
+
+            let documentView = FlippedView(frame: NSRect(origin: .zero, size: documentSize))
+            documentView.addSubview(mainStackView)
+            scrollView.documentView = documentView
+            containerView.addSubview(scrollView)
 
             NSLayoutConstraint.activate([
-                mainStackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 10),
-                mainStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -10),
-                mainStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 15),
-                mainStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -15)
+                scrollView.topAnchor.constraint(equalTo: containerView.topAnchor),
+                scrollView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+                scrollView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+                mainStackView.topAnchor.constraint(equalTo: documentView.topAnchor, constant: 10),
+                mainStackView.bottomAnchor.constraint(equalTo: documentView.bottomAnchor, constant: -10),
+                mainStackView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor, constant: 15),
+                mainStackView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor, constant: -15)
             ])
 
             viewController.view = containerView

--- a/Rectangle/ScreenDetection.swift
+++ b/Rectangle/ScreenDetection.swift
@@ -429,7 +429,8 @@ extension NSScreen {
 
         newFrame.origin.x += Defaults.screenEdgeGapLeft.cgFloat
         newFrame.origin.y += Defaults.screenEdgeGapBottom.cgFloat
-        newFrame.size.width -= (Defaults.screenEdgeGapLeft.cgFloat + Defaults.screenEdgeGapRight.cgFloat)
+        let screenEdgeGapRight = Defaults.screenEdgeGapRightEnabled.enabled ? Defaults.screenEdgeGapRight.cgFloat : 0
+        newFrame.size.width -= (Defaults.screenEdgeGapLeft.cgFloat + screenEdgeGapRight)
         
         if #available(macOS 12.0, *), self.safeAreaInsets.top != 0, Defaults.screenEdgeGapTopNotch.value != 0 {
             newFrame.size.height -= (Defaults.screenEdgeGapTopNotch.cgFloat + Defaults.screenEdgeGapBottom.cgFloat)

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -19030,6 +19030,9 @@
         }
       }
     },
+    "Gap width (px)" : {
+
+    },
     "GB9-OM-e27.title" : {
       "comment" : "Class = \"NSMenuItem\"; title = \"Bold\"; ObjectID = \"GB9-OM-e27\";",
       "extractionState" : "manual",
@@ -27765,6 +27768,9 @@
         }
       }
     },
+    "Leaves space along the right side of the usable screen area for notifications or other overlays." : {
+
+    },
     "Left Half then Top Half moves the window to the top left quarter; the action for the opposite edge expands it back." : {
 
     },
@@ -33161,6 +33167,9 @@
         }
       }
     },
+    "Only use on main display" : {
+
+    },
     "Open System Settings" : {
       "localizations" : {
         "ar" : {
@@ -37499,6 +37508,9 @@
         }
       }
     },
+    "Reserve space along the right side before Rectangle calculates window sizes. This can e.g. keep notification banners visible." : {
+
+    },
     "Resize adjacent windows when cycling side or corner shortcuts" : {
 
     },
@@ -37825,6 +37837,9 @@
           }
         }
       }
+    },
+    "Right edge gap" : {
+
     },
     "Right side, top/bottom near corners" : {
 
@@ -43585,6 +43600,9 @@
         }
       }
     },
+    "Use right edge gap" : {
+
+    },
     "uw2-9W-2jq.label" : {
       "comment" : "Class = \"NSTabViewItem\"; label = \"Shortcuts\"; ObjectID = \"uw2-9W-2jq\";",
       "extractionState" : "extracted_with_value",
@@ -46555,6 +46573,9 @@
           }
         }
       }
+    },
+    "When enabled, screen edge gaps are ignored on secondary displays." : {
+
     },
     "When using multiple displays, treats them as a single display. Requires System Settings > Desktop & Dock > Displays have separate Spaces to be OFF." : {
 


### PR DESCRIPTION
I use the currently hidden `screenEdgeGapRight` and `screenEdgeGapsOnMainScreenOnly` settings to keep the notification area clear at all times. Since hidden settings aren't particularly user-friendly, this PR aims to make this feature more easily accessible and manageable.

What this PR changes:
- Added a `screenEdgeGapRightEnabled` setting, defaulting to false.
  - To have the setting hold a default value of 370 instead of 0 when not in use. Default 370 because that's what neatly keeps space for the notification area on the right.
- Made `screenEdgeGapsOnMainScreenOnly` setting default to true.
  - Since this setting isn't exposed currently, the main use case for the setting is the notification area, which only sticks around on the main display.
- Added a section to the "extras" settings to explain the feature, toggle `screenEdgeGapRightEnabled`, `screenEdgeGapsOnMainScreenOnly`, and set the value of `screenEdgeGapRight`.
- Added a scroll bar to the popout "extras" settings view, since the menu is now quite tall and won't fit on all displays.
  - Probably already a problem on certain display configurations, but with the extra section this is definitely needed.

I've intentionally limited this change to the right edge gap, since that has a clear use case. There is an argument that the other sides could be exposed in the same way as well of course.