### PR TITLE
Add full-height vertical eighth window actions

### DIFF
--- a/Rectangle.xcodeproj/project.pbxproj
+++ b/Rectangle.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		F51A7467767F8EAF97321A00 /* TopRightSixteenthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD222258713B13274FB651B0 /* TopRightSixteenthCalculation.swift */; };
 		F7B6C43BB57F8064F49DDBB6 /* BottomLeftSixteenthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE147786B2CD7350FAFB700 /* BottomLeftSixteenthCalculation.swift */; };
 		FA34D0FF2F7E896E00EEBEF1 /* SpecificDisplayCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA34D0FE2F7E896E00EEBEF1 /* SpecificDisplayCalculation.swift */; };
+		A8E100012F99000000000002 /* VerticalEighthCalculation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E100012F99000000000001 /* VerticalEighthCalculation.swift */; };
 		FDE8FCE027C2950400EACCAA /* MultiWindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE8FCDF27C2950400EACCAA /* MultiWindowManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -432,6 +433,7 @@
 		F1AC0DE000000000000000C1 /* OverlapOffsetGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlapOffsetGeometry.swift; sourceTree = "<group>"; };
 		F3592F8E85CE82B8FA662A31 /* TwelfthsRepeated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwelfthsRepeated.swift; sourceTree = "<group>"; };
 		FA34D0FE2F7E896E00EEBEF1 /* SpecificDisplayCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecificDisplayCalculation.swift; sourceTree = "<group>"; };
+		A8E100012F99000000000001 /* VerticalEighthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalEighthCalculation.swift; sourceTree = "<group>"; };
 		FD222258713B13274FB651B0 /* TopRightSixteenthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopRightSixteenthCalculation.swift; sourceTree = "<group>"; };
 		FDE8FCDF27C2950400EACCAA /* MultiWindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowManager.swift; sourceTree = "<group>"; };
 		FEE147786B2CD7350FAFB700 /* BottomLeftSixteenthCalculation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomLeftSixteenthCalculation.swift; sourceTree = "<group>"; };
@@ -514,6 +516,7 @@
 			isa = PBXGroup;
 			children = (
 				FA34D0FE2F7E896E00EEBEF1 /* SpecificDisplayCalculation.swift */,
+				A8E100012F99000000000001 /* VerticalEighthCalculation.swift */,
 				BB0B80442EFB0AF900A9B165 /* BottomVerticalThirdCalculation.swift */,
 				BB0B80452EFB0AF900A9B165 /* BottomVerticalTwoThirdsCalculation.swift */,
 				BB0B80462EFB0AF900A9B165 /* MiddleVerticalThirdCalculation.swift */,
@@ -1198,6 +1201,7 @@
 				F7B6C43BB57F8064F49DDBB6 /* BottomLeftSixteenthCalculation.swift in Sources */,
 				9988C2A18B6AF03E09204981 /* BottomCenterLeftSixteenthCalculation.swift in Sources */,
 				FA34D0FF2F7E896E00EEBEF1 /* SpecificDisplayCalculation.swift in Sources */,
+				A8E100012F99000000000002 /* VerticalEighthCalculation.swift in Sources */,
 				630644571003EB468CB643D8 /* BottomCenterRightSixteenthCalculation.swift in Sources */,
 				2D240EE416CC03AC921E3A4F /* BottomRightSixteenthCalculation.swift in Sources */,
 			);

--- a/Rectangle/Assets.xcassets/WindowPositions/fifthVerticalEighthTemplate.imageset/Contents.json
+++ b/Rectangle/Assets.xcassets/WindowPositions/fifthVerticalEighthTemplate.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "fifthVerticalEighthTemplate.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Rectangle/Assets.xcassets/WindowPositions/fifthVerticalEighthTemplate.imageset/fifthVerticalEighthTemplate.svg
+++ b/Rectangle/Assets.xcassets/WindowPositions/fifthVerticalEighthTemplate.imageset/fifthVerticalEighthTemplate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="21" height="14" viewBox="0 0 21 14">
+  <rect x="0.5" y="0.5" width="20" height="13" rx="1" fill="none" stroke="black"/>
+  <rect x="10.5" y="1" width="2.375" height="12" fill="black"/>
+</svg>

--- a/Rectangle/Assets.xcassets/WindowPositions/firstVerticalEighthTemplate.imageset/Contents.json
+++ b/Rectangle/Assets.xcassets/WindowPositions/firstVerticalEighthTemplate.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "firstVerticalEighthTemplate.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Rectangle/Assets.xcassets/WindowPositions/firstVerticalEighthTemplate.imageset/firstVerticalEighthTemplate.svg
+++ b/Rectangle/Assets.xcassets/WindowPositions/firstVerticalEighthTemplate.imageset/firstVerticalEighthTemplate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="21" height="14" viewBox="0 0 21 14">
+  <rect x="0.5" y="0.5" width="20" height="13" rx="1" fill="none" stroke="black"/>
+  <rect x="1" y="1" width="2.375" height="12" fill="black"/>
+</svg>

--- a/Rectangle/Assets.xcassets/WindowPositions/fourthVerticalEighthTemplate.imageset/Contents.json
+++ b/Rectangle/Assets.xcassets/WindowPositions/fourthVerticalEighthTemplate.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "fourthVerticalEighthTemplate.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Rectangle/Assets.xcassets/WindowPositions/fourthVerticalEighthTemplate.imageset/fourthVerticalEighthTemplate.svg
+++ b/Rectangle/Assets.xcassets/WindowPositions/fourthVerticalEighthTemplate.imageset/fourthVerticalEighthTemplate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="21" height="14" viewBox="0 0 21 14">
+  <rect x="0.5" y="0.5" width="20" height="13" rx="1" fill="none" stroke="black"/>
+  <rect x="8.125" y="1" width="2.375" height="12" fill="black"/>
+</svg>

--- a/Rectangle/Assets.xcassets/WindowPositions/lastVerticalEighthTemplate.imageset/Contents.json
+++ b/Rectangle/Assets.xcassets/WindowPositions/lastVerticalEighthTemplate.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "lastVerticalEighthTemplate.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Rectangle/Assets.xcassets/WindowPositions/lastVerticalEighthTemplate.imageset/lastVerticalEighthTemplate.svg
+++ b/Rectangle/Assets.xcassets/WindowPositions/lastVerticalEighthTemplate.imageset/lastVerticalEighthTemplate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="21" height="14" viewBox="0 0 21 14">
+  <rect x="0.5" y="0.5" width="20" height="13" rx="1" fill="none" stroke="black"/>
+  <rect x="17.625" y="1" width="2.375" height="12" fill="black"/>
+</svg>

--- a/Rectangle/Assets.xcassets/WindowPositions/secondVerticalEighthTemplate.imageset/Contents.json
+++ b/Rectangle/Assets.xcassets/WindowPositions/secondVerticalEighthTemplate.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "secondVerticalEighthTemplate.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Rectangle/Assets.xcassets/WindowPositions/secondVerticalEighthTemplate.imageset/secondVerticalEighthTemplate.svg
+++ b/Rectangle/Assets.xcassets/WindowPositions/secondVerticalEighthTemplate.imageset/secondVerticalEighthTemplate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="21" height="14" viewBox="0 0 21 14">
+  <rect x="0.5" y="0.5" width="20" height="13" rx="1" fill="none" stroke="black"/>
+  <rect x="3.375" y="1" width="2.375" height="12" fill="black"/>
+</svg>

--- a/Rectangle/Assets.xcassets/WindowPositions/seventhVerticalEighthTemplate.imageset/Contents.json
+++ b/Rectangle/Assets.xcassets/WindowPositions/seventhVerticalEighthTemplate.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "seventhVerticalEighthTemplate.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Rectangle/Assets.xcassets/WindowPositions/seventhVerticalEighthTemplate.imageset/seventhVerticalEighthTemplate.svg
+++ b/Rectangle/Assets.xcassets/WindowPositions/seventhVerticalEighthTemplate.imageset/seventhVerticalEighthTemplate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="21" height="14" viewBox="0 0 21 14">
+  <rect x="0.5" y="0.5" width="20" height="13" rx="1" fill="none" stroke="black"/>
+  <rect x="15.25" y="1" width="2.375" height="12" fill="black"/>
+</svg>

--- a/Rectangle/Assets.xcassets/WindowPositions/sixthVerticalEighthTemplate.imageset/Contents.json
+++ b/Rectangle/Assets.xcassets/WindowPositions/sixthVerticalEighthTemplate.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "sixthVerticalEighthTemplate.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Rectangle/Assets.xcassets/WindowPositions/sixthVerticalEighthTemplate.imageset/sixthVerticalEighthTemplate.svg
+++ b/Rectangle/Assets.xcassets/WindowPositions/sixthVerticalEighthTemplate.imageset/sixthVerticalEighthTemplate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="21" height="14" viewBox="0 0 21 14">
+  <rect x="0.5" y="0.5" width="20" height="13" rx="1" fill="none" stroke="black"/>
+  <rect x="12.875" y="1" width="2.375" height="12" fill="black"/>
+</svg>

--- a/Rectangle/Assets.xcassets/WindowPositions/thirdVerticalEighthTemplate.imageset/Contents.json
+++ b/Rectangle/Assets.xcassets/WindowPositions/thirdVerticalEighthTemplate.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "thirdVerticalEighthTemplate.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Rectangle/Assets.xcassets/WindowPositions/thirdVerticalEighthTemplate.imageset/thirdVerticalEighthTemplate.svg
+++ b/Rectangle/Assets.xcassets/WindowPositions/thirdVerticalEighthTemplate.imageset/thirdVerticalEighthTemplate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="21" height="14" viewBox="0 0 21 14">
+  <rect x="0.5" y="0.5" width="20" height="13" rx="1" fill="none" stroke="black"/>
+  <rect x="5.75" y="1" width="2.375" height="12" fill="black"/>
+</svg>

--- a/Rectangle/PrefsWindow/PrefsViewController.swift
+++ b/Rectangle/PrefsWindow/PrefsViewController.swift
@@ -66,7 +66,9 @@ class PrefsViewController: NSViewController {
     
     // Settings
     override func awakeFromNib() {
-        
+        // Storyboard loading can awaken this controller more than once.
+        guard actionsToViews.isEmpty else { return }
+
         actionsToViews = [
             .leftHalf: leftHalfShortcutView,
             .rightHalf: rightHalfShortcutView,
@@ -111,6 +113,8 @@ class PrefsViewController: NSViewController {
             .bottomRightSixth: bottomRightSixthShortcutView
         ]
         
+        addVerticalEighthShortcutViews()
+
         for (action, view) in actionsToViews {
             view.setAssociatedUserDefaultsKey(action.name, withTransformerName: MASDictionaryTransformerName)
         }
@@ -126,6 +130,42 @@ class PrefsViewController: NSViewController {
         additionalShortcutsStackView.isHidden = true
     }
     
+    private func addVerticalEighthShortcutViews() {
+        let actionColumns: [[WindowAction]] = [
+            [.firstVerticalEighth, .secondVerticalEighth, .thirdVerticalEighth, .fourthVerticalEighth],
+            [.fifthVerticalEighth, .sixthVerticalEighth, .seventhVerticalEighth, .lastVerticalEighth]
+        ]
+
+        for (view, actions) in zip(additionalShortcutsStackView.arrangedSubviews, actionColumns) {
+            guard let column = view as? NSStackView else { continue }
+            for action in actions {
+                guard let title = action.displayName else { continue }
+                let label = NSTextField(labelWithString: title)
+                label.alignment = .right
+                let icon = NSImageView(image: action.image)
+                let labelStack = NSStackView(views: [label, icon])
+                labelStack.orientation = .horizontal
+                labelStack.alignment = .centerY
+                labelStack.spacing = 8
+
+                let shortcutView = MASShortcutView(frame: NSRect(x: 0, y: 0, width: 160, height: 19))
+                shortcutView.translatesAutoresizingMaskIntoConstraints = false
+                let row = NSStackView(views: [labelStack, shortcutView])
+                row.orientation = .horizontal
+                row.alignment = .centerY
+                row.spacing = 18
+                column.addArrangedSubview(row)
+                NSLayoutConstraint.activate([
+                    icon.widthAnchor.constraint(equalToConstant: 21),
+                    icon.heightAnchor.constraint(equalToConstant: 14),
+                    shortcutView.widthAnchor.constraint(equalToConstant: 160),
+                    shortcutView.heightAnchor.constraint(equalToConstant: 19)
+                ])
+                actionsToViews[action] = shortcutView
+            }
+        }
+    }
+
     @IBAction func toggleShowMore(_ sender: NSButton) {
         additionalShortcutsStackView.isHidden = !additionalShortcutsStackView.isHidden
         showMoreButton.title = additionalShortcutsStackView.isHidden

--- a/Rectangle/WindowAction.swift
+++ b/Rectangle/WindowAction.swift
@@ -135,7 +135,15 @@ enum WindowAction: Int, Codable {
          displaySix = 125,
          displaySeven = 126,
          displayEight = 127,
-         displayNine = 128
+         displayNine = 128,
+         firstVerticalEighth = 129,
+         secondVerticalEighth = 130,
+         thirdVerticalEighth = 131,
+         fourthVerticalEighth = 132,
+         fifthVerticalEighth = 133,
+         sixthVerticalEighth = 134,
+         seventhVerticalEighth = 135,
+         lastVerticalEighth = 136
 
     // Order matters here - it's used in the menu
     static let active = [leftHalf, rightHalf, centerHalf, topHalf, bottomHalf,
@@ -152,6 +160,8 @@ enum WindowAction: Int, Codable {
                          topLeftThird, topRightThird, bottomLeftThird, bottomRightThird,
                          topLeftEighth, topCenterLeftEighth, topCenterRightEighth, topRightEighth,
                          bottomLeftEighth, bottomCenterLeftEighth, bottomCenterRightEighth, bottomRightEighth,
+                         firstVerticalEighth, secondVerticalEighth, thirdVerticalEighth, fourthVerticalEighth,
+                         fifthVerticalEighth, sixthVerticalEighth, seventhVerticalEighth, lastVerticalEighth,
                          topLeftNinth, topCenterNinth, topRightNinth,
                          middleLeftNinth, middleCenterNinth, middleRightNinth,
                          bottomLeftNinth, bottomCenterNinth, bottomRightNinth,
@@ -328,6 +338,14 @@ enum WindowAction: Int, Codable {
         case .displaySeven: return "displaySeven"
         case .displayEight: return "displayEight"
         case .displayNine: return "displayNine"
+        case .firstVerticalEighth: return "firstVerticalEighth"
+        case .secondVerticalEighth: return "secondVerticalEighth"
+        case .thirdVerticalEighth: return "thirdVerticalEighth"
+        case .fourthVerticalEighth: return "fourthVerticalEighth"
+        case .fifthVerticalEighth: return "fifthVerticalEighth"
+        case .sixthVerticalEighth: return "sixthVerticalEighth"
+        case .seventhVerticalEighth: return "seventhVerticalEighth"
+        case .lastVerticalEighth: return "lastVerticalEighth"
         }
     }
 
@@ -538,6 +556,30 @@ enum WindowAction: Int, Codable {
         case .bottomRightEighth:
             key = "bottomRightEighth.title"
             value = "Bottom Right Eighth"
+        case .firstVerticalEighth:
+            key = "firstVerticalEighth.title"
+            value = "First Vertical Eighth"
+        case .secondVerticalEighth:
+            key = "secondVerticalEighth.title"
+            value = "Second Vertical Eighth"
+        case .thirdVerticalEighth:
+            key = "thirdVerticalEighth.title"
+            value = "Third Vertical Eighth"
+        case .fourthVerticalEighth:
+            key = "fourthVerticalEighth.title"
+            value = "Fourth Vertical Eighth"
+        case .fifthVerticalEighth:
+            key = "fifthVerticalEighth.title"
+            value = "Fifth Vertical Eighth"
+        case .sixthVerticalEighth:
+            key = "sixthVerticalEighth.title"
+            value = "Sixth Vertical Eighth"
+        case .seventhVerticalEighth:
+            key = "seventhVerticalEighth.title"
+            value = "Seventh Vertical Eighth"
+        case .lastVerticalEighth:
+            key = "lastVerticalEighth.title"
+            value = "Last Vertical Eighth"
         case .doubleHeightUp, .doubleHeightDown, .doubleWidthLeft, .doubleWidthRight, .halveHeightUp, .halveHeightDown, .halveWidthLeft, .halveWidthRight:
             return nil
         case .specified, .reverseAll, .tileAll, .cascadeAll, .leftTodo, .rightTodo, .cascadeActiveApp, .tileActiveApp:
@@ -797,6 +839,14 @@ enum WindowAction: Int, Codable {
         case .bottomCenterLeftEighth: return NSImage(imageLiteralResourceName: "cblEighthTemplate")
         case .bottomCenterRightEighth: return NSImage(imageLiteralResourceName: "cbrEighthTemplate")
         case .bottomRightEighth: return NSImage(imageLiteralResourceName: "brEighthTemplate")
+        case .firstVerticalEighth: return NSImage(imageLiteralResourceName: "firstVerticalEighthTemplate")
+        case .secondVerticalEighth: return NSImage(imageLiteralResourceName: "secondVerticalEighthTemplate")
+        case .thirdVerticalEighth: return NSImage(imageLiteralResourceName: "thirdVerticalEighthTemplate")
+        case .fourthVerticalEighth: return NSImage(imageLiteralResourceName: "fourthVerticalEighthTemplate")
+        case .fifthVerticalEighth: return NSImage(imageLiteralResourceName: "fifthVerticalEighthTemplate")
+        case .sixthVerticalEighth: return NSImage(imageLiteralResourceName: "sixthVerticalEighthTemplate")
+        case .seventhVerticalEighth: return NSImage(imageLiteralResourceName: "seventhVerticalEighthTemplate")
+        case .lastVerticalEighth: return NSImage(imageLiteralResourceName: "lastVerticalEighthTemplate")
         case .doubleHeightUp: return  NSImage()
         case .doubleHeightDown: return  NSImage()
         case .doubleWidthLeft: return  NSImage()
@@ -860,6 +910,10 @@ enum WindowAction: Int, Codable {
         switch self {
         case .leftHalf: return .right
         case .rightHalf: return .left
+        case .firstVerticalEighth: return .right
+        case .secondVerticalEighth, .thirdVerticalEighth, .fourthVerticalEighth,
+             .fifthVerticalEighth, .sixthVerticalEighth, .seventhVerticalEighth: return [.left, .right]
+        case .lastVerticalEighth: return .left
         case .bottomHalf: return .top
         case .topHalf: return .bottom
         case .bottomLeft: return [.top, .right]
@@ -883,6 +937,8 @@ enum WindowAction: Int, Codable {
             .topLeftThird, .topRightThird, .bottomLeftThird, .bottomRightThird,
             .topLeftEighth, .topCenterLeftEighth, .topCenterRightEighth, .topRightEighth,
             .bottomLeftEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth, .bottomRightEighth,
+            .firstVerticalEighth, .secondVerticalEighth, .thirdVerticalEighth, .fourthVerticalEighth,
+            .fifthVerticalEighth, .sixthVerticalEighth, .seventhVerticalEighth, .lastVerticalEighth,
             .topLeftTwelfth, .topCenterLeftTwelfth, .topCenterRightTwelfth, .topRightTwelfth,
             .middleLeftTwelfth, .middleCenterLeftTwelfth, .middleCenterRightTwelfth, .middleRightTwelfth,
             .bottomLeftTwelfth, .bottomCenterLeftTwelfth, .bottomCenterRightTwelfth, .bottomRightTwelfth,
@@ -944,7 +1000,9 @@ enum WindowAction: Int, Codable {
         case .firstThird, .centerThird, .lastThird, .firstTwoThirds, .centerTwoThirds, .lastTwoThirds: return .thirds
         case .firstFourth, .secondFourth, .thirdFourth, .lastFourth, .firstThreeFourths, .centerThreeFourths, .lastThreeFourths: return .fourths
         case .topLeftSixth, .topCenterSixth, .topRightSixth, .bottomLeftSixth, .bottomCenterSixth, .bottomRightSixth: return .sixths
-        case .topLeftEighth, .topCenterLeftEighth, .topCenterRightEighth, .topRightEighth, .bottomLeftEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth, .bottomRightEighth: return .eighths
+        case .topLeftEighth, .topCenterLeftEighth, .topCenterRightEighth, .topRightEighth, .bottomLeftEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth, .bottomRightEighth,
+             .firstVerticalEighth, .secondVerticalEighth, .thirdVerticalEighth, .fourthVerticalEighth,
+             .fifthVerticalEighth, .sixthVerticalEighth, .seventhVerticalEighth, .lastVerticalEighth: return .eighths
         case .topLeftNinth, .topCenterNinth, .topRightNinth, .middleLeftNinth, .middleCenterNinth, .middleRightNinth, .bottomLeftNinth, .bottomCenterNinth, .bottomRightNinth: return .ninths
         case .topLeftTwelfth, .topCenterLeftTwelfth, .topCenterRightTwelfth, .topRightTwelfth, .middleLeftTwelfth, .middleCenterLeftTwelfth, .middleCenterRightTwelfth, .middleRightTwelfth, .bottomLeftTwelfth, .bottomCenterLeftTwelfth, .bottomCenterRightTwelfth, .bottomRightTwelfth: return .twelfths
         case .topLeftSixteenth, .topCenterLeftSixteenth, .topCenterRightSixteenth, .topRightSixteenth, .upperMiddleLeftSixteenth, .upperMiddleCenterLeftSixteenth, .upperMiddleCenterRightSixteenth, .upperMiddleRightSixteenth, .lowerMiddleLeftSixteenth, .lowerMiddleCenterLeftSixteenth, .lowerMiddleCenterRightSixteenth, .lowerMiddleRightSixteenth, .bottomLeftSixteenth, .bottomCenterLeftSixteenth, .bottomCenterRightSixteenth, .bottomRightSixteenth: return .sixteenths

--- a/Rectangle/WindowCalculation/VerticalEighthCalculation.swift
+++ b/Rectangle/WindowCalculation/VerticalEighthCalculation.swift
@@ -1,0 +1,29 @@
+/// VerticalEighthCalculation.swift
+
+import Foundation
+
+class VerticalEighthCalculation: WindowCalculation {
+
+    override func calculateRect(_ params: RectCalculationParameters) -> RectResult {
+        let column: CGFloat
+        switch params.action {
+        case .firstVerticalEighth: column = 0
+        case .secondVerticalEighth: column = 1
+        case .thirdVerticalEighth: column = 2
+        case .fourthVerticalEighth: column = 3
+        case .fifthVerticalEighth: column = 4
+        case .sixthVerticalEighth: column = 5
+        case .seventhVerticalEighth: column = 6
+        case .lastVerticalEighth: column = 7
+        default: return RectResult(.null)
+        }
+
+        let visibleFrameOfScreen = params.visibleFrameOfScreen
+        let left = floor(visibleFrameOfScreen.width * column / 8.0)
+        let right = floor(visibleFrameOfScreen.width * (column + 1) / 8.0)
+        var rect = visibleFrameOfScreen
+        rect.origin.x += left
+        rect.size.width = right - left
+        return RectResult(rect)
+    }
+}

--- a/Rectangle/WindowCalculation/WindowCalculation.swift
+++ b/Rectangle/WindowCalculation/WindowCalculation.swift
@@ -266,6 +266,7 @@ class WindowCalculationFactory {
     static let bottomCenterRightSixteenthCalculation = BottomCenterRightSixteenthCalculation()
     static let bottomRightSixteenthCalculation = BottomRightSixteenthCalculation()
     static let specificDisplayCalculation = SpecificDisplayCalculation()
+    static let verticalEighthCalculation = VerticalEighthCalculation()
 
     static let calculationsByAction: [WindowAction: WindowCalculation] = [
      .leftHalf: leftHalfCalculation,
@@ -334,6 +335,14 @@ class WindowCalculationFactory {
      .bottomCenterLeftEighth: bottomCenterLeftEighthCalculation,
      .bottomCenterRightEighth: bottomCenterRightEighthCalculation,
      .bottomRightEighth: bottomRightEighthCalculation,
+     .firstVerticalEighth: verticalEighthCalculation,
+     .secondVerticalEighth: verticalEighthCalculation,
+     .thirdVerticalEighth: verticalEighthCalculation,
+     .fourthVerticalEighth: verticalEighthCalculation,
+     .fifthVerticalEighth: verticalEighthCalculation,
+     .sixthVerticalEighth: verticalEighthCalculation,
+     .seventhVerticalEighth: verticalEighthCalculation,
+     .lastVerticalEighth: verticalEighthCalculation,
      .halveHeightUp: halfOrDoubleDimensionCalculation,
      .halveHeightDown: halfOrDoubleDimensionCalculation,
      .halveWidthLeft: halfOrDoubleDimensionCalculation,

--- a/Rectangle/mul.lproj/Main.xcstrings
+++ b/Rectangle/mul.lproj/Main.xcstrings
@@ -17735,6 +17735,42 @@
         }
       }
     },
+    "fifthVerticalEighth.title" : {
+      "comment" : "Full-height column 5 of 8, from left to right.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fifth Vertical Eighth"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直向八分之一（第 5 欄）"
+          }
+        }
+      }
+    },
+    "firstVerticalEighth.title" : {
+      "comment" : "Full-height column 1 of 8, from left to right.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First Vertical Eighth"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直向八分之一（第 1 欄）"
+          }
+        }
+      }
+    },
     "FKE-Sm-Kum.title" : {
       "comment" : "Class = \"NSMenuItem\"; title = \"Rectangle Help\"; ObjectID = \"FKE-Sm-Kum\";",
       "extractionState" : "extracted_with_value",
@@ -18843,6 +18879,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "四等分直欄"
+          }
+        }
+      }
+    },
+    "fourthVerticalEighth.title" : {
+      "comment" : "Full-height column 4 of 8, from left to right.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fourth Vertical Eighth"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直向八分之一（第 4 欄）"
           }
         }
       }
@@ -27488,6 +27542,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chiều rộng lớn hơn"
+          }
+        }
+      }
+    },
+    "lastVerticalEighth.title" : {
+      "comment" : "Full-height column 8 of 8, from left to right.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last Vertical Eighth"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直向八分之一（第 8 欄）"
           }
         }
       }
@@ -38896,6 +38968,42 @@
         }
       }
     },
+    "secondVerticalEighth.title" : {
+      "comment" : "Full-height column 2 of 8, from left to right.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Second Vertical Eighth"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直向八分之一（第 2 欄）"
+          }
+        }
+      }
+    },
+    "seventhVerticalEighth.title" : {
+      "comment" : "Full-height column 7 of 8, from left to right.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seventh Vertical Eighth"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直向八分之一（第 7 欄）"
+          }
+        }
+      }
+    },
     "Show additional sizes in menu" : {
       "localizations" : {
         "ko" : {
@@ -39303,6 +39411,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "六等分"
+          }
+        }
+      }
+    },
+    "sixthVerticalEighth.title" : {
+      "comment" : "Full-height column 6 of 8, from left to right.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sixth Vertical Eighth"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直向八分之一（第 6 欄）"
           }
         }
       }
@@ -41062,6 +41188,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "⅓；靠近角落則上半／下半"
+          }
+        }
+      }
+    },
+    "thirdVerticalEighth.title" : {
+      "comment" : "Full-height column 3 of 8, from left to right.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Third Vertical Eighth"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直向八分之一（第 3 欄）"
           }
         }
       }

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -14,6 +14,242 @@ class RectangleTests: XCTestCase {
     }
 }
 
+class VerticalEighthCalculationTests: XCTestCase {
+
+    private let actionNames = [
+        "firstVerticalEighth", "secondVerticalEighth", "thirdVerticalEighth", "fourthVerticalEighth",
+        "fifthVerticalEighth", "sixthVerticalEighth", "seventhVerticalEighth", "lastVerticalEighth"
+    ]
+
+    func testActionsTileUsableFrameIntoEightFullHeightColumns() throws {
+        let frame = CGRect(x: 0, y: 40, width: 3840, height: 1000)
+        let expected = [
+            CGRect(x: 0, y: 40, width: 480, height: 1000),
+            CGRect(x: 480, y: 40, width: 480, height: 1000),
+            CGRect(x: 960, y: 40, width: 480, height: 1000),
+            CGRect(x: 1440, y: 40, width: 480, height: 1000),
+            CGRect(x: 1920, y: 40, width: 480, height: 1000),
+            CGRect(x: 2400, y: 40, width: 480, height: 1000),
+            CGRect(x: 2880, y: 40, width: 480, height: 1000),
+            CGRect(x: 3360, y: 40, width: 480, height: 1000)
+        ]
+
+        XCTAssertEqual(try rectangles(in: frame), expected)
+    }
+
+    func testGapsUseHalfInsetsAtSharedColumnEdges() throws {
+        let frame = CGRect(x: 0, y: 40, width: 3840, height: 1000)
+        let rects = try rectangles(in: frame)
+        let gapped = try zip(actions(), rects).map { action, rect in
+            GapCalculation.applyGaps(rect, dimension: action.gapsApplicable,
+                                     sharedEdges: action.gapSharedEdge, gapSize: 10)
+        }
+
+        XCTAssertEqual(gapped, [
+            CGRect(x: 10, y: 50, width: 465, height: 980),
+            CGRect(x: 485, y: 50, width: 470, height: 980),
+            CGRect(x: 965, y: 50, width: 470, height: 980),
+            CGRect(x: 1445, y: 50, width: 470, height: 980),
+            CGRect(x: 1925, y: 50, width: 470, height: 980),
+            CGRect(x: 2405, y: 50, width: 470, height: 980),
+            CGRect(x: 2885, y: 50, width: 470, height: 980),
+            CGRect(x: 3365, y: 50, width: 465, height: 980)
+        ])
+    }
+
+    func testActionsHaveMenuMetadataAndStableIdentifiers() throws {
+        let actions = try actions()
+        XCTAssertEqual(WindowAction.active.filter { actionNames.contains($0.name) }, actions)
+        XCTAssertEqual(actions.map { $0.rawValue }, [129, 130, 131, 132, 133, 134, 135, 136])
+        XCTAssertEqual(try JSONDecoder().decode([WindowAction].self, from: JSONEncoder().encode(actions)), actions)
+        for action in actions {
+            XCTAssertEqual(action.category, .eighths)
+            XCTAssertFalse(try XCTUnwrap(action.displayName).isEmpty)
+            XCTAssertTrue(action.image.isValid)
+            XCTAssertTrue(action.image.isTemplate)
+            XCTAssertNil(action.spectacleDefault)
+            XCTAssertNil(action.alternateDefault)
+        }
+    }
+
+    func testActionsAreAvailableInShortcutPreferences() throws {
+        let storyboard = NSStoryboard(name: "Main", bundle: Bundle(for: PrefsViewController.self))
+        let windowController = try XCTUnwrap(storyboard.instantiateController(withIdentifier: "PrefsWindowController") as? NSWindowController)
+        defer { windowController.close() }
+        let tabController = try XCTUnwrap(windowController.contentViewController as? NSTabViewController)
+        let controller = try XCTUnwrap(tabController.children.compactMap { $0 as? PrefsViewController }.first)
+        _ = controller.view
+
+        func shortcutViews(in view: NSView) -> [MASShortcutView] {
+            if let shortcutView = view as? MASShortcutView { return [shortcutView] }
+            return view.subviews.flatMap { shortcutViews(in: $0) }
+        }
+
+        let originalViews = controller.actionsToViews
+        let expectedActions = try actions()
+        for _ in 0..<2 {
+            controller.toggleShowMore(controller.showMoreButton)
+            let visibleShortcuts = shortcutViews(in: controller.additionalShortcutsStackView)
+            let verticalShortcuts = visibleShortcuts.filter { actionNames.contains($0.associatedUserDefaultsKey ?? "") }
+            XCTAssertEqual(verticalShortcuts.count, 8)
+            for action in expectedActions {
+                let shortcutView = try XCTUnwrap(controller.actionsToViews[action], "Missing shortcut: \(action.name)")
+                XCTAssertEqual(visibleShortcuts.filter { $0.associatedUserDefaultsKey == action.name }.count, 1, action.name)
+                XCTAssertEqual(shortcutView.associatedUserDefaultsKey, action.name)
+                XCTAssertTrue(shortcutView.isDescendant(of: controller.additionalShortcutsStackView))
+                XCTAssertTrue(shortcutView === originalViews[action])
+                let row = try XCTUnwrap(shortcutView.superview as? NSStackView)
+                let labelStack = try XCTUnwrap(row.arrangedSubviews.first as? NSStackView)
+                let label = try XCTUnwrap(labelStack.arrangedSubviews.first as? NSTextField)
+                XCTAssertEqual(label.stringValue, action.displayName)
+            }
+            for (action, shortcutView) in originalViews where !actionNames.contains(action.name) {
+                XCTAssertTrue(controller.actionsToViews[action] === shortcutView)
+                XCTAssertEqual(shortcutViews(in: controller.view).filter { $0.associatedUserDefaultsKey == action.name }.count, 1, action.name)
+            }
+            controller.toggleShowMore(controller.showMoreButton)
+            controller.awakeFromNib()
+        }
+    }
+
+    func testVerticalEighthNamesHaveEnglishAndTraditionalChineseLocalizations() throws {
+        let expectedNames: [(language: String, titles: [String])] = [
+            ("en", ["First Vertical Eighth", "Second Vertical Eighth", "Third Vertical Eighth", "Fourth Vertical Eighth",
+                    "Fifth Vertical Eighth", "Sixth Vertical Eighth", "Seventh Vertical Eighth", "Last Vertical Eighth"]),
+            ("zh-Hant", ["直向八分之一（第 1 欄）", "直向八分之一（第 2 欄）", "直向八分之一（第 3 欄）", "直向八分之一（第 4 欄）",
+                         "直向八分之一（第 5 欄）", "直向八分之一（第 6 欄）", "直向八分之一（第 7 欄）", "直向八分之一（第 8 欄）"])
+        ]
+        let appBundle = Bundle(for: PrefsViewController.self)
+        for expected in expectedNames {
+            let path = try XCTUnwrap(appBundle.path(forResource: expected.language, ofType: "lproj"))
+            let localizedBundle = try XCTUnwrap(Bundle(path: path))
+            for (action, title) in try zip(actions(), expected.titles) {
+                XCTAssertEqual(localizedBundle.localizedString(forKey: action.name + ".title", value: nil, table: "Main"), title)
+                if appBundle.preferredLocalizations.first == expected.language {
+                    XCTAssertEqual(action.displayName, title)
+                }
+            }
+        }
+    }
+
+    func testNonDivisibleWidthTilesWithoutGapsOrOverlap() throws {
+        let rects = try rectangles(in: CGRect(x: -1923, y: 37, width: 1923, height: 1041))
+        XCTAssertEqual(rects.map { $0.minX }, [-1923, -1683, -1443, -1202, -962, -722, -481, -241])
+        XCTAssertEqual(rects.map { $0.width }, [240, 240, 241, 240, 240, 241, 240, 241])
+        XCTAssertEqual(rects.last?.maxX, 0)
+        for (left, right) in zip(rects, rects.dropFirst()) {
+            XCTAssertEqual(left.maxX, right.minX)
+        }
+    }
+
+    func testOtherResolutionsAndPortraitDisplaysKeepFullHeightColumns() throws {
+        let fixtures: [(frame: CGRect, width: CGFloat, origins: [CGFloat])] = [
+            (CGRect(x: 10, y: 30, width: 2560, height: 1400), 320,
+             [10, 330, 650, 970, 1290, 1610, 1930, 2250]),
+            (CGRect(x: -5120, y: -1440, width: 5120, height: 1440), 640,
+             [-5120, -4480, -3840, -3200, -2560, -1920, -1280, -640]),
+            (CGRect(x: 2560, y: -1000, width: 800, height: 1200), 100,
+             [2560, 2660, 2760, 2860, 2960, 3060, 3160, 3260])
+        ]
+        for fixture in fixtures {
+            let rects = try rectangles(in: fixture.frame)
+            XCTAssertEqual(rects.map { $0.minX }, fixture.origins)
+            XCTAssertEqual(rects.map { $0.width }, Array(repeating: fixture.width, count: 8))
+            XCTAssertEqual(rects.map { $0.minY }, Array(repeating: fixture.frame.minY, count: 8))
+            XCTAssertEqual(rects.map { $0.height }, Array(repeating: fixture.frame.height, count: 8))
+            XCTAssertEqual(rects.last?.maxX, fixture.frame.maxX)
+        }
+    }
+
+    func testRepeatedActionsKeepTheirOwnColumns() throws {
+        let frame = CGRect(x: 0, y: 40, width: 3840, height: 1000)
+        let expected = try rectangles(in: frame)
+        for (action, rect) in try zip(actions(), expected) {
+            let calculation = try XCTUnwrap(WindowCalculationFactory.calculationsByAction[action])
+            let result = calculation.calculateRect(RectCalculationParameters(
+                window: Window(id: 1, rect: rect),
+                visibleFrameOfScreen: frame,
+                action: action,
+                lastAction: RectangleAction(action: action, subAction: nil, rect: rect.screenFlipped, count: 1)
+            ))
+            XCTAssertEqual(result.rect, rect)
+        }
+    }
+
+    func testSkipTopGapKeepsColumnsAtUsableTopEdge() throws {
+        let rects = try rectangles(in: CGRect(x: 0, y: 40, width: 3840, height: 1000))
+        for (action, rect) in try zip(actions(), rects) {
+            let gapped = GapCalculation.applyGaps(rect, dimension: action.gapsApplicable,
+                                                  sharedEdges: action.gapSharedEdge, gapSize: 10, skipTopGap: true)
+            XCTAssertEqual(gapped.minY, 50)
+            XCTAssertEqual(gapped.height, 990)
+            XCTAssertEqual(gapped.maxY, 1040)
+        }
+    }
+
+    func testCalculationUsesTheSelectedScreensAdjustedVisibleFrame() throws {
+        let screen = RepeatedMaximizeTestScreen(frame: CGRect(x: -2560, y: 1440, width: 2560, height: 1440))
+        let calculation = try XCTUnwrap(WindowCalculationFactory.calculationsByAction[.firstVerticalEighth])
+        let result = try XCTUnwrap(calculation.calculate(WindowCalculationParameters(
+            window: Window(id: nil, rect: CGRect(x: 100, y: 100, width: 600, height: 400)),
+            usableScreens: UsableScreens(currentScreen: screen, numScreens: 2),
+            action: .firstVerticalEighth,
+            lastAction: nil,
+            ignoreTodo: true
+        )))
+        let visibleFrame = screen.adjustedVisibleFrame(true)
+        XCTAssertTrue(result.screen === screen)
+        XCTAssertEqual(result.resultingAction, .firstVerticalEighth)
+        XCTAssertEqual(result.rect.minX, visibleFrame.minX)
+        XCTAssertEqual(result.rect.minY, visibleFrame.minY)
+        XCTAssertEqual(result.rect.height, visibleFrame.height)
+    }
+
+    func testExistingEighthsKeepTheirFourByTwoGeometryAndIdentifiers() throws {
+        let actions: [WindowAction] = [.topLeftEighth, .topCenterLeftEighth, .topCenterRightEighth, .topRightEighth,
+                                       .bottomLeftEighth, .bottomCenterLeftEighth, .bottomCenterRightEighth, .bottomRightEighth]
+        XCTAssertEqual(actions.map { $0.rawValue }, [58, 59, 60, 61, 62, 63, 64, 65])
+        let expected = [
+            CGRect(x: 0, y: 540, width: 960, height: 500),
+            CGRect(x: 960, y: 540, width: 960, height: 500),
+            CGRect(x: 1920, y: 540, width: 960, height: 500),
+            CGRect(x: 2880, y: 540, width: 960, height: 500),
+            CGRect(x: 0, y: 40, width: 960, height: 500),
+            CGRect(x: 960, y: 40, width: 960, height: 500),
+            CGRect(x: 1920, y: 40, width: 960, height: 500),
+            CGRect(x: 2880, y: 40, width: 960, height: 500)
+        ]
+        for (action, rect) in zip(actions, expected) {
+            let calculation = try XCTUnwrap(WindowCalculationFactory.calculationsByAction[action])
+            let result = calculation.calculateRect(RectCalculationParameters(
+                window: Window(id: 1, rect: .zero),
+                visibleFrameOfScreen: CGRect(x: 0, y: 40, width: 3840, height: 1000),
+                action: action,
+                lastAction: nil
+            ))
+            XCTAssertEqual(result.rect, rect)
+        }
+    }
+
+    private func actions() throws -> [WindowAction] {
+        try actionNames.map { name in
+            try XCTUnwrap(WindowAction.active.first { $0.name == name }, "Missing action: \(name)")
+        }
+    }
+
+    private func rectangles(in frame: CGRect) throws -> [CGRect] {
+        try actions().map { action in
+            let calculation = try XCTUnwrap(WindowCalculationFactory.calculationsByAction[action])
+            return calculation.calculateRect(RectCalculationParameters(
+                window: Window(id: 1, rect: CGRect(x: 100, y: 100, width: 600, height: 400)),
+                visibleFrameOfScreen: frame,
+                action: action,
+                lastAction: nil
+            )).rect
+        }
+    }
+}
+
 class PositionCyclesTests: XCTestCase {
 
     func testSixthsReturnTrue() {


### PR DESCRIPTION
## Summary

Adds 8 new full-height vertical eighth window actions for wide and ultrawide displays.

Each action places the window into one of eight equal-width columns across the usable screen area:

- First Vertical Eighth
- Second Vertical Eighth
- Third Vertical Eighth
- Fourth Vertical Eighth
- Fifth Vertical Eighth
- Sixth Vertical Eighth
- Seventh Vertical Eighth
- Last Vertical Eighth

The existing 4x2 eighth actions and their identifiers remain unchanged.

## Implementation

- Added 8 new `WindowAction` cases with stable identifiers.
- Added a shared `VerticalEighthCalculation`.
- Uses the current screen's adjusted visible frame.
- Handles widths that are not evenly divisible by 8 without cumulative gaps or overlap.
- Supports Rectangle's existing gap behavior.
- Added shortcut preference rows and icons.
- Added English and Traditional Chinese localization.
- Works across multiple displays.

## Screenshots

### Shortcut preferences
<img width="1700" height="1772" alt="Shortcut preferences" src="https://github.com/user-attachments/assets/aad44132-4c84-4392-a396-74e8254a7d94" />

### Vertical eighth placement
<img width="7680" height="2160" alt="Vertical eighth placement" src="https://github.com/user-attachments/assets/017817d9-9a96-430b-af96-c9385be84869" />


## Validation

- 344 tests passed.
- Debug build passed.
- Release build passed.
- Manual smoke test passed:
  - shortcut configuration
  - first / second vertical eighth placement
  - rightmost eighth boundary
  - gap behavior
  - second display
- Existing 4x2 eighth behavior remains unchanged.