### PR TITLE
fix: don't realign a window that is within a point of filling its zone

### DIFF
--- a/Rectangle/WindowMover/WindowMover.swift
+++ b/Rectangle/WindowMover/WindowMover.swift
@@ -14,10 +14,16 @@ protocol WindowMover {
 /// `.top` edge corresponds to maxY and `.bottom` to minY (matching the rest of Rectangle).
 enum ClampedWindowAligner {
 
+    /// A window may come back a hair smaller than its zone without being clamped in any
+    /// meaningful sense: macOS shortens an AX size change that grows a window onto the Dock
+    /// edge by a point. Realigning that shortfall moves the gap off the Dock edge, where it
+    /// was invisible, onto an opposite edge where it is not, so leave the axis alone instead.
+    static let alignmentTolerance: CGFloat = 1.0
+
     static func aligned(window: CGRect, inZone zone: CGRect, sharedEdges: Edge) -> CGRect {
         var result = window
 
-        if window.width != zone.width {
+        if abs(window.width - zone.width) > alignmentTolerance {
             if sharedEdges.contains(.left), !sharedEdges.contains(.right) {
                 result.origin.x = zone.minX
             } else if sharedEdges.contains(.right), !sharedEdges.contains(.left) {
@@ -27,7 +33,7 @@ enum ClampedWindowAligner {
             }
         }
 
-        if window.height != zone.height {
+        if abs(window.height - zone.height) > alignmentTolerance {
             if sharedEdges.contains(.top), !sharedEdges.contains(.bottom) {
                 result.origin.y = zone.maxY - window.height
             } else if sharedEdges.contains(.bottom), !sharedEdges.contains(.top) {

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -4282,6 +4282,45 @@ class ClampedWindowAlignerTests: XCTestCase {
         XCTAssertTrue(result.equalTo(window))
     }
 
+    // A maximize against a Dock on the right comes back a point narrow (see #1852). Centering
+    // that shortfall would put the window at x=1 and leave a visible gap on the left edge.
+
+    func testMaximizeOnePointNarrowStaysPut() {
+        let zone = CGRect(x: 0, y: 0, width: 1679, height: 1079)
+        let window = CGRect(x: 0, y: 0, width: 1678, height: 1079)
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.left, .right, .top, .bottom])
+        XCTAssertTrue(result.equalTo(window))
+    }
+
+    func testRightHalfOnePointNarrowStaysPut() {
+        let zone = CGRect(x: 840, y: 0, width: 839, height: 1079)
+        let window = CGRect(x: 840, y: 0, width: 838, height: 1079)
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        XCTAssertTrue(result.equalTo(window))
+    }
+
+    func testOnePointShortHeightStaysPut() {
+        let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let window = CGRect(x: 1000, y: 0, width: 1000, height: 1199)
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        XCTAssertTrue(result.equalTo(window))
+    }
+
+    func testShortfallJustOverToleranceStillAligns() {
+        let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let window = CGRect(x: 1000, y: 0, width: 998.5, height: 1200)
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        XCTAssertEqual(result.origin.x, 1001.5, accuracy: 0.001) // zone.maxX - width = 2000 - 998.5
+    }
+
+    func testOnePointNarrowLeavesOtherAxisAlignmentIntact() {
+        let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let window = CGRect(x: 1000, y: 0, width: 999, height: 800) // a point narrow, genuinely short
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        XCTAssertEqual(result.origin.x, 1000, accuracy: 0.001) // width within tolerance, left alone
+        XCTAssertEqual(result.origin.y, 200, accuracy: 0.001)  // height still centered: (1200-800)/2
+    }
+
     func testEdgesAndCornersAlignmentKeepsHalfEdges() {
         let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
         let rightHalf = CGRect(x: 1000, y: 0, width: 1000, height: 1200)


### PR DESCRIPTION
Fixes #1852.

## Problem

With the Dock on the right, Maximize leaves the window 1pt narrower than the screen and shifted 1pt right (x=1 instead of x=0). From the log in the issue, on a 1679pt-wide visible frame:

```
AX sizing proposed: (1679.0, 1079.0), result: (1678.0, 1079.0)
AX position proposed: (1.0, 38.0), result: (1.0, 38.0)
maximize, calculatedRect: (0.0, 38.0, 1679.0, 1079.0), resultRect: (1.0, 38.0, 1678.0, 1079.0)
```

Two things combine, as diagnosed by @nyg in the issue:

1. macOS shortens an AX size change that grows a window's right edge onto the Dock edge, so a requested width of 1679 comes back as 1678. A position change to the same edge is not clamped, which is why Left Half → Last Two Thirds (resized at x=0, then moved) is exact while Right Half → Last Two Thirds is not.
2. `ClampedWindowAligner` reads that 1pt shortfall as a clamped window. Maximize shares both left and right screen edges, so the window gets centered: `round((1679 - 1678) / 2) = 1`.

The net effect is that the 1pt gap moves off the Dock edge, where it was invisible, onto the opposite edge, where it is not.

## Fix

Skip realignment on an axis when the shortfall there is within a point. I took the first of the two options suggested in the issue — the alternative, applying the size to the left of the target and then moving the window, would change `AccessibilityElement.setFrame` behavior for every action to address a 1pt cosmetic issue.

The check is per axis, so a window that is a point narrow but genuinely short still gets aligned vertically. Real clamps — a window holding a fixed aspect ratio, for example — are unaffected, since those miss the zone by far more than a point.

## Tests

Five cases added to `ClampedWindowAlignerTests`, using the measurements from the issue:

- `testMaximizeOnePointNarrowStaysPut` — the reported case (zone 1679 wide, window 1678, all four edges shared)
- `testRightHalfOnePointNarrowStaysPut` — the right-half variant from the issue's measurement table
- `testOnePointShortHeightStaysPut` — same tolerance on the vertical axis
- `testOnePointNarrowLeavesOtherAxisAlignmentIntact` — a point narrow *and* genuinely short: width is left alone, height still centers
- `testShortfallJustOverToleranceStillAligns` — pins the boundary so the tolerance can't be widened later without a test failing

The first four fail on `main` and pass with this change. The boundary test passes both ways by design. Full suite: 338 tests, 0 failures.