### PR TITLE
Add an option to keep constrained windows top-aligned

### DIFF
--- a/Rectangle/WindowMover/FixedSizeWindowMover.swift
+++ b/Rectangle/WindowMover/FixedSizeWindowMover.swift
@@ -10,14 +10,13 @@ class FixedSizeWindowMover: WindowMover {
         let currentWindowRect: CGRect = windowElement.frame
         if currentWindowRect.isNull { return }
 
-        let sharedEdges = Defaults.moveFixedSizeToEdge.value.alignmentEdges(
-            for: resultParameters.calcResult.initialRect.screenFlipped,
-            in: resultParameters.visibleFrameOfScreen.screenFlipped
+        let adjusted = ClampedWindowAligner.aligned(
+            window: currentWindowRect,
+            inZone: rect.screenFlipped,
+            initialRect: resultParameters.calcResult.initialRect.screenFlipped,
+            screenFrame: resultParameters.visibleFrameOfScreen.screenFlipped,
+            alignment: Defaults.moveFixedSizeToEdge.value
         )
-
-        let adjusted = ClampedWindowAligner.aligned(window: currentWindowRect,
-                                                    inZone: rect.screenFlipped,
-                                                    sharedEdges: sharedEdges)
 
         if !adjusted.equalTo(currentWindowRect) {
             windowElement.setFrame(adjusted)

--- a/Rectangle/WindowMover/WindowMover.swift
+++ b/Rectangle/WindowMover/WindowMover.swift
@@ -8,10 +8,8 @@ protocol WindowMover {
 
 /// Repositions a window that may not fill its snap zone. Pure geometry, no side effects.
 ///
-/// Leading-corner alignment keeps the requested origin. Other modes anchor to selected
-/// screen edges or center on unfilled axes. Edge names follow `CGRect.sharedEdges`:
-/// `.top` means maxY and `.bottom` means minY, even in AX space where Y grows downward.
-/// All frames must use the same (screen-flipped / AX) coordinate space.
+/// All frames must use screen-flipped (AX) coordinates. `CGRect.sharedEdges` names
+/// maxY `.top` and minY `.bottom`, even though Y grows downward.
 enum ClampedWindowAligner {
 
     /// A window may come back a hair smaller than its zone without being clamped in any
@@ -61,9 +59,8 @@ enum ClampedWindowAligner {
     }
 }
 
-/// Repositions the app-accepted frame after `StandardWindowMover` requests a resize.
-/// Leading-corner mode retains the requested origin rather than centering or edge-aligning
-/// within unused space. The app-accepted size is preserved in every mode.
+/// Repositions windows after `StandardWindowMover` requests a resize,
+/// keeping the size the app allows.
 class EdgeAlignmentWindowMover: WindowMover {
 
     func moveWindow(toRect rect: CGRect, resultParameters: ResultParameters) {

--- a/Rectangle/WindowMover/WindowMover.swift
+++ b/Rectangle/WindowMover/WindowMover.swift
@@ -8,10 +8,10 @@ protocol WindowMover {
 
 /// Repositions a window that may not fill its snap zone. Pure geometry, no side effects.
 ///
-/// Per axis: if the zone touches exactly one screen edge on that axis, anchor the window
-/// to that edge; if it spans the full axis (both edges) or floats inside (neither), center.
-/// `window` and `zone` must be in the same (screen-flipped) coordinate space, where the
-/// `.top` edge corresponds to maxY and `.bottom` to minY (matching the rest of Rectangle).
+/// Leading-corner alignment keeps the requested origin. Other modes anchor to selected
+/// screen edges or center on unfilled axes. Edge names follow `CGRect.sharedEdges`:
+/// `.top` means maxY and `.bottom` means minY, even in AX space where Y grows downward.
+/// All frames must use the same (screen-flipped / AX) coordinate space.
 enum ClampedWindowAligner {
 
     /// A window may come back a hair smaller than its zone without being clamped in any
@@ -20,7 +20,21 @@ enum ClampedWindowAligner {
     /// was invisible, onto an opposite edge where it is not, so leave the axis alone instead.
     static let alignmentTolerance: CGFloat = 1.0
 
-    static func aligned(window: CGRect, inZone zone: CGRect, sharedEdges: Edge) -> CGRect {
+    static func aligned(window: CGRect, inZone zone: CGRect, initialRect: CGRect,
+                        screenFrame: CGRect, alignment: EdgeAlignment) -> CGRect {
+        let sharedEdges: Edge
+        switch alignment {
+        case .edgesAndCorners:
+            sharedEdges = initialRect.sharedEdges(withRect: screenFrame)
+        case .corners:
+            let edges = initialRect.sharedEdges(withRect: screenFrame)
+            sharedEdges = edges.isCorner ? edges : .none
+        case .leadingCorner:
+            return CGRect(origin: zone.origin, size: window.size)
+        case .centered:
+            sharedEdges = .none
+        }
+
         var result = window
 
         if abs(window.width - zone.width) > alignmentTolerance {
@@ -47,10 +61,9 @@ enum ClampedWindowAligner {
     }
 }
 
-/// For resizable windows that clamp smaller than their snap zone (e.g. FaceTime keeping a
-/// fixed aspect ratio), `StandardWindowMover` leaves them at the zone's leading corner with
-/// a gap on the screen-edge side. Re-anchor or center them according to `moveFixedSizeToEdge`.
-/// No-op when the window already fills the zone.
+/// Repositions the app-accepted frame after `StandardWindowMover` requests a resize.
+/// Leading-corner mode retains the requested origin rather than centering or edge-aligning
+/// within unused space. The app-accepted size is preserved in every mode.
 class EdgeAlignmentWindowMover: WindowMover {
 
     func moveWindow(toRect rect: CGRect, resultParameters: ResultParameters) {
@@ -60,14 +73,13 @@ class EdgeAlignmentWindowMover: WindowMover {
         let currentWindowRect: CGRect = windowElement.frame
         if currentWindowRect.isNull { return }
 
-        let sharedEdges = Defaults.moveFixedSizeToEdge.value.alignmentEdges(
-            for: resultParameters.calcResult.initialRect.screenFlipped,
-            in: resultParameters.visibleFrameOfScreen.screenFlipped
+        let adjusted = ClampedWindowAligner.aligned(
+            window: currentWindowRect,
+            inZone: rect.screenFlipped,
+            initialRect: resultParameters.calcResult.initialRect.screenFlipped,
+            screenFrame: resultParameters.visibleFrameOfScreen.screenFlipped,
+            alignment: Defaults.moveFixedSizeToEdge.value
         )
-
-        let adjusted = ClampedWindowAligner.aligned(window: currentWindowRect,
-                                                    inZone: rect.screenFlipped,
-                                                    sharedEdges: sharedEdges)
 
         if !adjusted.equalTo(currentWindowRect) {
             windowElement.setFrame(adjusted)
@@ -79,17 +91,5 @@ enum EdgeAlignment: Int {
     case edgesAndCorners = 1
     case corners = 2
     case centered = 3
-
-    func alignmentEdges(for rect: CGRect, in screenFrame: CGRect) -> Edge {
-        let sharedEdges = rect.sharedEdges(withRect: screenFrame)
-
-        switch self {
-        case .edgesAndCorners:
-            return sharedEdges
-        case .corners:
-            return sharedEdges.isCorner ? sharedEdges : .none
-        case .centered:
-            return .none
-        }
-    }
+    case leadingCorner = 4
 }

--- a/RectangleTests/RectangleTests.swift
+++ b/RectangleTests/RectangleTests.swift
@@ -4948,13 +4948,14 @@ class TodoShortcutValidatorTests: XCTestCase {
 
 class ClampedWindowAlignerTests: XCTestCase {
 
-    // Screen 2000x1200 at origin. Coordinates are already screen-flipped (window space):
-    // the zone's maxY edge is the screen TOP, minY edge is the screen BOTTOM.
+    // AX coordinates: minY is the visual top. Edge names follow CGRect.sharedEdges.
+    private let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
 
     func testRightHalfClampedBothAxesAnchorsRightCentersVertically() {
         let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
         let window = CGRect(x: 1000, y: 0, width: 600, height: 800) // narrower + shorter than zone
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: screenFrame, alignment: .edgesAndCorners)
         XCTAssertEqual(result.origin.x, 1400, accuracy: 0.001) // zone.maxX - width = 2000 - 600
         XCTAssertEqual(result.origin.y, 200, accuracy: 0.001)  // centered: (1200 - 800)/2
         XCTAssertEqual(result.width, 600, accuracy: 0.001)
@@ -4964,7 +4965,8 @@ class ClampedWindowAlignerTests: XCTestCase {
     func testRightHalfFullHeightLeavesVerticalUntouched() {
         let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
         let window = CGRect(x: 1000, y: 0, width: 600, height: 1200) // fills height
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: screenFrame, alignment: .edgesAndCorners)
         XCTAssertEqual(result.origin.x, 1400, accuracy: 0.001)
         XCTAssertEqual(result.origin.y, 0, accuracy: 0.001)
     }
@@ -4972,15 +4974,17 @@ class ClampedWindowAlignerTests: XCTestCase {
     func testLeftHalfClampedAnchorsLeftCentersVertically() {
         let zone = CGRect(x: 0, y: 0, width: 1000, height: 1200)
         let window = CGRect(x: 0, y: 0, width: 600, height: 800)
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.left, .top, .bottom])
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: screenFrame, alignment: .edgesAndCorners)
         XCTAssertEqual(result.origin.x, 0, accuracy: 0.001)
         XCTAssertEqual(result.origin.y, 200, accuracy: 0.001)
     }
 
-    func testTopRightQuarterAnchorsToCorner() {
-        let zone = CGRect(x: 1000, y: 600, width: 1000, height: 600) // top-right; maxY=1200=screen top
+    func testBottomRightQuarterAnchorsToCorner() {
+        let zone = CGRect(x: 1000, y: 600, width: 1000, height: 600)
         let window = CGRect(x: 1000, y: 600, width: 600, height: 400)
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top])
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: screenFrame, alignment: .edgesAndCorners)
         XCTAssertEqual(result.origin.x, 1400, accuracy: 0.001) // maxX - width
         XCTAssertEqual(result.origin.y, 800, accuracy: 0.001)  // maxY - height = 1200 - 400
     }
@@ -4988,7 +4992,8 @@ class ClampedWindowAlignerTests: XCTestCase {
     func testInteriorZoneCentersBothAxes() {
         let zone = CGRect(x: 600, y: 400, width: 800, height: 400)
         let window = CGRect(x: 600, y: 400, width: 400, height: 200)
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [])
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: screenFrame, alignment: .edgesAndCorners)
         XCTAssertEqual(result.origin.x, 800, accuracy: 0.001) // (800-400)/2 + 600
         XCTAssertEqual(result.origin.y, 500, accuracy: 0.001) // (400-200)/2 + 400
     }
@@ -4996,7 +5001,8 @@ class ClampedWindowAlignerTests: XCTestCase {
     func testExactFitReturnsUnchanged() {
         let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
         let window = zone
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: screenFrame, alignment: .edgesAndCorners)
         XCTAssertTrue(result.equalTo(window))
     }
 
@@ -5006,65 +5012,109 @@ class ClampedWindowAlignerTests: XCTestCase {
     func testMaximizeOnePointNarrowStaysPut() {
         let zone = CGRect(x: 0, y: 0, width: 1679, height: 1079)
         let window = CGRect(x: 0, y: 0, width: 1678, height: 1079)
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.left, .right, .top, .bottom])
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: zone, alignment: .edgesAndCorners)
         XCTAssertTrue(result.equalTo(window))
     }
 
     func testRightHalfOnePointNarrowStaysPut() {
         let zone = CGRect(x: 840, y: 0, width: 839, height: 1079)
         let window = CGRect(x: 840, y: 0, width: 838, height: 1079)
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        let screen = CGRect(x: 0, y: 0, width: 1679, height: 1079)
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: screen, alignment: .edgesAndCorners)
         XCTAssertTrue(result.equalTo(window))
     }
 
     func testOnePointShortHeightStaysPut() {
         let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
         let window = CGRect(x: 1000, y: 0, width: 1000, height: 1199)
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: screenFrame, alignment: .edgesAndCorners)
         XCTAssertTrue(result.equalTo(window))
     }
 
     func testShortfallJustOverToleranceStillAligns() {
         let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
         let window = CGRect(x: 1000, y: 0, width: 998.5, height: 1200)
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: screenFrame, alignment: .edgesAndCorners)
         XCTAssertEqual(result.origin.x, 1001.5, accuracy: 0.001) // zone.maxX - width = 2000 - 998.5
     }
 
     func testOnePointNarrowLeavesOtherAxisAlignmentIntact() {
         let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
         let window = CGRect(x: 1000, y: 0, width: 999, height: 800) // a point narrow, genuinely short
-        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, sharedEdges: [.right, .top, .bottom])
+        let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                  screenFrame: screenFrame, alignment: .edgesAndCorners)
         XCTAssertEqual(result.origin.x, 1000, accuracy: 0.001) // width within tolerance, left alone
         XCTAssertEqual(result.origin.y, 200, accuracy: 0.001)  // height still centered: (1200-800)/2
     }
 
-    func testEdgesAndCornersAlignmentKeepsHalfEdges() {
-        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
-        let rightHalf = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
-        let result = EdgeAlignment.edgesAndCorners.alignmentEdges(for: rightHalf, in: screenFrame)
-        XCTAssertEqual(result, [.right, .top, .bottom])
+    func testCornersModeCentersHalfButAnchorsQuarter() {
+        let window = CGRect(x: 1000, y: 0, width: 600, height: 400)
+        let half = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let quarter = CGRect(x: 1000, y: 0, width: 1000, height: 600)
+
+        XCTAssertEqual(ClampedWindowAligner.aligned(window: window, inZone: half, initialRect: half,
+                                                    screenFrame: screenFrame, alignment: .corners),
+                       CGRect(x: 1200, y: 400, width: 600, height: 400))
+        XCTAssertEqual(ClampedWindowAligner.aligned(window: window, inZone: quarter, initialRect: quarter,
+                                                    screenFrame: screenFrame, alignment: .corners),
+                       CGRect(x: 1400, y: 0, width: 600, height: 400))
     }
 
-    func testCornersAlignmentCentersHalfEdges() {
-        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
-        let rightHalf = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
-        let result = EdgeAlignment.corners.alignmentEdges(for: rightHalf, in: screenFrame)
-        XCTAssertEqual(result, .none)
+    func testCenteredModeCentersEvenInCorner() {
+        let zone = CGRect(x: 1000, y: 0, width: 1000, height: 600)
+        let window = CGRect(x: 1000, y: 0, width: 600, height: 400)
+        XCTAssertEqual(ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                    screenFrame: screenFrame, alignment: .centered),
+                       CGRect(x: 1200, y: 100, width: 600, height: 400))
     }
 
-    func testCornersAlignmentKeepsCornerEdges() {
-        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
-        let topRight = CGRect(x: 1000, y: 600, width: 1000, height: 600)
-        let result = EdgeAlignment.corners.alignmentEdges(for: topRight, in: screenFrame)
-        XCTAssertEqual(result, [.right, .top])
+    func testLeadingCornerKeepsAspectRatioWindowsTopAlignedAcrossSideWidths() {
+        // Offset display, including negative coordinates; widths are 1/2, 2/3, 1/3.
+        let screen = CGRect(x: -2400, y: -600, width: 2400, height: 1400)
+        for width: CGFloat in [1200, 1600, 800] {
+            for x in [screen.minX, screen.maxX - width] {
+                let zone = CGRect(x: x, y: screen.minY, width: width, height: screen.height)
+                let window = CGRect(x: 100, y: 200, width: width, height: width * 9 / 16)
+                let result = ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                          screenFrame: screen, alignment: .leadingCorner)
+                XCTAssertEqual(result, CGRect(x: x, y: -600, width: width, height: width * 9 / 16))
+            }
+        }
     }
 
-    func testCenteredAlignmentIgnoresSharedEdges() {
-        let screenFrame = CGRect(x: 0, y: 0, width: 2000, height: 1200)
-        let topRight = CGRect(x: 1000, y: 600, width: 1000, height: 600)
-        let result = EdgeAlignment.centered.alignmentEdges(for: topRight, in: screenFrame)
-        XCTAssertEqual(result, .none)
+    func testLeadingCornerUsesGappedZoneOriginForWidthConstrainedWindow() {
+        let initialRect = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let zone = initialRect.insetBy(dx: 12, dy: 12)
+        let window = CGRect(x: 1500, y: 200, width: 600, height: zone.height)
+
+        XCTAssertEqual(ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: initialRect,
+                                                    screenFrame: screenFrame, alignment: .leadingCorner),
+                       CGRect(x: 1012, y: 12, width: 600, height: 1176))
+        // Existing edge alignment must still detect edges before gaps are applied.
+        XCTAssertEqual(ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: initialRect,
+                                                    screenFrame: screenFrame, alignment: .edgesAndCorners),
+                       CGRect(x: 1388, y: 200, width: 600, height: 1176))
+    }
+
+    func testLeadingCornerPreservesFixedSizeLargerThanZone() {
+        let zone = CGRect(x: 1000, y: 600, width: 1000, height: 600)
+        let window = CGRect(x: 100, y: 200, width: 1100, height: 800)
+        XCTAssertEqual(ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                    screenFrame: screenFrame, alignment: .leadingCorner),
+                       CGRect(x: 1000, y: 600, width: 1100, height: 800))
+        // Screen containment is applied separately by BestEffortWindowMover.
+    }
+
+    func testLeadingCornerRestoresRequestedOriginWithinSizeTolerance() {
+        let zone = CGRect(x: 1000, y: 0, width: 1000, height: 1200)
+        let window = CGRect(x: 1004, y: 7, width: 999, height: 1199)
+        XCTAssertEqual(ClampedWindowAligner.aligned(window: window, inZone: zone, initialRect: zone,
+                                                    screenFrame: screenFrame, alignment: .leadingCorner),
+                       CGRect(x: 1000, y: 0, width: 999, height: 1199))
     }
 }
 
@@ -5263,6 +5313,12 @@ final class WindowSizeConstraintExecutionTests: XCTestCase {
             (Defaults.cooperativeCornerResize, CodableDefault(bool: false)),
             (Defaults.useCursorScreenDetection, CodableDefault(bool: false)),
             (Defaults.moveFixedSizeToEdge, CodableDefault(int: EdgeAlignment.edgesAndCorners.rawValue)),
+            (Defaults.horizontalSplitRatio, CodableDefault(float: 50)),
+            (Defaults.verticalSplitRatio, CodableDefault(float: 50)),
+            (Defaults.halvesPreserveOtherAxisSize, CodableDefault(bool: false)),
+            (Defaults.cycleSizesIsChanged, CodableDefault(bool: false)),
+            (Defaults.resizeOnDirectionalMove, CodableDefault(bool: false)),
+            (Defaults.centeredDirectionalMove, CodableDefault(int: 2)),
             (Defaults.gapSize, CodableDefault(float: 0)),
             (Defaults.stageSize, CodableDefault(float: 0)),
             (Defaults.screenEdgeGapLeft, CodableDefault(float: 0)),
@@ -5289,6 +5345,91 @@ final class WindowSizeConstraintExecutionTests: XCTestCase {
         AppDelegate.windowHistory.lastRectangleActions = savedActions
         Logger.logging = savedLogging
         super.tearDown()
+    }
+
+    func testLeadingOriginPersistsThroughConstrainedHalfCycles() {
+        assertConstrainedHalfCycles(alignment: .leadingCorner, topOffsets: [0, 0, 0, 0])
+    }
+
+    func testEdgesAndCornersCentersConstrainedHalfCycles() {
+        assertConstrainedHalfCycles(alignment: .edgesAndCorners, topOffsets: [363, 250, 475, 363])
+    }
+
+    func testCornersOnlyCentersConstrainedHalfCycles() {
+        assertConstrainedHalfCycles(alignment: .corners, topOffsets: [363, 250, 475, 363])
+    }
+
+    func testCenteredModeCentersConstrainedHalfCycles() {
+        assertConstrainedHalfCycles(alignment: .centered, topOffsets: [363, 250, 475, 363])
+    }
+
+    private func assertConstrainedHalfCycles(alignment: EdgeAlignment, topOffsets: [CGFloat],
+                                            file: StaticString = #filePath, line: UInt = #line) {
+        Defaults.moveFixedSizeToEdge.value = alignment
+        Defaults.subsequentExecutionMode.value = .resize
+        let screen = TestScreen(frame: CGRect(x: -2400, y: -600, width: 2400, height: 1400))
+        let window = ConstrainedWindow(frame: CGRect(x: -2000, y: -200, width: 800, height: 450).screenFlipped) {
+            CGRect(origin: $0.origin, size: CGSize(width: $0.width, height: $0.width * 9 / 16))
+        }
+        let manager = TestWindowManager(screenDetection: TestScreenDetection(source: screen))
+
+        // Each execution consumes the achieved frame and history from the previous one.
+        // Changing sides must start the new action's cycle at one half.
+        for action: WindowAction in [.leftHalf, .rightHalf] {
+            for (index, width) in [CGFloat(1200), 1600, 800, 1200].enumerated() {
+                manager.execute(ExecutionParameters(action, screen: screen, windowElement: window,
+                                                    windowId: windowId, source: .menuItem))
+
+                let x = action == .leftHalf ? screen.frame.minX : screen.frame.maxX - width
+                XCTAssertEqual(window.frame,
+                               CGRect(x: x, y: screen.frame.screenFlipped.minY + topOffsets[index],
+                                      width: width, height: width * 9 / 16),
+                               "\(action), width \(width)", file: file, line: line)
+            }
+        }
+    }
+
+    func testLeadingOriginFixedWindowIsContainedAfterBottomRightPlacement() {
+        Defaults.moveFixedSizeToEdge.value = .leadingCorner
+        let screen = TestScreen(frame: CGRect(x: -1600, y: 200, width: 1200, height: 900))
+        let size = CGSize(width: 800, height: 700)
+        let window = ConstrainedWindow(frame: CGRect(x: -1500, y: 300, width: size.width, height: size.height).screenFlipped,
+                                       resizable: false) {
+            CGRect(origin: $0.origin, size: size)
+        }
+        let manager = TestWindowManager(screenDetection: TestScreenDetection(source: screen))
+
+        manager.execute(ExecutionParameters(.bottomRight, screen: screen, windowElement: window,
+                                            windowId: windowId, source: .menuItem))
+
+        // The 600x450 snap region cannot hold this window. Containment takes precedence
+        // over its requested origin without shrinking the app's accepted size.
+        let visibleFrame = screen.frame.screenFlipped
+        XCTAssertEqual(window.frame,
+                       CGRect(x: visibleFrame.maxX - size.width, y: visibleFrame.maxY - size.height,
+                              width: size.width, height: size.height))
+        XCTAssertTrue(visibleFrame.contains(window.frame))
+    }
+
+    func testLeadingOriginDoesNotOverrideAppPositionAfterMovementOnlyAction() {
+        Defaults.moveFixedSizeToEdge.value = .leadingCorner
+        let screen = TestScreen(frame: CGRect(x: -2400, y: -600, width: 2400, height: 1400))
+        let initialFrame = CGRect(x: -1900, y: 0, width: 600, height: 400).screenFlipped
+        var initialMove = true
+        let window = ConstrainedWindow(frame: initialFrame) { requestedFrame in
+            // Simulate the app correcting its position after the initial move.
+            // A subsequent alignment write would wrongly undo that correction.
+            defer { initialMove = false }
+            return initialMove ? requestedFrame.offsetBy(dx: 0, dy: 7) : requestedFrame
+        }
+        let manager = TestWindowManager(screenDetection: TestScreenDetection(source: screen))
+
+        manager.execute(ExecutionParameters(.moveRight, screen: screen, windowElement: window,
+                                            windowId: windowId, source: .menuItem))
+
+        XCTAssertEqual(window.frame,
+                       CGRect(x: screen.frame.maxX - initialFrame.width, y: initialFrame.minY + 7,
+                              width: initialFrame.width, height: initialFrame.height))
     }
 
     func testClampedFirstAndLastThirdsWarnAndPreserveAchievedGeometry() {
@@ -5446,6 +5587,30 @@ final class WindowSizeConstraintExecutionTests: XCTestCase {
                     currentFrame.size.width = max(frame.width, 600)
                 }
             }
+        }
+    }
+
+    private final class ConstrainedWindow: AccessibilityElement {
+        private var currentFrame: CGRect
+        private let resizable: Bool
+        private let acceptedFrame: (CGRect) -> CGRect
+
+        init(frame: CGRect, resizable: Bool = true, acceptedFrame: @escaping (CGRect) -> CGRect) {
+            currentFrame = frame
+            self.resizable = resizable
+            self.acceptedFrame = acceptedFrame
+            super.init(AXUIElementCreateSystemWide())
+        }
+
+        override var frame: CGRect { currentFrame }
+        override var isSheet: Bool? { false }
+        override var isSystemDialog: Bool? { false }
+        override var minimumSize: CGSize? { nil }
+        override func getWindowId() -> CGWindowID? { nil }
+        override func isResizable() -> Bool { resizable }
+
+        override func setFrame(_ frame: CGRect, adjustSizeFirst: Bool = true) {
+            currentFrame = acceptedFrame(frame)
         }
     }
 

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -645,4 +645,13 @@ Some windows can't be resized to fill a snap area — either because they're a f
 defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 1  # align edges and corners (default)
 defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 2  # align corners only, center halves/sides
 defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 3  # center within the snap area
+defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 4  # keep the requested snap area's top-left origin
+```
+
+Mode `4` preserves the size accepted by the application and places it at the requested snap area's top-left origin, including any configured gaps. For an aspect-ratio-constrained window that accepts the requested width (for example, IINA), Left Half and Right Half stay top-aligned through the `1/2 → 2/3 → 1/3` width cycle. If the window also constrains its width, it starts at the snap area's left edge rather than aligning to its right edge. This applies to both resizable and fixed-size windows; Rectangle's final screen-containment adjustment still applies if the window would extend offscreen.
+
+Restart Rectangle after changing this preference. To restore the default:
+
+```bash
+defaults delete com.knollsoft.Rectangle moveFixedSizeToEdge
 ```

--- a/TerminalCommands.md
+++ b/TerminalCommands.md
@@ -645,10 +645,12 @@ Some windows can't be resized to fill a snap area — either because they're a f
 defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 1  # align edges and corners (default)
 defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 2  # align corners only, center halves/sides
 defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 3  # center within the snap area
-defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 4  # keep the requested snap area's top-left origin
+defaults write com.knollsoft.Rectangle moveFixedSizeToEdge -int 4  # keep windows at the snap area's top-left
 ```
 
-Mode `4` preserves the size accepted by the application and places it at the requested snap area's top-left origin, including any configured gaps. For an aspect-ratio-constrained window that accepts the requested width (for example, IINA), Left Half and Right Half stay top-aligned through the `1/2 → 2/3 → 1/3` width cycle. If the window also constrains its width, it starts at the snap area's left edge rather than aligning to its right edge. This applies to both resizable and fixed-size windows; Rectangle's final screen-containment adjustment still applies if the window would extend offscreen.
+Mode `4` keeps constrained windows at the snap area's top-left. For video windows such as IINA, this keeps left/right snaps top-aligned as you cycle through sizes.
+
+Narrower windows stay at the snap area's left edge, even for right-side snaps. Gaps still apply, and Rectangle may shift the window to keep it on screen.
 
 Restart Rectangle after changing this preference. To restore the default:
 


### PR DESCRIPTION
## Summary

Add an option to keep constrained windows at the top of their snap area.

## Why another mode?

| Mode | Placement within the snap area |
| --- | --- |
| **1 — default** | Align to screen edges and corners; center where no single edge applies. |
| **2** | Align corner snaps; center other snaps. |
| **3** | Always center. |
| **4 — new** | Use the snap area's top-left origin. |

For left/right snaps, existing modes center shorter video windows vertically. Mode 4 keeps them top-aligned as you cycle through sizes.

- Applies to resizable and fixed-size windows; existing modes, the default, and screen containment are unchanged.
- 28 focused tests passed; Debug/arm64 build succeeded.

Closes #1825.