### PR TITLE
Add default-off experimental window animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Drag a window to the edge of the screen. When the mouse cursor reaches the edge 
 | Bottom left, center, or right third                    | Respective third                       |
 | Bottom left or right third, then drag to bottom center | First or last two thirds, respectively |
 
+### Experimental window animations
+
+In the snap-area preferences, **Animate windows (experimental)** enables a short transition for window actions and restoring a snapped window's size, including dragging it away from an edge. It is off by default and is separate from **Animate footprint**, which only affects the snap preview.
+
+This experiment uses Accessibility position and size updates. Results depend on how quickly the target app resizes and on its minimum window size. Rectangle still checks and corrects the final position. Reduce Motion, VoiceOver, and Switch Control bypass the animation. Cross-display actions, fixed-size window actions, and actions with cooperative corner resizing enabled use the existing immediate behavior; bulk tiling and cascading are also unchanged.
+
 ### Ignore an app
 
 Ignoring an app means that when the app is frontmost, keyboard shortcuts are un-registered from macOS. When the app is no longer frontmost, keyboard shortcuts are re-registered with macOS. This is useful for apps that have the same shortcuts like Rectangle and you do not want to change them.

--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AC0100010000000000000001 /* WindowAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0100010000000000000002 /* WindowAnimator.swift */; };
 		01f52cab9bce43359775bdd7 /* JSONDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = de0950b8b00f40308934a523 /* JSONDefaultTests.swift */; };
 		05DBEA44B55E6F8C5FC3D6E0 /* MiddleLeftTwelfthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEABF10E66D648DDB37DABBA /* MiddleLeftTwelfthCalculation.swift */; };
 		0F29956694B5BB31EBDAE445 /* UpperMiddleRightSixteenthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B5B09465C38F8B766B3C3C /* UpperMiddleRightSixteenthCalculation.swift */; };
@@ -228,6 +229,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		AC0100010000000000000002 /* WindowAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAnimator.swift; sourceTree = "<group>"; };
 		16B4044DB4809116039F96EB /* SixteenthsRepeated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SixteenthsRepeated.swift; sourceTree = "<group>"; };
 		246168B345ECE6C375ACEEB7 /* BottomLeftTwelfthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomLeftTwelfthCalculation.swift; sourceTree = "<group>"; };
 		30166BCF24F27D6A00A38608 /* SpecifiedCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifiedCalculation.swift; sourceTree = "<group>"; };
@@ -627,6 +629,7 @@
 			children = (
 				9824704A22B189250037B409 /* BestEffortWindowMover.swift */,
 				9824704622B189240037B409 /* StandardWindowMover.swift */,
+				AC0100010000000000000002 /* WindowAnimator.swift */,
 				9824704722B189240037B409 /* WindowMover.swift */,
 				98B3559723CE025700E410E0 /* FixedSizeWindowMover.swift */,
 			);
@@ -1056,6 +1059,7 @@
 				9821403122B38A0500ABFB3F /* TopHalfCalculation.swift in Sources */,
 				9818E01428B5A4FD004AA524 /* SixthsCompoundCalculation.swift in Sources */,
 				9824704B22B189250037B409 /* StandardWindowMover.swift in Sources */,
+				AC0100010000000000000001 /* WindowAnimator.swift in Sources */,
 				9821402722B3888100ABFB3F /* ChangeSizeCalculation.swift in Sources */,
 				6490B39927BF97BB0056C220 /* TopCenterRightEighthCalculation.swift in Sources */,
 				98B3559823CE025700E410E0 /* FixedSizeWindowMover.swift in Sources */,

--- a/Rectangle/AccessibilityElement.swift
+++ b/Rectangle/AccessibilityElement.swift
@@ -132,6 +132,7 @@ class AccessibilityElement {
     /// To handle moving to different displays, we have to adjust the size then the position, then the size again since macOS will enforce sizes that fit on the current display.
     /// When windows take a long time to adjust size & position, there is some visual stutter with doing each of these actions. The stutter can be slightly reduced by removing the initial size adjustment, which can make unsnap restore appear smoother.
     func setFrame(_ frame: CGRect, adjustSizeFirst: Bool = true) {
+        WindowAnimator.shared.cancel(for: self)
         let appElement = applicationElement
         let builtInAssistiveTechnologyEnabled = NSWorkspace.shared.isVoiceOverEnabled
             || NSWorkspace.shared.isSwitchControlEnabled
@@ -153,6 +154,38 @@ class AccessibilityElement {
                 size = frame.size
             }
         )
+    }
+
+    /// Keep the existing Enhanced UI policy active for the whole transition,
+    /// instead of toggling application accessibility on every timer tick.
+    func beginAnimatedAdjustment() -> () -> Void {
+        let appElement = applicationElement
+        let restore = Defaults.enhancedUI.value.beginWindowAdjustment(
+            bundleIdentifier: appElement?.bundleIdentifier,
+            builtInAssistiveTechnologyEnabled: NSWorkspace.shared.isVoiceOverEnabled
+                || NSWorkspace.shared.isSwitchControlEnabled,
+            readEnhancedUI: { appElement?.enhancedUserInterface },
+            writeEnhancedUI: { appElement?.enhancedUserInterface = $0 }
+        )
+        // Avoid a long stream of blocking requests to an unresponsive app.
+        setMessagingTimeout(0.05)
+        return { [self] in
+            setMessagingTimeout(0)
+            restore()
+        }
+    }
+
+    /// No per-frame readbacks or logging. The normal mover checks the achieved
+    /// geometry once the transition ends and applies any necessary corrections.
+    func setAnimationFrame(_ frame: CGRect) -> Bool {
+        var size = frame.size
+        var position = frame.origin
+        guard let sizeValue = AXValueCreate(.cgSize, &size),
+              let positionValue = AXValueCreate(.cgPoint, &position) else { return false }
+        guard AXUIElementSetAttributeValue(wrappedElement, kAXSizeAttribute as CFString, sizeValue) == .success,
+              AXUIElementSetAttributeValue(wrappedElement, kAXPositionAttribute as CFString, positionValue) == .success
+        else { return false }
+        return true
     }
     
     private var childElements: [AccessibilityElement]? {
@@ -540,22 +573,34 @@ enum EnhancedUI: Int {
         bundleIdentifier: String?,
         builtInAssistiveTechnologyEnabled: Bool,
         readEnhancedUI: () -> Bool?,
-        writeEnhancedUI: (Bool) -> Void,
+        writeEnhancedUI: @escaping (Bool) -> Void,
         adjustment: () -> Void
     ) {
+        let restore = beginWindowAdjustment(bundleIdentifier: bundleIdentifier,
+                                            builtInAssistiveTechnologyEnabled: builtInAssistiveTechnologyEnabled,
+                                            readEnhancedUI: readEnhancedUI,
+                                            writeEnhancedUI: writeEnhancedUI)
+        adjustment()
+        restore()
+    }
+
+    func beginWindowAdjustment(
+        bundleIdentifier: String?,
+        builtInAssistiveTechnologyEnabled: Bool,
+        readEnhancedUI: () -> Bool?,
+        writeEnhancedUI: @escaping (Bool) -> Void
+    ) -> () -> Void {
         let enhancedUIWasEnabled = readEnhancedUI()
         if enhancedUIWasEnabled == true {
             writeEnhancedUI(false)
         }
 
-        adjustment()
-
-        if enhancedUIWasEnabled == true,
-           restoresEnhancedUI(
+        let shouldRestore = enhancedUIWasEnabled == true && restoresEnhancedUI(
                bundleIdentifier: bundleIdentifier,
                builtInAssistiveTechnologyEnabled: builtInAssistiveTechnologyEnabled
-           ) {
-            writeEnhancedUI(true)
+           )
+        return {
+            if shouldRestore { writeEnhancedUI(true) }
         }
     }
 }

--- a/Rectangle/Base.lproj/Main.storyboard
+++ b/Rectangle/Base.lproj/Main.storyboard
@@ -3970,6 +3970,16 @@ DQ
                                                                     <action selector="toggleAnimateFootprint:" target="t2d-Q7-RLy" id="qo7-sw-gbY"/>
                                                                 </connections>
                                                             </button>
+                                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ani-win-opt">
+                                                                <rect key="frame" x="0.0" y="0.0" width="278" height="16"/>
+                                                                <buttonCell key="cell" type="check" title="Animate windows (experimental)" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ani-win-cell">
+                                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                    <font key="font" metaFont="system"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="toggleExperimentalWindowAnimations:" target="t2d-Q7-RLy" id="ani-win-action"/>
+                                                                </connections>
+                                                            </button>
                                                         </subviews>
                                                         <visibilityPriorities>
                                                             <integer value="1000"/>
@@ -4498,6 +4508,7 @@ DQ
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="experimentalWindowAnimationsCheckbox" destination="ani-win-opt" id="ani-win-outlet"/>
                         <outlet property="animateFootprintCheckbox" destination="cbx-fa-jJh" id="KmN-pe-s68"/>
                         <outlet property="bottomLandscapeSelect" destination="3c6-3h-J52" id="1a0-LW-wrh"/>
                         <outlet property="bottomLeftLandscapeSelect" destination="bVZ-3z-DYF" id="1Ql-jU-1fz"/>

--- a/Rectangle/Defaults.swift
+++ b/Rectangle/Defaults.swift
@@ -12,6 +12,7 @@ class Defaults {
     static let cycleSizesIsChanged = BoolDefault(key: "cycleSizesIsChanged")
     static let cornerCycleExpansionAxis = IntEnumDefault<CornerCycleExpansionAxis>(key: "cornerCycleExpansionAxis", defaultValue: .horizontal)
     static let cooperativeCornerResize = BoolDefault(key: "cooperativeCornerResize")
+    static let experimentalWindowAnimations = BoolDefault(key: "experimentalWindowAnimations")
     static let allowAnyShortcut = BoolDefault(key: "allowAnyShortcut")
     static let windowSnapping = OptionalBoolDefault(key: "windowSnapping")
     static let almostMaximizeHeight = FloatDefault(key: "almostMaximizeHeight")
@@ -120,6 +121,7 @@ class Defaults {
         cycleSizesIsChanged,
         cornerCycleExpansionAxis,
         cooperativeCornerResize,
+        experimentalWindowAnimations,
         allowAnyShortcut,
         windowSnapping,
         almostMaximizeHeight,

--- a/Rectangle/PrefsWindow/SnapAreaViewController.swift
+++ b/Rectangle/PrefsWindow/SnapAreaViewController.swift
@@ -7,6 +7,7 @@ class SnapAreaViewController: NSViewController {
     @IBOutlet weak var windowSnappingCheckbox: NSButton!
     @IBOutlet weak var unsnapRestoreButton: NSButton!
     @IBOutlet weak var animateFootprintCheckbox: NSButton!
+    @IBOutlet weak var experimentalWindowAnimationsCheckbox: NSButton!
     @IBOutlet weak var hapticFeedbackCheckbox: NSButton!
     @IBOutlet weak var missionControlDraggingCheckbox: NSButton!
 
@@ -48,6 +49,11 @@ class SnapAreaViewController: NSViewController {
         let newSetting: Float = sender.state == .on ? 0.75 : 0
         Defaults.footprintAnimationDurationMultiplier.value = newSetting
     }
+
+    @IBAction func toggleExperimentalWindowAnimations(_ sender: NSButton) {
+        Defaults.experimentalWindowAnimations.enabled = sender.state == .on
+        if sender.state == .off { WindowAnimator.shared.finish() }
+    }
     
     @IBAction func toggleHapticFeedback(_ sender: NSButton) {
         let newSetting: Bool = sender.state == .on
@@ -84,6 +90,7 @@ class SnapAreaViewController: NSViewController {
         windowSnappingCheckbox.state = Defaults.windowSnapping.userDisabled ? .off : .on
         unsnapRestoreButton.state = Defaults.unsnapRestore.userDisabled ? .off : .on
         animateFootprintCheckbox.state = Defaults.footprintAnimationDurationMultiplier.value > 0 ? .on : .off
+        experimentalWindowAnimationsCheckbox.state = Defaults.experimentalWindowAnimations.enabled ? .on : .off
         hapticFeedbackCheckbox.state = Defaults.hapticFeedbackOnSnap.userEnabled ? .on : .off
         missionControlDraggingCheckbox.state = Defaults.missionControlDragging.userDisabled ? .on : .off
         missionControlDraggingCheckbox.isHidden = !Defaults.missionControlDragging.userDisabled
@@ -113,6 +120,7 @@ class SnapAreaViewController: NSViewController {
     // Only load the selects when the view appears, to fix a performance issue where switching to this tab was taking a long time to load
     var selectsLoaded = false
     override func viewWillAppear() {
+        experimentalWindowAnimationsCheckbox.state = Defaults.experimentalWindowAnimations.enabled ? .on : .off
         if !selectsLoaded {
             loadSnapAreas()
             selectsLoaded = true

--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -195,12 +195,15 @@ class SnappingManager {
     func handle(event: NSEvent) {
         switch event.type {
         case .leftMouseDown:
+            // A manual grab owns the window from this point onward.
+            WindowAnimator.shared.finish()
             if !Defaults.obtainWindowOnClick.userDisabled {
                 windowElement = AccessibilityElement.getWindowElementUnderCursor()
                 windowId = windowElement?.getWindowId()
                 initialWindowRect = windowElement?.frame
             }
         case .leftMouseUp:
+            WindowAnimator.shared.finish()
             if let currentSnapArea = self.currentSnapArea {
                 box?.orderOut(nil)
                 currentSnapArea.action.postSnap(windowElement: windowElement, windowId: windowId, screen: currentSnapArea.screen)
@@ -336,7 +339,19 @@ class SnappingManager {
                             }
                         }
                     }
-                    windowElement.setFrame(newRect, adjustSizeFirst: false)
+                    var cursorOffset = CGPoint.zero
+                    let initialCursor = NSEvent.mouseLocation.screenFlipped
+                    WindowAnimator.shared.animate(windowElement, to: newRect, duration: 0.16, offset: {
+                        // Follow the drag during restoration, but do not follow
+                        // unrelated cursor movement after the button is released.
+                        if NSEvent.pressedMouseButtons & 1 != 0 {
+                            let cursor = NSEvent.mouseLocation.screenFlipped
+                            cursorOffset = CGPoint(x: cursor.x - initialCursor.x, y: cursor.y - initialCursor.y)
+                        }
+                        return cursorOffset
+                    }) { frame in
+                        windowElement.setFrame(frame, adjustSizeFirst: false)
+                    }
                 } else {
                     windowElement.size = restoreRect.size
                 }

--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -341,7 +341,7 @@ class SnappingManager {
                     }
                     var cursorOffset = CGPoint.zero
                     let initialCursor = NSEvent.mouseLocation.screenFlipped
-                    WindowAnimator.shared.animate(windowElement, to: newRect, duration: 0.16, offset: {
+                    WindowAnimator.shared.animate(windowElement, to: newRect, duration: 0.18, offset: {
                         // Follow the drag during restoration, but do not follow
                         // unrelated cursor movement after the button is released.
                         if NSEvent.pressedMouseButtons & 1 != 0 {

--- a/Rectangle/WindowManager.swift
+++ b/Rectangle/WindowManager.swift
@@ -64,7 +64,15 @@ class WindowManager {
                 return
             }
             if let restoreRect = AppDelegate.windowHistory.restoreRects[windowId] {
-                frontmostWindowElement.setFrame(restoreRect)
+                if WindowAnimator.enabled, frontmostWindowElement.isResizable(),
+                   let screenFrame = screenDetection.detectScreens(using: frontmostWindowElement)?.currentScreen.frame.screenFlipped,
+                   screenFrame.contains(restoreRect) {
+                    WindowAnimator.shared.animate(frontmostWindowElement, to: restoreRect) { frame in
+                        frontmostWindowElement.setFrame(frame)
+                    }
+                } else {
+                    frontmostWindowElement.setFrame(restoreRect)
+                }
             }
             AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: windowId)
             return
@@ -88,7 +96,10 @@ class WindowManager {
             return
         }
         
-        let currentWindowRect: CGRect = frontmostWindowElement.frame
+        // Use the pending destination for shortcut cycling and restore history;
+        // the next transition still starts from the actual on-screen frame.
+        let currentWindowRect = WindowAnimator.shared.destination(for: frontmostWindowElement)
+            ?? frontmostWindowElement.frame
         
         var lastRectangleAction = windowId.flatMap { AppDelegate.windowHistory.lastRectangleActions[$0] }
         
@@ -196,53 +207,71 @@ class WindowManager {
                                                 source: parameters.source,
                                                 isFixedSize: isFixedSize)
         
-        var resultingRect: CGRect
-        if let cooperativeCornerPlan {
-            resultingRect = applyCooperativeCornerResize(result: resultParameters,
-                                                         plan: cooperativeCornerPlan)
-        } else {
-            resultingRect = apply(result: resultParameters)
-        }
-
-        if let cooperativeCornerPlan {
-            // AX can enforce a minimum size that was not reported before the settling pass.
-            ActiveSideSplitRatios.shared.recordAchievedCooperativeAction(cooperativeCornerPlan.action,
-                                                                        achievedFrame: resultingRect.screenFlipped,
-                                                                        screenFrame: cooperativeCornerPlan.screenFrame,
-                                                                        gapSize: cooperativeCornerPlan.gapSize)
-        }
-        
-        if isMovedAcrossDisplays {
-            if calcResult.rect.size != resultingRect.size {
-                Logger.log("Window size wasn't applied perfectly across displays. Trying again.")
+        // The initial experiment only interpolates single-window, same-display
+        // resizes. Cooperative changes and display transfers retain their settling
+        // order, and non-resizable windows retain the fixed-size mover chain.
+        let animated = WindowAnimator.enabled && !isFixedSize && !isMovedAcrossDisplays
+            && !Defaults.cooperativeCornerResize.enabled
+        let completeMove = { [self] in
+            var resultingRect: CGRect
+            if let cooperativeCornerPlan {
+                resultingRect = applyCooperativeCornerResize(result: resultParameters,
+                                                             plan: cooperativeCornerPlan)
+            } else {
                 resultingRect = apply(result: resultParameters)
-                
-                if calcResult.rect.size != resultingRect.size {
-                    Logger.log("Final attempt to adjust across displays.")
-                    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(25)) { [weak self] in
-                        guard let self else { return }
-                        let finalRect = self.apply(result: resultParameters)
-                        self.windowMovedAcrossDisplays(windowElement: frontmostWindowElement, resultingRect: finalRect)
-                        self.postProcess(result: resultParameters, resultingRect: finalRect)
-                    }
-                    return
-                }
             }
-            windowMovedAcrossDisplays(windowElement: frontmostWindowElement, resultingRect: resultingRect)
-        }
 
-        if !isMovedAcrossDisplays {
-            applyCooperativeCornerCleanupIfNeeded(focusedWindowId: windowId,
-                                                  source: parameters.source,
-                                                  oldFocusedFrame: currentNormalizedRect,
-                                                  newFocusedFrame: resultingRect.screenFlipped,
-                                                  screenFrame: sourceScreens.currentScreen.adjustedVisibleFrame(ignoreTodo),
-                                                  currentAction: action,
-                                                  lastRectangleAction: lastRectangleAction)
-            resultingRect = frontmostWindowElement.frame
+            if let cooperativeCornerPlan {
+                // AX can enforce a minimum size that was not reported before the settling pass.
+                ActiveSideSplitRatios.shared.recordAchievedCooperativeAction(cooperativeCornerPlan.action,
+                                                                            achievedFrame: resultingRect.screenFlipped,
+                                                                            screenFrame: cooperativeCornerPlan.screenFrame,
+                                                                            gapSize: cooperativeCornerPlan.gapSize)
+            }
+
+            if isMovedAcrossDisplays {
+                if calcResult.rect.size != resultingRect.size {
+                    Logger.log("Window size wasn't applied perfectly across displays. Trying again.")
+                    resultingRect = apply(result: resultParameters)
+
+                    if calcResult.rect.size != resultingRect.size {
+                        Logger.log("Final attempt to adjust across displays.")
+                        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(25)) { [weak self] in
+                            guard let self else { return }
+                            let finalRect = self.apply(result: resultParameters)
+                            self.windowMovedAcrossDisplays(windowElement: frontmostWindowElement, resultingRect: finalRect)
+                            self.postProcess(result: resultParameters, resultingRect: finalRect, incrementCount: !animated)
+                        }
+                        return
+                    }
+                }
+                windowMovedAcrossDisplays(windowElement: frontmostWindowElement, resultingRect: resultingRect)
+            }
+
+            if !isMovedAcrossDisplays {
+                applyCooperativeCornerCleanupIfNeeded(focusedWindowId: windowId,
+                                                      source: parameters.source,
+                                                      oldFocusedFrame: currentNormalizedRect,
+                                                      newFocusedFrame: resultingRect.screenFlipped,
+                                                      screenFrame: sourceScreens.currentScreen.adjustedVisibleFrame(ignoreTodo),
+                                                      currentAction: action,
+                                                      lastRectangleAction: lastRectangleAction)
+                resultingRect = frontmostWindowElement.frame
+            }
+
+            postProcess(result: resultParameters, resultingRect: resultingRect, incrementCount: !animated)
         }
-        
-        postProcess(result: resultParameters, resultingRect: resultingRect)
+        if animated {
+            // Record the logical destination now so a repeated shortcut can cycle
+            // without treating an intermediate animation frame as a manual move.
+            recordAction(windowId: windowId, resultingRect: calcResult.rect.screenFlipped,
+                         action: calcResult.resultingAction, subAction: calcResult.resultingSubAction)
+            WindowAnimator.shared.animate(frontmostWindowElement, to: calcResult.rect.screenFlipped) { _ in
+                completeMove()
+            }
+        } else {
+            completeMove()
+        }
     }
     
     /// Move/resize a window based on the calculation results.
@@ -272,14 +301,14 @@ class WindowManager {
         }
     }
 
-    func postProcess(result: ResultParameters, resultingRect: CGRect) {
+    func postProcess(result: ResultParameters, resultingRect: CGRect, incrementCount: Bool = true) {
         let calcResult = result.calcResult
         
         if Defaults.moveCursor.userEnabled, result.source == .keyboardShortcut {
             CGWarpMouseCursorPosition(resultingRect.centerPoint)
         }
         
-        recordAction(windowId: result.windowId, resultingRect: resultingRect, action: calcResult.resultingAction, subAction: calcResult.resultingSubAction)
+        recordAction(windowId: result.windowId, resultingRect: resultingRect, action: calcResult.resultingAction, subAction: calcResult.resultingSubAction, incrementCount: incrementCount)
         
         if Logger.logging {
             var logItems = ["\(result.action.name)",

--- a/Rectangle/WindowMover/WindowAnimator.swift
+++ b/Rectangle/WindowMover/WindowAnimator.swift
@@ -1,0 +1,154 @@
+/// WindowAnimator.swift
+
+import Cocoa
+
+/// A time-based transition. Missed timer ticks are skipped, never queued up.
+/// Window I/O and the clock are supplied separately so cancellation and failures
+/// can be tested without moving a user's windows.
+final class WindowFrameAnimation {
+    let destination: CGRect
+    private let origin: CGRect
+    private let startTime: TimeInterval
+    private let duration: TimeInterval
+    private let offset: () -> CGPoint
+    private let write: (CGRect) -> Bool
+    private let cleanup: () -> Void
+    private let completion: (CGRect) -> Void
+    private(set) var isFinished = false
+
+    init(from: CGRect, to: CGRect, startTime: TimeInterval, duration: TimeInterval,
+         offset: @escaping () -> CGPoint = { .zero },
+         write: @escaping (CGRect) -> Bool,
+         cleanup: @escaping () -> Void,
+         completion: @escaping (CGRect) -> Void) {
+        origin = from
+        destination = to
+        self.startTime = startTime
+        self.duration = duration
+        self.offset = offset
+        self.write = write
+        self.cleanup = cleanup
+        self.completion = completion
+    }
+
+    func tick(at time: TimeInterval) {
+        guard !isFinished else { return }
+        let progress = duration > 0 ? min(1, max(0, (time - startTime) / duration)) : 1
+        if progress >= 1 {
+            finish()
+            return
+        }
+        // Smoothstep has zero velocity at both ends and does not overshoot.
+        let eased = CGFloat(progress * progress * (3 - 2 * progress))
+        let delta = offset()
+        let frame = CGRect(x: origin.minX + (destination.minX - origin.minX) * eased + delta.x,
+                           y: origin.minY + (destination.minY - origin.minY) * eased + delta.y,
+                           width: origin.width + (destination.width - origin.width) * eased,
+                           height: origin.height + (destination.height - origin.height) * eased)
+        if !write(frame) {
+            // A refused AX write ends interpolation; the ordinary mover settles
+            // the destination using the application's existing size constraints.
+            finish()
+        }
+    }
+
+    func finish() {
+        guard !isFinished else { return }
+        let delta = offset()
+        isFinished = true
+        cleanup()
+        completion(destination.offsetBy(dx: delta.x, dy: delta.y))
+    }
+
+    func cancel() {
+        guard !isFinished else { return }
+        isFinished = true
+        cleanup()
+    }
+}
+
+/// Main-run-loop ownership serializes AX adjustments and history updates. Only
+/// one window animates at a time, including when two windows belong to one app.
+final class WindowAnimator {
+    static let shared = WindowAnimator()
+    private var window: AccessibilityElement?
+    private var animation: WindowFrameAnimation?
+    private var timer: Timer?
+    private var mouseMonitor: Any?
+
+    private init() {
+        for name in [NSApplication.willTerminateNotification, NSApplication.didChangeScreenParametersNotification] {
+            NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                self?.finish()
+            }
+        }
+    }
+
+    static var enabled: Bool {
+        Defaults.experimentalWindowAnimations.enabled
+            && !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+            && !NSWorkspace.shared.isVoiceOverEnabled
+            && !NSWorkspace.shared.isSwitchControlEnabled
+    }
+
+    func destination(for element: AccessibilityElement) -> CGRect? {
+        window == element ? animation?.destination : nil
+    }
+
+    func cancel(for element: AccessibilityElement) {
+        if window == element { animation?.cancel() }
+    }
+
+    func finish() {
+        animation?.finish()
+    }
+
+    func animate(_ element: AccessibilityElement, to destination: CGRect,
+                 duration: TimeInterval = 0.25,
+                 offset: @escaping () -> CGPoint = { .zero },
+                 completion: @escaping (CGRect) -> Void) {
+        if window == element {
+            animation?.cancel()
+        } else {
+            animation?.finish()
+        }
+        let origin = element.frame
+        guard Self.enabled, !origin.isNull, !destination.isNull,
+              !origin.isEmpty, !destination.isEmpty, origin != destination else {
+            completion(destination)
+            return
+        }
+        let restoreAccessibility = element.beginAnimatedAdjustment()
+        window = element
+        animation = WindowFrameAnimation(from: origin, to: destination,
+                                         startTime: ProcessInfo.processInfo.systemUptime,
+                                         duration: duration, offset: offset,
+                                         write: { element.setAnimationFrame($0) },
+                                         cleanup: { [weak self] in
+            self?.timer?.invalidate()
+            self?.timer = nil
+            if let monitor = self?.mouseMonitor {
+                NSEvent.removeMonitor(monitor)
+                self?.mouseMonitor = nil
+            }
+            self?.animation = nil
+            self?.window = nil
+            restoreAccessibility()
+        }, completion: completion)
+        let timer = Timer(timeInterval: 1.0 / 60, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            if !Self.enabled {
+                self.finish()
+            } else {
+                self.animation?.tick(at: ProcessInfo.processInfo.systemUptime)
+            }
+        }
+        self.timer = timer
+        // Keyboard animations must also yield to a manual grab when drag-to-snap
+        // is disabled and SnappingManager is not listening for mouse events.
+        mouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown) { [weak self] _ in
+            self?.finish()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+    }
+}

--- a/Rectangle/WindowMover/WindowAnimator.swift
+++ b/Rectangle/WindowMover/WindowAnimator.swift
@@ -38,8 +38,12 @@ final class WindowFrameAnimation {
             finish()
             return
         }
-        // Smoothstep has zero velocity at both ends and does not overshoot.
-        let eased = CGFloat(progress * progress * (3 - 2 * progress))
+        // A critically damped response starts at rest, moves quickly, then has a
+        // longer settling tail. Normalize the finite interval to reach the exact
+        // destination without overshoot or a visible final correction.
+        let response = 7.0
+        let eased = CGFloat((1 - (1 + response * progress) * exp(-response * progress))
+            / (1 - (1 + response) * exp(-response)))
         let delta = offset()
         let frame = CGRect(x: origin.minX + (destination.minX - origin.minX) * eased + delta.x,
                            y: origin.minY + (destination.minY - origin.minY) * eased + delta.y,
@@ -104,7 +108,7 @@ final class WindowAnimator {
     }
 
     func animate(_ element: AccessibilityElement, to destination: CGRect,
-                 duration: TimeInterval = 0.25,
+                 duration: TimeInterval = 0.3,
                  offset: @escaping () -> CGPoint = { .zero },
                  completion: @escaping (CGRect) -> Void) {
         if window == element {

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -1,6 +1,36 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "ani-win-cell.title" : {
+      "comment" : "Class = \"NSButtonCell\"; title = \"Animate windows (experimental)\"; ObjectID = \"ani-win-cell\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Animate windows (experimental)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "窗口动画（实验性）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視窗動畫（實驗性）"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウインドウをアニメーション表示（実験的）"
+          }
+        }
+      }
+    },
     "0Ak-33-SM7.title" : {
       "comment" : "Class = \"NSTextFieldCell\"; title = \"Top Right\"; ObjectID = \"0Ak-33-SM7\";",
       "extractionState" : "extracted_with_value",

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -5,6 +5,195 @@ import MASShortcut
 import XCTest
 @testable import Rectangle
 
+final class WindowFrameAnimationTests: XCTestCase {
+    private let start = CGRect(x: 100, y: 100, width: 600, height: 400)
+    private let target = CGRect(x: 0, y: 30, width: 900, height: 800)
+
+    func testDelayedTickSkipsToCompletionAndSettlesExactlyOnce() {
+        var writes: [CGRect] = []
+        var completed: [CGRect] = []
+        var cleanupCount = 0
+        let animation = WindowFrameAnimation(from: start, to: target, startTime: 10, duration: 0.25,
+                                             write: { writes.append($0); return true },
+                                             cleanup: { cleanupCount += 1 },
+                                             completion: { completed.append($0) })
+        animation.tick(at: 10.125)
+        XCTAssertEqual(writes, [CGRect(x: 50, y: 65, width: 750, height: 600)])
+        animation.tick(at: 12)
+        animation.tick(at: 13)
+        animation.finish()
+        animation.cancel()
+        XCTAssertEqual(writes.count, 1)
+        XCTAssertEqual(completed, [target])
+        XCTAssertEqual(cleanupCount, 1)
+    }
+
+    func testCancellationDoesNotSettleAnObsoleteDestination() {
+        var visible = start
+        var completed: [CGRect] = []
+        var cleanupCount = 0
+        let first = WindowFrameAnimation(from: visible, to: target, startTime: 0, duration: 1,
+                                         write: { visible = $0; return true },
+                                         cleanup: { cleanupCount += 1 },
+                                         completion: { completed.append($0) })
+        first.tick(at: 0.5)
+        first.cancel()
+        let interrupted = visible
+        let second = WindowFrameAnimation(from: visible, to: start, startTime: 0.5, duration: 1,
+                                          write: { visible = $0; return true },
+                                          cleanup: { cleanupCount += 1 },
+                                          completion: { completed.append($0) })
+        first.tick(at: 1)
+        second.tick(at: 0.5)
+        XCTAssertEqual(visible, interrupted)
+        second.tick(at: 2)
+        XCTAssertEqual(completed, [start])
+        XCTAssertEqual(cleanupCount, 2)
+    }
+
+    func testRefusedWriteStopsFurtherRequestsAndRunsFallbackAfterCleanup() {
+        var events: [String] = []
+        let animation = WindowFrameAnimation(from: start, to: target, startTime: 0, duration: 1,
+                                             write: { _ in events.append("write"); return false },
+                                             cleanup: { events.append("cleanup") },
+                                             completion: { frame in
+            XCTAssertEqual(frame, self.target)
+            events.append("settle")
+        })
+        animation.tick(at: 0.2)
+        animation.tick(at: 0.4)
+        XCTAssertEqual(events, ["write", "cleanup", "settle"])
+    }
+
+    func testDragTranslationAppliesToIntermediateAndFinalFrames() {
+        var delta = CGPoint(x: 10, y: 20)
+        var writes: [CGRect] = []
+        var final: CGRect?
+        let animation = WindowFrameAnimation(from: start, to: target, startTime: 0, duration: 1,
+                                             offset: { delta },
+                                             write: { writes.append($0); return true },
+                                             cleanup: {}, completion: { final = $0 })
+        animation.tick(at: 0.5)
+        XCTAssertEqual(writes.last, CGRect(x: 60, y: 85, width: 750, height: 600))
+        delta = CGPoint(x: 80, y: -10)
+        animation.finish()
+        XCTAssertEqual(final, target.offsetBy(dx: 80, dy: -10))
+    }
+
+    func testZeroDurationCompletesWithoutIntermediateWrites() {
+        var final: CGRect?
+        let animation = WindowFrameAnimation(from: start, to: target, startTime: 0, duration: 0,
+                                             write: { _ in XCTFail("Unexpected intermediate write"); return true },
+                                             cleanup: {}, completion: { final = $0 })
+        animation.tick(at: 0)
+        XCTAssertEqual(final, target)
+    }
+
+    func testAnimationPreferenceIsIncludedInConfigurationExport() {
+        XCTAssertTrue(Defaults.array.contains { $0.key == "experimentalWindowAnimations" })
+    }
+
+    func testEnhancedUIIsRestoredAfterTheWholeAdjustment() {
+        var writes: [Bool] = []
+        let restore = EnhancedUI.automatic.beginWindowAdjustment(
+            bundleIdentifier: "com.apple.TextEdit", builtInAssistiveTechnologyEnabled: false,
+            readEnhancedUI: { true }, writeEnhancedUI: { writes.append($0) })
+        XCTAssertEqual(writes, [false])
+        restore()
+        XCTAssertEqual(writes, [false, true])
+    }
+}
+
+final class AnimatedWindowHistoryTests: XCTestCase {
+    func testRetargetingPreservesRestoreFrameAndCountsEachShortcutOnce() throws {
+        let settings: [(Default, CodableDefault)] = [
+            (Defaults.experimentalWindowAnimations, CodableDefault(bool: true)),
+            (Defaults.cooperativeCornerResize, CodableDefault(bool: false)),
+            (Defaults.useCursorScreenDetection, CodableDefault(bool: false)),
+            (Defaults.subsequentExecutionMode, CodableDefault(int: SubsequentExecutionMode.resize.rawValue)),
+            (Defaults.moveCursor, CodableDefault(int: 2)),
+            (Defaults.todo, CodableDefault(int: 2))
+        ]
+        let saved = settings.map { ($0.0, $0.0.toCodable()) }
+        let id: CGWindowID = 0x7fff0123
+        let oldRestore = AppDelegate.windowHistory.restoreRects[id]
+        let oldAction = AppDelegate.windowHistory.lastRectangleActions[id]
+        defer {
+            WindowAnimator.shared.finish()
+            saved.forEach { $0.0.load(from: $0.1) }
+            AppDelegate.windowHistory.restoreRects[id] = oldRestore
+            AppDelegate.windowHistory.lastRectangleActions[id] = oldAction
+            ActiveSideSplitRatios.shared.resetAll()
+        }
+        settings.forEach { $0.0.load(from: $0.1) }
+        try XCTSkipUnless(WindowAnimator.enabled, "System accessibility settings bypass animation")
+        AppDelegate.windowHistory.restoreRects[id] = nil
+        AppDelegate.windowHistory.lastRectangleActions[id] = nil
+        let screen = AnimationScreen()
+        let window = AnimationWindow()
+        let original = window.frame
+        let manager = WindowManager(screenDetection: AnimationScreens(screen: screen))
+        func execute(_ action: WindowAction) {
+            manager.execute(ExecutionParameters(action, screen: screen, windowElement: window, windowId: id))
+        }
+        execute(.leftHalf)
+        XCTAssertNotNil(WindowAnimator.shared.destination(for: window))
+        // Simulate a partially presented frame before the next keyboard event.
+        _ = window.setAnimationFrame(original.offsetBy(dx: 10, dy: 0))
+        execute(.rightHalf)
+        execute(.rightHalf)
+        XCTAssertEqual(AppDelegate.windowHistory.restoreRects[id], original)
+        XCTAssertEqual(AppDelegate.windowHistory.lastRectangleActions[id]?.count, 2)
+        WindowAnimator.shared.finish()
+        XCTAssertEqual(AppDelegate.windowHistory.lastRectangleActions[id]?.rect, window.frame)
+        XCTAssertEqual(AppDelegate.windowHistory.lastRectangleActions[id]?.count, 2)
+        execute(.restore)
+        WindowAnimator.shared.finish()
+        XCTAssertEqual(window.frame, original)
+        XCTAssertNil(AppDelegate.windowHistory.lastRectangleActions[id])
+        XCTAssertEqual(window.openAdjustments, 0)
+    }
+
+    private final class AnimationScreen: NSScreen {
+        override var frame: NSRect { CGRect(x: 0, y: 0, width: 1600, height: 1000) }
+        override var visibleFrame: NSRect { frame }
+        override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
+        override var hash: Int { ObjectIdentifier(self).hashValue }
+        override func isEqual(_ object: Any?) -> Bool { (object as AnyObject?) === self }
+    }
+
+    private final class AnimationScreens: ScreenDetection {
+        let screen: NSScreen
+        init(screen: NSScreen) { self.screen = screen }
+        override func detectScreens(using frontmostWindowElement: AccessibilityElement?) -> UsableScreens? {
+            UsableScreens(currentScreen: screen, numScreens: 1)
+        }
+    }
+
+    private final class AnimationWindow: AccessibilityElement {
+        var currentFrame = CGRect(x: 100, y: 100, width: 600, height: 400).screenFlipped
+        var openAdjustments = 0
+        init() { super.init(AXUIElementCreateSystemWide()) }
+        override var frame: CGRect { currentFrame }
+        override var isSheet: Bool? { false }
+        override var isSystemDialog: Bool? { false }
+        override var minimumSize: CGSize? { nil }
+        override func isResizable() -> Bool { true }
+        override func beginAnimatedAdjustment() -> () -> Void {
+            openAdjustments += 1
+            return { self.openAdjustments -= 1 }
+        }
+        override func setAnimationFrame(_ frame: CGRect) -> Bool {
+            currentFrame = frame
+            return true
+        }
+        override func setFrame(_ frame: CGRect, adjustSizeFirst: Bool = true) {
+            WindowAnimator.shared.cancel(for: self)
+            currentFrame = frame
+        }
+    }
+}
+
 class RectangleTests: XCTestCase {
 
     override func setUp() {
@@ -4544,7 +4733,7 @@ final class CrossDisplayResizeTests: XCTestCase {
 
         override func windowMovedAcrossDisplays(windowElement: AccessibilityElement, resultingRect: CGRect) {}
 
-        override func postProcess(result: ResultParameters, resultingRect: CGRect) {
+        override func postProcess(result: ResultParameters, resultingRect: CGRect, incrementCount: Bool = true) {
             didFinish?(result, resultingRect)
         }
     }
@@ -4964,4 +5153,3 @@ class HalvesPreserveOtherAxisSizeTests: XCTestCase {
                                   lastAction: lastAction)
     }
 }
-

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -18,7 +18,10 @@ final class WindowFrameAnimationTests: XCTestCase {
                                              cleanup: { cleanupCount += 1 },
                                              completion: { completed.append($0) })
         animation.tick(at: 10.125)
-        XCTAssertEqual(writes, [CGRect(x: 50, y: 65, width: 750, height: 600)])
+        XCTAssertEqual(writes.count, 1)
+        // Most of the distance is covered early, leaving time to settle.
+        XCTAssertGreaterThan(writes[0].width, 750)
+        XCTAssertLessThan(writes[0].width, target.width)
         animation.tick(at: 12)
         animation.tick(at: 13)
         animation.finish()
@@ -73,8 +76,8 @@ final class WindowFrameAnimationTests: XCTestCase {
                                              offset: { delta },
                                              write: { writes.append($0); return true },
                                              cleanup: {}, completion: { final = $0 })
-        animation.tick(at: 0.5)
-        XCTAssertEqual(writes.last, CGRect(x: 60, y: 85, width: 750, height: 600))
+        animation.tick(at: 0)
+        XCTAssertEqual(writes.last, start.offsetBy(dx: 10, dy: 20))
         delta = CGPoint(x: 80, y: -10)
         animation.finish()
         XCTAssertEqual(final, target.offsetBy(dx: 80, dy: -10))
@@ -87,6 +90,22 @@ final class WindowFrameAnimationTests: XCTestCase {
                                              cleanup: {}, completion: { final = $0 })
         animation.tick(at: 0)
         XCTAssertEqual(final, target)
+    }
+
+    func testSpringResponseIsMonotonicAndNeverOvershoots() {
+        var frames: [CGRect] = []
+        let animation = WindowFrameAnimation(from: start, to: target, startTime: 0, duration: 1,
+                                             write: { frames.append($0); return true },
+                                             cleanup: {}, completion: { frames.append($0) })
+        for tick in 0...100 { animation.tick(at: Double(tick) / 100) }
+        XCTAssertEqual(frames.first, start)
+        XCTAssertEqual(frames.last, target)
+        for (previous, current) in zip(frames, frames.dropFirst()) {
+            XCTAssertGreaterThanOrEqual(current.width, previous.width)
+            XCTAssertLessThanOrEqual(current.width, target.width)
+            XCTAssertLessThanOrEqual(current.minX, previous.minX)
+            XCTAssertGreaterThanOrEqual(current.minX, target.minX)
+        }
     }
 
     func testAnimationPreferenceIsIncludedInConfigurationExport() {


### PR DESCRIPTION
Adds **Animate windows (experimental)** to Snap Areas preferences, off by default. When enabled, same-display window actions transition over 300 ms, and dragging a snapped window away restores its size over 180 ms. Keyboard Restore also uses the transition when the saved frame is on the same display.

Related to #1465.

The implementation interpolates position and size using elapsed time and a critically damped curve with a longer settling tail, with up to 60 updates per second through Accessibility. Missed ticks are skipped. Repeated shortcuts retarget from the displayed frame while retaining the logical destination for cycling and restore history. Existing window movers perform the final correction and readback. Refused AX writes end interpolation and fall back to that correction path.

The existing Enhanced UI policy spans the transition and is restored on completion or cancellation. Reduce Motion, VoiceOver, and Switch Control bypass animation. A manual grab finishes an in-progress transition even when drag-to-snap is disabled. The preference is included in configuration import/export, with English, Simplified Chinese, Traditional Chinese, and Japanese labels.

Initial scope: cross-display window actions, fixed-size window handling, cooperative corner adjustments, and bulk tiling/cascading retain their existing behavior. Target applications can still impose minimum sizes or respond slowly, so this remains experimental.

Validation:

- Xcode 26.6 on macOS 27.0: Debug tests passed, 319 tests, zero failures.
- Release build passed.
- Added coverage for delayed ticks, cancellation and retargeting, failed writes, monotonic motion without overshoot, drag offsets, accessibility restoration, configuration export, and rapid-shortcut history preservation.
- Live settings check: default off, checkbox layout, and persistence after restart verified.
- Manual TextEdit check on macOS 27.0: snapping, keyboard Restore, and drag-to-restore confirmed smooth; the final curve was selected after comparison with an earlier timing curve.
- Broader app/framework and older-macOS visual coverage remains to be gathered; no universal smoothness claim is intended.
