### PR TITLE
fix: keep the restore rect when unsnapRestoreFromSizeChange is off

### DIFF
--- a/Rectangle/Snapping/SnappingManager.swift
+++ b/Rectangle/Snapping/SnappingManager.swift
@@ -317,8 +317,9 @@ class SnappingManager {
         }
     }
     
-    private func unsnapRestore(windowId: CGWindowID, currentRect: CGRect, cursorLoc: CGPoint?) {
+    func unsnapRestore(windowId: CGWindowID, currentRect: CGRect, cursorLoc: CGPoint?) {
         guard !Defaults.unsnapRestore.userDisabled else { return }
+        guard !isRestoreSuppressedBySizeChange(windowId: windowId) else { return }
         
         // if window was put there by rectangle, restore size
         if let restoreRect = getRestoreRect(windowId: windowId) {
@@ -348,14 +349,19 @@ class SnappingManager {
         }
     }
     
+    private func isRestoreSuppressedBySizeChange(windowId: CGWindowID) -> Bool {
+        guard Defaults.unsnapRestoreFromSizeChange.userDisabled,
+              let lastAction = AppDelegate.windowHistory.lastRectangleActions[windowId],
+              lastAction.rect == initialWindowRect
+        else { return false }
+        
+        return lastAction.action.category == .size
+    }
+    
     private func getRestoreRect(windowId: CGWindowID) -> CGRect? {
         guard let lastAction = AppDelegate.windowHistory.lastRectangleActions[windowId],
               lastAction.rect == initialWindowRect
         else { return nil }
-        
-        if lastAction.action.category == .size && Defaults.unsnapRestoreFromSizeChange.userDisabled {
-            return nil
-        }
         
         return AppDelegate.windowHistory.restoreRects[windowId]
     }

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -4495,6 +4495,69 @@ class SnappingManagerSessionTests: XCTestCase {
     }
 }
 
+class SnappingManagerUnsnapRestoreTests: XCTestCase {
+
+    private let windowId = CGWindowID(918_273)
+    private var savedSnappingEnabled: Bool?
+    private var savedUnsnapRestore: Bool?
+    private var savedUnsnapRestoreFromSizeChange: Bool?
+    private var savedRestoreRects = [CGWindowID: CGRect]()
+    private var savedActions = [CGWindowID: RectangleAction]()
+
+    override func setUp() {
+        super.setUp()
+        savedSnappingEnabled = Defaults.windowSnapping.enabled
+        savedUnsnapRestore = Defaults.unsnapRestore.enabled
+        savedUnsnapRestoreFromSizeChange = Defaults.unsnapRestoreFromSizeChange.enabled
+        savedRestoreRects = AppDelegate.windowHistory.restoreRects
+        savedActions = AppDelegate.windowHistory.lastRectangleActions
+        Defaults.windowSnapping.enabled = false
+        Defaults.unsnapRestore.enabled = true
+        AppDelegate.windowHistory.restoreRects.removeValue(forKey: windowId)
+        AppDelegate.windowHistory.lastRectangleActions.removeValue(forKey: windowId)
+    }
+
+    override func tearDown() {
+        Defaults.windowSnapping.enabled = savedSnappingEnabled
+        Defaults.unsnapRestore.enabled = savedUnsnapRestore
+        Defaults.unsnapRestoreFromSizeChange.enabled = savedUnsnapRestoreFromSizeChange
+        AppDelegate.windowHistory.restoreRects = savedRestoreRects
+        AppDelegate.windowHistory.lastRectangleActions = savedActions
+        super.tearDown()
+    }
+
+    func testSuppressedSizeChangeRestoreKeepsTheUserPositionedRect() {
+        Defaults.unsnapRestoreFromSizeChange.enabled = false
+        let userRect = CGRect(x: 164, y: 73, width: 1414, height: 861)
+        let smallerRect = CGRect(x: 179, y: 88, width: 1354, height: 801)
+        AppDelegate.windowHistory.restoreRects[windowId] = userRect
+        AppDelegate.windowHistory.lastRectangleActions[windowId] = RectangleAction(action: .smaller,
+                                                                                   subAction: nil,
+                                                                                   rect: smallerRect,
+                                                                                   count: 2)
+        let snappingManager = SnappingManager()
+        snappingManager.initialWindowRect = smallerRect
+
+        snappingManager.unsnapRestore(windowId: windowId,
+                                      currentRect: smallerRect.offsetBy(dx: 40, dy: 0),
+                                      cursorLoc: nil)
+
+        XCTAssertEqual(AppDelegate.windowHistory.restoreRects[windowId], userRect)
+    }
+
+    func testDraggingAWindowRectangleDidNotPlaceRecordsTheRestoreRect() {
+        let draggedFrom = CGRect(x: 100, y: 100, width: 800, height: 600)
+        let snappingManager = SnappingManager()
+        snappingManager.initialWindowRect = draggedFrom
+
+        snappingManager.unsnapRestore(windowId: windowId,
+                                      currentRect: draggedFrom.offsetBy(dx: 40, dy: 0),
+                                      cursorLoc: nil)
+
+        XCTAssertEqual(AppDelegate.windowHistory.restoreRects[windowId], draggedFrom)
+    }
+}
+
 class ShortcutManagerSessionTests: XCTestCase {
 
     private final class ValueBox<Value> {

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -409,6 +409,14 @@ defaults write com.knollsoft.Rectangle smallerShrinksMaximizedHeight -bool true
 defaults write com.knollsoft.Rectangle unsnapRestore -int 2
 ```
 
+## Disabling window restore when moving windows sized by "Make Smaller" or "Make Larger"
+
+Keeps the window restore behavior above for everything else:
+
+```bash
+defaults write com.knollsoft.Rectangle unsnapRestoreFromSizeChange -int 2
+```
+
 ## Changing the margin for the snap areas
 
 Each margin is configured separately, and has a default value of 5


### PR DESCRIPTION
Related to #1784.

I went looking at #1784 and saw you already added `unsnapRestoreFromSizeChange` in 0.98, so this is not an attempt to change the default or add the settings checkbox. I know you want to do that with the UI rework. It is a smaller thing I hit while reading that code.

When `unsnapRestoreFromSizeChange` is set to 2, `getRestoreRect` returns nil for the size-change case, and `unsnapRestore` treats a nil there the same as "Rectangle never placed this window" and runs `restoreRects[windowId] = initialWindowRect`. So the drag correctly skips the resize, but it overwrites the user's stored restore rect with the resized frame.

Concretely: size a window yourself, press Make Smaller, drag it. The window stays small, which is what the setting is for, but the restore rect is now the small frame, so Restore brings back the small window instead of the size you had set.

I split the suppression check out into `isRestoreSuppressedBySizeChange` and return early from `unsnapRestore` before the branch that records a restore rect. `getRestoreRect` goes back to answering only "did Rectangle put this window here". `unsnapRestore` is internal again so the test can drive it; it was internal before d0a893d.

I also added `unsnapRestoreFromSizeChange` to TerminalCommands.md, since it shipped undocumented and it is the answer people land on #1784 looking for. If you would rather document it yourself, say so and I will drop that part.

Two tests in `SnappingManagerUnsnapRestoreTests` cover it, using the rects from the log in #1784. Full suite: 366 tests, 0 failures.
